### PR TITLE
Add GitHub Pages redirect to dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>SwiftIOC Dashboard Redirect</title>
+    <meta http-equiv="refresh" content="0; url=public/">
+    <link rel="canonical" href="public/">
+    <style>
+      body {
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        margin: 0;
+        padding: 2rem;
+        display: flex;
+        min-height: 100vh;
+        align-items: center;
+        justify-content: center;
+        background-color: #0f172a;
+        color: #e2e8f0;
+      }
+      a {
+        color: #38bdf8;
+      }
+      .card {
+        max-width: 32rem;
+        background: rgba(15, 23, 42, 0.85);
+        padding: 2rem;
+        border-radius: 1rem;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+        text-align: center;
+      }
+      h1 {
+        font-size: 1.5rem;
+        margin-bottom: 0.75rem;
+      }
+      p {
+        margin: 0.5rem 0 0;
+        line-height: 1.5;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Redirecting to the SwiftIOC Dashboard</h1>
+      <p>If you are not redirected automatically, <a href="public/">click here to open the dashboard</a>.</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a root `index.html` that immediately redirects visitors to the published dashboard in `public/`
- provide a styled fallback link so the dashboard remains accessible if the redirect does not trigger

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691139d906f08327a26ee9f22428f876)