### PR TITLE
Ensure generated highlight timestamp is a string

### DIFF
--- a/scripts/summarize_iocs.py
+++ b/scripts/summarize_iocs.py
@@ -131,7 +131,13 @@ def build_highlights(diag: Dict[str, Any] | None, rows: List[Dict[str, Any]]) ->
     duplicates = diag.get("duplicates_removed") if diag else None
     if duplicates is None:
         duplicates = 0
-    generated = diag.get("ts") if diag else iso(datetime.now(timezone.utc))
+    generated_value = diag.get("ts") if diag else None
+    if isinstance(generated_value, str) and generated_value:
+        generated = generated_value
+    elif generated_value:
+        generated = str(generated_value)
+    else:
+        generated = iso(datetime.now(timezone.utc))
     window = diag.get("window_hours") if diag else None
     counts = (diag.get("counts") if diag else None) or derive_counts(rows)
     active_sources = sum(1 for _, value in counts.items() if value > 0)


### PR DESCRIPTION
## Summary
- ensure the generated timestamp highlight falls back to a string value even when diagnostics metadata is missing

## Testing
- pyright

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911369f01ec83278aeea3456a9935fa)