### PR TITLE
Add IOC summary script and publish GitHub Pages outputs

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  ENABLE_PAGES: "false"  # set to "true" to deploy GitHub Pages
+  ENABLE_PAGES: "true"
 
 jobs:
   collect:
@@ -84,6 +84,14 @@ jobs:
             --diag-json public/diagnostics/run.json \
             --report public/diagnostics/REPORT.md \
             --fail-on-empty urlhaus_recent_urls malwarebazaar_recent
+
+      - name: Summarize IOC outputs
+        run: |
+          python scripts/summarize_iocs.py \
+            --diag public/diagnostics/run.json \
+            --ioc-jsonl public/iocs/latest.jsonl \
+            --out public/diagnostics/summary.md \
+            --index public/index.md
 
       - name: Upload artifacts (diagnostics & outputs)
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ ATT&CK® framework, and ensure downstream tools receive consistent IOC data.
 ```
 ├── public/                 # Default output directory for generated feeds
 │   ├── iocs/               # CSV, JSON, JSONL, TSV, and STIX artifacts
+│   ├── diagnostics/        # Run report, JSON diagnostics, and auto summary
 │   └── changelog/          # Markdown changelog between runs
+├── scripts/                # Utility helpers for post-processing
+│   └── summarize_iocs.py   # Generates Markdown summaries for Pages & artifacts
 ├── requirements.txt        # Python dependencies
 ├── sources.example.yml     # Sample feed configuration
 ├── swiftioc.py             # Main collector implementation & CLI
@@ -227,6 +230,7 @@ Running the collector produces the following structure (paths relative to
 
 ```
 public/
+├── index.md
 ├── iocs/
 │   ├── latest.csv
 │   ├── latest.tsv
@@ -238,13 +242,33 @@ public/
 └── diagnostics/
     ├── REPORT.md
     ├── run.json
+    ├── summary.md
     └── raw/                 # optional when --save-raw-dir is supplied
 ```
 
 All indicators share a common schema (`indicator`, `type`, `source`,
 `first_seen`, `last_seen`, `confidence`, `tlp`, `tags`, `reference`, `context`).
 `REPORT.md` and `run.json` summarise totals, per-source counts, type breakdowns,
-and any issues encountered.
+and any issues encountered, while `summary.md` condenses the run into a portal-
+ready Markdown snapshot that also drives `public/index.md`.
+
+### Auto-generated IOC summary
+
+The helper script [`scripts/summarize_iocs.py`](scripts/summarize_iocs.py)
+produces the Markdown summary and GitHub Pages landing page. It runs
+automatically in the **Collect – SwiftIOC** workflow and also appends the same
+information to the GitHub Actions job summary. You can execute it locally after
+any collection run:
+
+```bash
+python scripts/summarize_iocs.py \
+  --diag public/diagnostics/run.json \
+  --ioc-jsonl public/iocs/latest.jsonl
+```
+
+Override `--out` or `--index` if you want to write the summary elsewhere.
+The workflow ships with GitHub Pages deployment enabled, so everything under
+`public/`—including the summary—goes live after each successful run.
 
 ## 🔌 Integrations & compatibility
 SwiftIOC plays well with popular security platforms and file formats:

--- a/public/diagnostics/summary.md
+++ b/public/diagnostics/summary.md
@@ -1,0 +1,55 @@
+# SwiftIOC IOC Summary
+
+_Generated 2025-11-10T00:38:51Z_
+
+## Highlights
+
+| Metric | Value |
+| --- | ---: |
+| Generated | 2025-11-10T00:38:51Z |
+| Total indicators | 2497 |
+| Duplicates removed | 0 |
+| Sources reporting | 4 |
+| Indicator types | 4 |
+| Multi-source overlaps | 0 |
+| Earliest first_seen | 2025-11-08T00:38:37Z |
+| Newest first_seen | 2025-11-10T00:34:46Z |
+
+## Per-source totals
+
+| Source | Indicators |
+| --- | ---: |
+| urlhaus_recent_urls | 1635 |
+| malwarebazaar_recent | 769 |
+| sslbl_ja3 | 92 |
+| feodo_ipblocklist | 1 |
+
+## Indicator types
+
+| Type | Indicators |
+| --- | ---: |
+| url | 1635 |
+| sha256 | 769 |
+| ja3 | 92 |
+| ipv4 | 1 |
+
+## Top tags
+
+| Tag | Indicators |
+| --- | ---: |
+| malware | 2405 |
+| Mirai | 496 |
+| sslbl | 92 |
+| tls | 92 |
+| fingerprint | 92 |
+| Rhadamanthys | 20 |
+| Ngioweb | 14 |
+| AgentTesla | 11 |
+| RemcosRAT | 10 |
+| XWorm | 9 |
+
+## Multi-source overlaps
+
+_No overlapping indicators detected._
+
+For more detail see [diagnostics/REPORT.md](diagnostics/REPORT.md) and the machine-readable feeds in [iocs/](iocs/).

--- a/public/index.md
+++ b/public/index.md
@@ -1,0 +1,57 @@
+# SwiftIOC Threat Intelligence Snapshot
+
+This site is generated automatically from the latest SwiftIOC collection run.
+
+_Generated 2025-11-10T00:38:51Z_
+
+## Highlights
+
+| Metric | Value |
+| --- | ---: |
+| Generated | 2025-11-10T00:38:51Z |
+| Total indicators | 2497 |
+| Duplicates removed | 0 |
+| Sources reporting | 4 |
+| Indicator types | 4 |
+| Multi-source overlaps | 0 |
+| Earliest first_seen | 2025-11-08T00:38:37Z |
+| Newest first_seen | 2025-11-10T00:34:46Z |
+
+## Per-source totals
+
+| Source | Indicators |
+| --- | ---: |
+| urlhaus_recent_urls | 1635 |
+| malwarebazaar_recent | 769 |
+| sslbl_ja3 | 92 |
+| feodo_ipblocklist | 1 |
+
+## Indicator types
+
+| Type | Indicators |
+| --- | ---: |
+| url | 1635 |
+| sha256 | 769 |
+| ja3 | 92 |
+| ipv4 | 1 |
+
+## Top tags
+
+| Tag | Indicators |
+| --- | ---: |
+| malware | 2405 |
+| Mirai | 496 |
+| sslbl | 92 |
+| tls | 92 |
+| fingerprint | 92 |
+| Rhadamanthys | 20 |
+| Ngioweb | 14 |
+| AgentTesla | 11 |
+| RemcosRAT | 10 |
+| XWorm | 9 |
+
+## Multi-source overlaps
+
+_No overlapping indicators detected._
+
+For more detail see [diagnostics/REPORT.md](diagnostics/REPORT.md) and the machine-readable feeds in [iocs/](iocs/).

--- a/scripts/summarize_iocs.py
+++ b/scripts/summarize_iocs.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Generate a concise Markdown summary for the latest SwiftIOC run."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
+
+ISO_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime(ISO_FMT)
+
+
+def load_diag(path: Path) -> Dict[str, Any] | None:
+    if path and path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def load_iocs(path: Path) -> List[Dict[str, Any]]:
+    if not path or not path.exists():
+        return []
+    rows: List[Dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return rows
+
+
+def to_table(rows: Sequence[Tuple[str, str]], headers: Tuple[str, str]) -> List[str]:
+    if not rows:
+        return ["_No data available._", ""]
+    lines = [f"| {headers[0]} | {headers[1]} |", "| --- | ---: |"]
+    lines.extend(f"| {k} | {v} |" for k, v in rows)
+    lines.append("")
+    return lines
+
+
+def summarize_counts(counts: Dict[str, int], limit: int = 10) -> List[Tuple[str, str]]:
+    if not counts:
+        return []
+    ordered = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))[:limit]
+    return [(name, f"{value}") for name, value in ordered]
+
+
+def summarize_types(type_counts: Dict[str, int]) -> List[Tuple[str, str]]:
+    return summarize_counts(type_counts)
+
+
+def summarize_tags(rows: Iterable[Dict[str, Any]], limit: int = 10) -> List[Tuple[str, str]]:
+    counter: Counter[str] = Counter()
+    for row in rows:
+        tags = (row.get("tags") or "").split(",")
+        for tag in tags:
+            tag = tag.strip()
+            if tag:
+                counter[tag] += 1
+    ordered = counter.most_common(limit)
+    return [(tag, f"{count}") for tag, count in ordered]
+
+
+def summarize_overlaps(rows: Iterable[Dict[str, Any]], limit: int = 10) -> List[Tuple[str, str]]:
+    overlaps: List[Tuple[str, str]] = []
+    for row in rows:
+        sources = [s.strip() for s in (row.get("source") or "").split(",") if s.strip()]
+        if len(sources) <= 1:
+            continue
+        indicator = row.get("indicator") or "(unknown)"
+        indicator_type = row.get("type") or "?"
+        overlaps.append((f"{indicator_type}: {indicator}", ", ".join(sorted(set(sources)))))
+    overlaps.sort(key=lambda item: (-len(item[1].split(",")), item[0]))
+    return overlaps[:limit]
+
+
+def derive_counts(rows: Iterable[Dict[str, Any]]) -> Dict[str, int]:
+    counts: Counter[str] = Counter()
+    for row in rows:
+        sources = (row.get("source") or "").split(",")
+        for src in sources:
+            src = src.strip()
+            if src:
+                counts[src] += 1
+    return dict(counts)
+
+
+def derive_types(rows: Iterable[Dict[str, Any]]) -> Dict[str, int]:
+    counts: Counter[str] = Counter()
+    for row in rows:
+        typ = (row.get("type") or "").strip()
+        if typ:
+            counts[typ] += 1
+    return dict(counts)
+
+
+def derive_first_last(rows: Iterable[Dict[str, Any]]) -> Tuple[str | None, str | None]:
+    first_seen: List[datetime] = []
+    for row in rows:
+        value = row.get("first_seen") or row.get("firstSeen")
+        if not value:
+            continue
+        try:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        first_seen.append(dt.astimezone(timezone.utc))
+    if not first_seen:
+        return None, None
+    earliest = min(first_seen)
+    latest = max(first_seen)
+    return iso(earliest), iso(latest)
+
+
+def build_highlights(diag: Dict[str, Any] | None, rows: List[Dict[str, Any]]) -> List[Tuple[str, str]]:
+    total = diag.get("total") if diag else None
+    if total is None:
+        total = len(rows)
+    duplicates = diag.get("duplicates_removed") if diag else None
+    if duplicates is None:
+        duplicates = 0
+    generated = diag.get("ts") if diag else iso(datetime.now(timezone.utc))
+    window = diag.get("window_hours") if diag else None
+    counts = (diag.get("counts") if diag else None) or derive_counts(rows)
+    active_sources = sum(1 for _, value in counts.items() if value > 0)
+    type_counts = (diag.get("type_counts") if diag else None) or derive_types(rows)
+    types_seen = len(type_counts)
+    earliest = diag.get("earliest_first_seen") if diag else None
+    newest = diag.get("newest_first_seen") if diag else None
+    if not earliest or not newest:
+        derived_first, derived_latest = derive_first_last(rows)
+        earliest = earliest or derived_first
+        newest = newest or derived_latest
+    overlaps = summarize_overlaps(rows, limit=9999)
+    highlight_rows: List[Tuple[str, str]] = [("Generated", generated)]
+    if window is not None:
+        highlight_rows.append(("Window (hours)", str(window)))
+    highlight_rows.append(("Total indicators", f"{total}"))
+    highlight_rows.append(("Duplicates removed", f"{duplicates}"))
+    highlight_rows.append(("Sources reporting", f"{active_sources}"))
+    highlight_rows.append(("Indicator types", f"{types_seen}"))
+    highlight_rows.append(("Multi-source overlaps", f"{len(overlaps)}"))
+    if earliest:
+        highlight_rows.append(("Earliest first_seen", earliest))
+    if newest:
+        highlight_rows.append(("Newest first_seen", newest))
+    return highlight_rows
+
+
+def render_summary(diag: Dict[str, Any] | None, rows: List[Dict[str, Any]]) -> Tuple[str, str, str]:
+    highlight_rows = build_highlights(diag, rows)
+    counts = (diag.get("counts") if diag else None) or derive_counts(rows)
+    type_counts = (diag.get("type_counts") if diag else None) or derive_types(rows)
+    tag_rows = summarize_tags(rows)
+    overlap_rows = summarize_overlaps(rows)
+
+    sections: List[str] = ["## Highlights", ""]
+    sections.extend(to_table(highlight_rows, ("Metric", "Value")))
+
+    sections.append("## Per-source totals")
+    sections.append("")
+    sections.extend(to_table(summarize_counts(counts), ("Source", "Indicators")))
+
+    sections.append("## Indicator types")
+    sections.append("")
+    sections.extend(to_table(summarize_types(type_counts), ("Type", "Indicators")))
+
+    sections.append("## Top tags")
+    sections.append("")
+    sections.extend(to_table(tag_rows, ("Tag", "Indicators")))
+
+    sections.append("## Multi-source overlaps")
+    sections.append("")
+    if overlap_rows:
+        sections.append("| Indicator | Sources |")
+        sections.append("| --- | --- |")
+        sections.extend(f"| {indicator} | {sources} |" for indicator, sources in overlap_rows)
+        sections.append("")
+    else:
+        sections.append("_No overlapping indicators detected._")
+        sections.append("")
+
+    sections.append(
+        "For more detail see [diagnostics/REPORT.md](diagnostics/REPORT.md) and the machine-readable feeds in [iocs/](iocs/)."
+    )
+    sections.append("")
+
+    summary_body = "\n".join(sections)
+
+    generated = diag.get("ts") if diag else iso(datetime.now(timezone.utc))
+    summary_lines = ["# SwiftIOC IOC Summary", "", f"_Generated {generated}_", "", summary_body]
+    summary_md = "\n".join(summary_lines)
+
+    index_lines = [
+        "# SwiftIOC Threat Intelligence Snapshot",
+        "",
+        "This site is generated automatically from the latest SwiftIOC collection run.",
+        "",
+        f"_Generated {generated}_",
+        "",
+        summary_body,
+    ]
+    index_md = "\n".join(index_lines)
+
+    step_md = "## SwiftIOC IOC Summary\n\n" + summary_body
+    return summary_md, index_md, step_md
+
+
+def write_output(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content.strip() + "\n", encoding="utf-8")
+
+
+def append_step_summary(content: str) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as f:
+        f.write(content.strip() + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize SwiftIOC outputs into Markdown.")
+    parser.add_argument("--diag", type=Path, default=Path("public/diagnostics/run.json"), help="Path to diagnostics JSON file")
+    parser.add_argument("--ioc-jsonl", type=Path, default=Path("public/iocs/latest.jsonl"), help="Path to IOC JSONL export")
+    parser.add_argument("--out", type=Path, default=Path("public/diagnostics/summary.md"), help="Output Markdown summary path")
+    parser.add_argument("--index", type=Path, default=Path("public/index.md"), help="Output index Markdown path for GitHub Pages")
+    args = parser.parse_args()
+
+    diag = load_diag(args.diag)
+    rows = load_iocs(args.ioc_jsonl)
+
+    summary_md, index_md, step_md = render_summary(diag or {}, rows)
+    write_output(args.out, summary_md)
+    write_output(args.index, index_md)
+    append_step_summary(step_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a `scripts/summarize_iocs.py` helper that turns diagnostics and IOC exports into Markdown summaries
- run the summarizer inside the scheduled collector workflow and ship the results to GitHub Pages
- document the new outputs and check in the generated summary/index so the portal has initial content

## Testing
- python -m compileall scripts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691131c2883083278fb354afd2242fe8)