### PR TITLE
Revamp dashboard layout and add live data preview

### DIFF
--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -1,0 +1,251 @@
+(function () {
+  const PREVIEW_LIMIT = 12;
+  const container = document.querySelector('[data-preview-container]');
+  if (!container) return;
+
+  const table = container.querySelector('[data-preview-table]');
+  const tbody = container.querySelector('[data-preview-body]');
+  const statusEl = container.querySelector('[data-preview-status]');
+  const filterSelect = container.querySelector('[data-preview-filter]');
+  const refreshButton = container.querySelector('[data-preview-refresh]');
+
+  const state = {
+    rows: [],
+    filter: 'all',
+  };
+
+  const normaliseType = (value) => (value || '').toString().trim();
+
+  const setStatus = (message, mode = 'idle') => {
+    if (!statusEl) return;
+    statusEl.textContent = message;
+    statusEl.dataset.state = mode;
+  };
+
+  const setBusy = (busy) => {
+    container.setAttribute('aria-busy', busy ? 'true' : 'false');
+  };
+
+  const safeParse = (line) => {
+    try {
+      return JSON.parse(line);
+    } catch (error) {
+      console.warn('Skipping malformed preview row', error);
+      return null;
+    }
+  };
+
+  const readPreview = async (url, limit) => {
+    const response = await fetch(url, { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch preview (${response.status})`);
+    }
+
+    const takeFromBuffer = (buffer, rows) => {
+      const lines = buffer.split(/\r?\n/);
+      const remainder = lines.pop() ?? '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        const parsed = safeParse(trimmed);
+        if (parsed) {
+          rows.push(parsed);
+          if (rows.length >= limit) {
+            break;
+          }
+        }
+      }
+      return remainder;
+    };
+
+    const rows = [];
+
+    if (!response.body || !response.body.getReader) {
+      const text = await response.text();
+      takeFromBuffer(text, rows);
+      return rows.slice(0, limit);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (rows.length < limit) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        buffer = takeFromBuffer(buffer, rows);
+        if (rows.length >= limit) {
+          await reader.cancel().catch(() => {});
+          break;
+        }
+      }
+
+      if (rows.length < limit && buffer.trim()) {
+        const parsed = safeParse(buffer.trim());
+        if (parsed) {
+          rows.push(parsed);
+        }
+      }
+    } finally {
+      if (reader.releaseLock) {
+        reader.releaseLock();
+      }
+    }
+
+    return rows.slice(0, limit);
+  };
+
+  const renderRows = (rows) => {
+    if (!tbody) return;
+    tbody.innerHTML = '';
+
+    const fragment = document.createDocumentFragment();
+    rows.forEach((row) => {
+      const tr = document.createElement('tr');
+
+      const makeCell = (title, value, className) => {
+        const td = document.createElement('td');
+        td.dataset.title = title;
+        if (className) td.classList.add(className);
+        td.textContent = value;
+        return td;
+      };
+
+      const indicatorCell = document.createElement('td');
+      indicatorCell.dataset.title = 'Indicator';
+      indicatorCell.classList.add('indicator-cell');
+      indicatorCell.textContent = row.indicator ?? '';
+      tr.appendChild(indicatorCell);
+
+      tr.appendChild(makeCell('Type', row.type ?? '—'));
+      tr.appendChild(makeCell('Source', row.source ?? '—'));
+
+      const firstSeenCell = makeCell('First seen', row.first_seen ?? '—');
+      tr.appendChild(firstSeenCell);
+
+      const confidenceCell = makeCell('Confidence', row.confidence ?? '—', 'confidence-cell');
+      const confidence = normaliseType(row.confidence).toLowerCase();
+      if (confidence) {
+        confidenceCell.classList.add(`confidence-${confidence}`);
+      }
+      tr.appendChild(confidenceCell);
+
+      const tagsCell = document.createElement('td');
+      tagsCell.dataset.title = 'Tags';
+      const tags = (row.tags || '')
+        .toString()
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter(Boolean)
+        .slice(0, 4);
+      if (tags.length) {
+        const tagList = document.createElement('div');
+        tagList.className = 'tag-list';
+        tags.forEach((tag) => {
+          const tagEl = document.createElement('span');
+          tagEl.className = 'tag';
+          tagEl.textContent = tag;
+          tagList.appendChild(tagEl);
+        });
+        tagsCell.appendChild(tagList);
+      } else {
+        tagsCell.textContent = '—';
+      }
+      tr.appendChild(tagsCell);
+
+      fragment.appendChild(tr);
+    });
+
+    tbody.appendChild(fragment);
+  };
+
+  const applyFilter = () => {
+    const filter = state.filter;
+    const rows = state.rows;
+    const filtered =
+      filter === 'all' ? rows : rows.filter((row) => normaliseType(row.type).toLowerCase() === filter);
+
+    if (!filtered.length) {
+      if (tbody) tbody.innerHTML = '';
+      table.hidden = true;
+      setStatus('No indicators match this filter yet.', 'empty');
+      return;
+    }
+
+    renderRows(filtered);
+    table.hidden = false;
+    const summary = filter === 'all' ? '' : ` (type: ${filter.toUpperCase()})`;
+    setStatus(`Showing ${filtered.length} of ${rows.length} recent indicators${summary}.`, 'ready');
+  };
+
+  const populateFilterOptions = (rows) => {
+    if (!filterSelect) return;
+    const options = new Set();
+    rows.forEach((row) => {
+      const type = normaliseType(row.type).toLowerCase();
+      if (type) options.add(type);
+    });
+
+    const orderedValues = ['all', ...Array.from(options).sort()];
+
+    filterSelect.innerHTML = '';
+    orderedValues.forEach((value) => {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = value === 'all' ? 'All types' : value;
+      filterSelect.appendChild(option);
+    });
+    filterSelect.value = 'all';
+    filterSelect.disabled = false;
+  };
+
+  const loadPreview = async (silent = false) => {
+    setBusy(true);
+    table.hidden = true;
+    if (tbody) {
+      tbody.innerHTML = '';
+    }
+    setStatus(silent ? 'Refreshing live data…' : 'Loading live data…', 'loading');
+
+    if (filterSelect) filterSelect.disabled = true;
+    if (refreshButton) refreshButton.disabled = true;
+
+    try {
+      const rows = await readPreview('iocs/latest.jsonl', PREVIEW_LIMIT);
+      state.rows = rows;
+      state.filter = 'all';
+
+      if (!rows.length) {
+        setStatus('No indicators available right now. Check back shortly.', 'empty');
+        return;
+      }
+
+      populateFilterOptions(rows);
+      applyFilter();
+    } catch (error) {
+      console.error('Unable to load live preview', error);
+      setStatus('Unable to load the preview. Try again shortly or download the full feed below.', 'error');
+    } finally {
+      if (filterSelect) filterSelect.disabled = state.rows.length === 0;
+      if (refreshButton) refreshButton.disabled = false;
+      setBusy(false);
+    }
+  };
+
+  if (filterSelect) {
+    filterSelect.addEventListener('change', (event) => {
+      state.filter = event.target.value;
+      applyFilter();
+    });
+  }
+
+  if (refreshButton) {
+    refreshButton.addEventListener('click', () => {
+      loadPreview(true);
+    });
+  }
+
+  loadPreview();
+})();

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -1,182 +1,537 @@
 :root {
-  color-scheme: light dark;
+  color-scheme: dark light;
   font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --bg-color: #0f172a;
-  --surface-color: rgba(15, 23, 42, 0.8);
-  --surface-light: #1e293b;
+  line-height: 1.6;
+  --bg-color: #060b1a;
+  --bg-gradient: radial-gradient(circle at 10% 20%, rgba(56, 189, 248, 0.18), transparent 55%),
+    radial-gradient(circle at 90% 10%, rgba(168, 85, 247, 0.12), transparent 55%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.92), rgba(6, 11, 26, 0.98));
+  --surface-color: rgba(15, 23, 42, 0.85);
+  --surface-soft: rgba(15, 23, 42, 0.75);
+  --surface-solid: #111827;
+  --border-color: rgba(148, 163, 184, 0.35);
+  --border-soft: rgba(148, 163, 184, 0.2);
   --text-color: #f8fafc;
-  --text-muted: rgba(226, 232, 240, 0.7);
+  --text-muted: rgba(226, 232, 240, 0.72);
   --accent: #38bdf8;
-  --accent-strong: #0284c7;
-  --border-color: rgba(148, 163, 184, 0.3);
+  --accent-strong: #0ea5e9;
+  --positive: #4ade80;
+  --warning: #facc15;
   background-color: var(--bg-color);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.15), transparent 50%),
-              radial-gradient(circle at bottom right, rgba(147, 51, 234, 0.1), transparent 50%),
-              var(--bg-color);
+  background: var(--bg-gradient);
   color: var(--text-color);
+  -webkit-font-smoothing: antialiased;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at center, rgba(59, 130, 246, 0.08), transparent 60%);
+  opacity: 0.7;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 1rem;
+  padding: 0.75rem 1rem;
+  background: #111827;
+  color: var(--text-color);
+  border-radius: 0.75rem;
+  z-index: 100;
+}
+
+.skip-link:focus {
+  left: 1rem;
 }
 
 .page-wrapper {
   max-width: 1200px;
   margin: 0 auto;
   padding: 3rem 1.5rem 5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
 }
 
 .page-header {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  margin-bottom: 3rem;
+  position: sticky;
+  top: 0;
+  z-index: 20;
 }
 
 .top-nav {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  gap: 2rem;
-  padding: 1rem 1.5rem;
+  gap: 1.5rem;
+  padding: 0.9rem 1.5rem;
+  border-radius: 1.25rem;
   border: 1px solid var(--border-color);
-  border-radius: 1rem;
-  background: rgba(15, 23, 42, 0.7);
-  backdrop-filter: blur(10px);
-  position: sticky;
-  top: 1rem;
-  z-index: 10;
-}
-
-.top-nav a {
-  color: var(--text-muted);
-  text-decoration: none;
-  font-weight: 500;
-  transition: color 0.2s ease;
-}
-
-.top-nav a:hover,
-.top-nav a:focus {
-  color: var(--text-color);
+  background: rgba(6, 11, 26, 0.72);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 18px 45px rgba(2, 6, 23, 0.45);
+  flex-wrap: wrap;
 }
 
 .brand {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.2rem;
+  color: inherit;
+  text-decoration: none;
 }
 
-.brand strong {
-  font-size: 1.25rem;
+.brand-mark {
+  font-size: 1.2rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.brand span {
-  font-size: 0.85rem;
+.brand-tagline {
+  font-size: 0.8rem;
   color: var(--text-muted);
 }
 
-.section-title {
-  font-size: 1.75rem;
-  margin: 0 0 1rem;
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-left: auto;
 }
 
-.section-subtitle {
+.nav-links a {
   color: var(--text-muted);
-  margin-bottom: 2rem;
+  text-decoration: none;
+  font-weight: 500;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  transition: color 0.2s ease, background 0.2s ease;
 }
 
-.card-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.5rem;
+.nav-links a:hover,
+.nav-links a:focus {
+  color: var(--text-color);
+  background: rgba(148, 163, 184, 0.16);
 }
 
-.stat-card {
-  border-radius: 1rem;
-  padding: 1.5rem;
-  border: 1px solid var(--border-color);
-  background: linear-gradient(145deg, rgba(148, 163, 184, 0.08), rgba(15, 23, 42, 0.5));
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.3);
+.page-main {
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
 }
 
-.stat-card h3 {
-  margin-top: 0;
-  margin-bottom: 0.5rem;
-  font-size: 1rem;
-  color: var(--text-muted);
+.hero {
+  display: flex;
+  gap: 2.5rem;
+  align-items: stretch;
+  flex-wrap: wrap;
+}
+
+.hero-body {
+  flex: 2;
+  min-width: 18rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.hero-aside {
+  flex: 1;
+  min-width: 16rem;
+  display: flex;
+  align-items: stretch;
+}
+
+.hero-card {
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  background: var(--surface-color);
+  border: 1px solid var(--border-soft);
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.hero-card-title {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  color: var(--text-muted);
 }
 
-.stat-value {
-  font-size: 2rem;
+.eyebrow {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
   font-weight: 600;
 }
 
-.updated-at {
-  color: var(--text-muted);
-  font-size: 0.9rem;
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.75rem);
 }
 
-.table-wrapper {
+.hero-lede {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 1.05rem;
+}
+
+.hero-meta {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.hero-meta li {
+  border: 1px solid var(--border-soft);
   border-radius: 1rem;
+  padding: 0.85rem 1rem;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.meta-label {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.35rem;
+}
+
+.meta-value {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.button-link,
+.button-link:visited {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #0f172a;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.button-link:hover,
+.button-link:focus {
+  transform: translateY(-1px);
+  background: var(--accent-strong);
+  box-shadow: 0 10px 25px rgba(14, 165, 233, 0.35);
+}
+
+.button-link.secondary {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  box-shadow: none;
+}
+
+.button-link.secondary:hover,
+.button-link.secondary:focus {
+  background: rgba(56, 189, 248, 0.12);
+  box-shadow: none;
+}
+
+button.button-link {
+  border: none;
+  cursor: pointer;
+  font: inherit;
+}
+
+.chip-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.chip {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+}
+
+.section-heading p {
+  margin: 0.65rem 0 0;
+  color: var(--text-muted);
+  max-width: 60ch;
+}
+
+.metrics-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.metric-card {
+  border-radius: 1.2rem;
+  padding: 1.5rem;
+  border: 1px solid var(--border-soft);
+  background: linear-gradient(160deg, rgba(148, 163, 184, 0.14), rgba(15, 23, 42, 0.65));
+  box-shadow: 0 16px 35px rgba(2, 6, 23, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.metric-card h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.metric-value {
+  margin: 0;
+  font-size: 2.2rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.metric-subvalue {
+  display: block;
+  font-size: 0.9rem;
+  color: var(--accent);
+}
+
+.metric-detail {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.table-card {
+  border-radius: 1.2rem;
   overflow: hidden;
   border: 1px solid var(--border-color);
-  margin-bottom: 2.5rem;
-  background: rgba(15, 23, 42, 0.65);
+  background: rgba(15, 23, 42, 0.75);
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.38);
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
+  color: inherit;
 }
 
 thead {
-  background: rgba(51, 65, 85, 0.4);
+  background: rgba(51, 65, 85, 0.45);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
 }
 
 td,
 th {
-  padding: 0.85rem 1.25rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 0.9rem 1.2rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
   text-align: left;
 }
 
-tr:last-child td {
-  border-bottom: none;
+.numeric {
+  text-align: right;
 }
 
-.badge {
-  display: inline-block;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  background: rgba(56, 189, 248, 0.1);
+tbody tr:hover {
+  background: rgba(56, 189, 248, 0.08);
+}
+
+.timeline-grid .metric-card {
+  background: linear-gradient(170deg, rgba(34, 197, 94, 0.12), rgba(15, 23, 42, 0.65));
+}
+
+.data-preview .section-heading p {
+  max-width: 70ch;
+}
+
+.preview-panel {
+  border-radius: 1.2rem;
+  border: 1px solid var(--border-color);
+  background: rgba(15, 23, 42, 0.82);
+  box-shadow: 0 22px 45px rgba(2, 6, 23, 0.45);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.preview-panel[aria-busy="true"] {
+  outline: 2px solid rgba(56, 189, 248, 0.35);
+}
+
+.preview-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.toolbar-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+select {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border-soft);
+  color: var(--text-color);
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  font: inherit;
+}
+
+select:disabled {
+  opacity: 0.6;
+}
+
+.preview-table-wrapper {
+  position: relative;
+  overflow-x: auto;
+}
+
+.preview-table {
+  min-width: 720px;
+}
+
+.preview-table td,
+.preview-table th {
+  vertical-align: top;
+}
+
+.preview-table td {
+  font-size: 0.9rem;
+}
+
+.preview-table td.indicator-cell {
+  font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", ui-monospace, monospace;
+  font-size: 0.85rem;
+  word-break: break-all;
+}
+
+.preview-table td.confidence-cell {
+  text-transform: capitalize;
+}
+
+.preview-table td .tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.tag-list .tag {
+  padding: 0.25rem 0.55rem;
+  border-radius: 0.6rem;
+  background: rgba(56, 189, 248, 0.12);
   color: var(--accent);
+  font-size: 0.75rem;
   font-weight: 600;
+}
+
+.confidence-high {
+  color: var(--positive);
+  font-weight: 600;
+}
+
+.confidence-medium {
+  color: var(--warning);
+  font-weight: 600;
+}
+
+.confidence-low {
+  color: #f87171;
+  font-weight: 600;
+}
+
+.preview-status {
+  margin-top: 0.75rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.preview-status[data-state="error"] {
+  color: #fda4af;
+}
+
+.preview-status[data-state="empty"] {
+  color: var(--warning);
+}
+
+.preview-footnote {
+  margin: 0;
+  color: var(--text-muted);
   font-size: 0.85rem;
 }
 
 .actions-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 1.5rem;
-  margin-top: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .action-card {
-  border: 1px solid var(--border-color);
-  border-radius: 1rem;
+  border-radius: 1.1rem;
+  border: 1px solid var(--border-soft);
+  background: rgba(15, 23, 42, 0.7);
   padding: 1.75rem 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  background: rgba(15, 23, 42, 0.65);
+  box-shadow: 0 16px 35px rgba(2, 6, 23, 0.35);
   transition: transform 0.2s ease, border-color 0.2s ease;
 }
 
@@ -186,14 +541,9 @@ tr:last-child td {
   border-color: var(--accent);
 }
 
-.action-card h3 {
-  margin: 0;
-}
-
 .action-description {
+  margin: 0.5rem 0 0;
   color: var(--text-muted);
-  font-size: 0.95rem;
-  line-height: 1.5;
 }
 
 .action-links {
@@ -202,40 +552,121 @@ tr:last-child td {
   gap: 0.75rem;
 }
 
-.button-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.65rem 1rem;
-  border-radius: 999px;
-  background: var(--accent);
-  color: #0f172a;
-  font-weight: 600;
-  text-decoration: none;
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-
-.button-link:hover,
-.button-link:focus {
-  background: var(--accent-strong);
-  transform: translateY(-2px);
-}
-
 .footer {
-  margin-top: 4rem;
-  padding-top: 2rem;
   border-top: 1px solid var(--border-color);
+  padding-top: 1.5rem;
   color: var(--text-muted);
-  font-size: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  font-size: 0.9rem;
 }
 
-@media (max-width: 768px) {
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+@media (max-width: 900px) {
   .top-nav {
-    flex-direction: column;
-    align-items: flex-start;
+    position: static;
   }
 
-  .stat-value {
-    font-size: 1.75rem;
+  .hero {
+    flex-direction: column;
+  }
+
+  .hero-aside {
+    width: 100%;
+  }
+
+  .preview-table {
+    min-width: 100%;
+  }
+}
+
+@media (max-width: 720px) {
+  .nav-links {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .nav-links a {
+    padding: 0.45rem 0.65rem;
+  }
+
+  .hero-meta {
+    grid-template-columns: 1fr;
+  }
+
+  table,
+  thead,
+  tbody,
+  th,
+  td,
+  tr {
+    display: block;
+  }
+
+  thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+  }
+
+  tr {
+    margin-bottom: 1rem;
+    border: 1px solid var(--border-soft);
+    border-radius: 1rem;
+    background: rgba(15, 23, 42, 0.7);
+    padding: 0.75rem 1rem;
+  }
+
+  td,
+  th {
+    border: none;
+    padding: 0.4rem 0;
+  }
+
+  td::before {
+    content: attr(data-title);
+    font-weight: 600;
+    color: var(--text-muted);
+    display: block;
+    margin-bottom: 0.2rem;
+  }
+
+  .numeric {
+    text-align: left;
+  }
+
+  .preview-table td,
+  .preview-table th {
+    display: block;
+    width: 100%;
+  }
+
+  .preview-table td::before {
+    content: attr(data-title);
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-bottom: 0.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/public/index.md
+++ b/public/index.md
@@ -1,249 +1,407 @@
-<link rel="stylesheet" href="assets/styles.css">
-<div class="page-wrapper">
-  <header class="page-header">
-    <nav class="top-nav" aria-label="Primary">
-      <div class="brand">
-        <strong>SwiftIOC</strong>
-        <span>Automated Threat Intelligence Collector</span>
-      </div>
-      <div class="action-links">
-        <a href="#highlights" class="button-link">Highlights</a>
-        <a href="#sources" class="button-link">Sources</a>
-        <a href="#indicator-types" class="button-link">Indicator Types</a>
-        <a href="#actions" class="button-link">Data Actions</a>
-        <a href="diagnostics/summary.md" class="button-link">Diagnostics</a>
-      </div>
-    </nav>
-    <div>
-      <h1 class="section-title">SwiftIOC Threat Intelligence Snapshot</h1>
-      <p class="section-subtitle">Automatically generated snapshot from the most recent SwiftIOC collection run, designed for quick situational awareness and rapid access to downloadable intelligence feeds.</p>
-      <p class="updated-at">Generated 2025-11-10T00:38:51Z</p>
-    </div>
-  </header>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SwiftIOC Threat Intelligence Dashboard</title>
+    <meta
+      name="description"
+      content="Live snapshot of the most recent SwiftIOC automated threat intelligence collection run with download links, source breakdowns, and a live data preview."
+    />
+    <link rel="preload" href="assets/styles.css" as="style" />
+    <link rel="stylesheet" href="assets/styles.css" />
+  </head>
+  <body>
+    <a href="#main" class="skip-link">Skip to main content</a>
+    <div class="page-wrapper">
+      <header class="page-header">
+        <nav class="top-nav" aria-label="Primary navigation">
+          <a class="brand" href="./">
+            <span class="brand-mark">SwiftIOC</span>
+            <span class="brand-tagline">Automated Threat Intelligence</span>
+          </a>
+          <div class="nav-links">
+            <a href="#overview">Overview</a>
+            <a href="#highlights">Highlights</a>
+            <a href="#timeline">Timeline</a>
+            <a href="#sources">Sources</a>
+            <a href="#indicator-types">Types</a>
+            <a href="#preview">Preview</a>
+            <a href="#actions">Downloads</a>
+            <a href="diagnostics/summary.md">Diagnostics</a>
+          </div>
+        </nav>
+      </header>
 
-  <section id="highlights">
-    <h2 class="section-title">Operational Highlights</h2>
-    <p class="section-subtitle">A summary of the current indicator of compromise (IOC) landscape derived from all enabled sources.</p>
-    <div class="card-grid">
-      <article class="stat-card">
-        <h3>Total Indicators</h3>
-        <div class="stat-value">2,497</div>
-        <p class="action-description">Unique IOCs collected during the latest cycle.</p>
-      </article>
-      <article class="stat-card">
-        <h3>Sources Reporting</h3>
-        <div class="stat-value">4</div>
-        <p class="action-description">Active intelligence feeds that produced data in this run.</p>
-      </article>
-      <article class="stat-card">
-        <h3>Indicator Types</h3>
-        <div class="stat-value">4</div>
-        <p class="action-description">Distinct IOC formats identified across the feeds.</p>
-      </article>
-      <article class="stat-card">
-        <h3>Duplicates Removed</h3>
-        <div class="stat-value">0</div>
-        <p class="action-description">Indicators deduplicated to maintain a clean dataset.</p>
-      </article>
-    </div>
-  </section>
+      <main id="main" class="page-main" tabindex="-1">
+        <section id="overview" class="hero">
+          <div class="hero-body">
+            <p class="eyebrow">Automated Threat Intelligence Collector</p>
+            <h1>SwiftIOC Threat Intelligence Snapshot</h1>
+            <p class="hero-lede">
+              Automatically generated from the latest SwiftIOC collection run. Use this dashboard for
+              instant situational awareness, source health, and quick access to download-ready feeds.
+            </p>
+            <ul class="hero-meta">
+              <li>
+                <span class="meta-label">Generated</span>
+                <span class="meta-value">2025-11-10T00:38:51Z</span>
+              </li>
+              <li>
+                <span class="meta-label">Collection window</span>
+                <span class="meta-value">2025-11-08 → 2025-11-10</span>
+              </li>
+              <li>
+                <span class="meta-label">Feeds online</span>
+                <span class="meta-value">4 active sources</span>
+              </li>
+            </ul>
+            <div class="hero-actions">
+              <a class="button-link" href="#preview">Live preview</a>
+              <a class="button-link secondary" href="#actions">Download data</a>
+            </div>
+          </div>
+          <div class="hero-aside">
+            <div class="hero-card">
+              <h2 class="hero-card-title">Quality signals</h2>
+              <p>SwiftIOC deduplicates indicators, preserves provenance, and publishes in open formats.</p>
+              <ul class="chip-list">
+                <li class="chip">TLP: CLEAR</li>
+                <li class="chip">High confidence majority</li>
+                <li class="chip">JSONL · STIX · CSV</li>
+              </ul>
+            </div>
+          </div>
+        </section>
 
-  <section id="timeline">
-    <h2 class="section-title">Collection Timeline</h2>
-    <div class="card-grid">
-      <article class="stat-card">
-        <h3>Earliest First Seen</h3>
-        <div class="stat-value">2025-11-08<br><span class="badge">00:38:37Z</span></div>
-        <p class="action-description">Oldest IOC sighting retained in the active window.</p>
-      </article>
-      <article class="stat-card">
-        <h3>Newest First Seen</h3>
-        <div class="stat-value">2025-11-10<br><span class="badge">00:34:46Z</span></div>
-        <p class="action-description">Most recent IOC discovery across all sources.</p>
-      </article>
-      <article class="stat-card">
-        <h3>Multi-source Overlaps</h3>
-        <div class="stat-value">0</div>
-        <p class="action-description">IOCs independently confirmed by more than one feed.</p>
-      </article>
-    </div>
-  </section>
+        <section id="highlights" class="section">
+          <div class="section-heading">
+            <h2>Operational highlights</h2>
+            <p>Key metrics that summarise the current indicator landscape across all enabled feeds.</p>
+          </div>
+          <div class="metrics-grid">
+            <article class="metric-card">
+              <h3>Total indicators</h3>
+              <p class="metric-value">2,497</p>
+              <p class="metric-detail">Unique IOCs collected during the latest cycle.</p>
+            </article>
+            <article class="metric-card">
+              <h3>Sources reporting</h3>
+              <p class="metric-value">4</p>
+              <p class="metric-detail">Active intelligence feeds that produced data this run.</p>
+            </article>
+            <article class="metric-card">
+              <h3>Indicator types</h3>
+              <p class="metric-value">4</p>
+              <p class="metric-detail">Distinct IOC formats discovered across the feeds.</p>
+            </article>
+            <article class="metric-card">
+              <h3>Duplicates removed</h3>
+              <p class="metric-value">0</p>
+              <p class="metric-detail">Indicators deduplicated to maintain a clean dataset.</p>
+            </article>
+          </div>
+        </section>
 
-  <section id="sources">
-    <h2 class="section-title">Per-source Totals</h2>
-    <p class="section-subtitle">Understand which feeds are contributing the most intelligence at a glance.</p>
-    <div class="table-wrapper">
-      <table>
-        <thead>
-          <tr>
-            <th scope="col">Source</th>
-            <th scope="col" style="text-align:right">Indicators</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>urlhaus_recent_urls</td>
-            <td style="text-align:right">1,635</td>
-          </tr>
-          <tr>
-            <td>malwarebazaar_recent</td>
-            <td style="text-align:right">769</td>
-          </tr>
-          <tr>
-            <td>sslbl_ja3</td>
-            <td style="text-align:right">92</td>
-          </tr>
-          <tr>
-            <td>feodo_ipblocklist</td>
-            <td style="text-align:right">1</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </section>
+        <section id="timeline" class="section">
+          <div class="section-heading">
+            <h2>Collection timeline</h2>
+            <p>Understand recency and overlap across sources to plan enrichment and response.</p>
+          </div>
+          <div class="metrics-grid timeline-grid">
+            <article class="metric-card">
+              <h3>Earliest first seen</h3>
+              <p class="metric-value">
+                2025-11-08
+                <span class="metric-subvalue">00:38:37Z</span>
+              </p>
+              <p class="metric-detail">Oldest IOC sighting retained in the active window.</p>
+            </article>
+            <article class="metric-card">
+              <h3>Newest first seen</h3>
+              <p class="metric-value">
+                2025-11-10
+                <span class="metric-subvalue">00:34:46Z</span>
+              </p>
+              <p class="metric-detail">Most recent IOC discovery across all sources.</p>
+            </article>
+            <article class="metric-card">
+              <h3>Multi-source overlaps</h3>
+              <p class="metric-value">0</p>
+              <p class="metric-detail">Indicators independently confirmed by more than one feed.</p>
+            </article>
+          </div>
+        </section>
 
-  <section id="indicator-types">
-    <h2 class="section-title">Indicator Types</h2>
-    <p class="section-subtitle">Breakdown of IOC formats to support filtering and response planning.</p>
-    <div class="table-wrapper">
-      <table>
-        <thead>
-          <tr>
-            <th scope="col">Type</th>
-            <th scope="col" style="text-align:right">Indicators</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>url</td>
-            <td style="text-align:right">1,635</td>
-          </tr>
-          <tr>
-            <td>sha256</td>
-            <td style="text-align:right">769</td>
-          </tr>
-          <tr>
-            <td>ja3</td>
-            <td style="text-align:right">92</td>
-          </tr>
-          <tr>
-            <td>ipv4</td>
-            <td style="text-align:right">1</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </section>
+        <section id="sources" class="section">
+          <div class="section-heading">
+            <h2>Per-source totals</h2>
+            <p>See which feeds are contributing the most intelligence at a glance.</p>
+          </div>
+          <div class="table-card">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Source</th>
+                  <th scope="col" class="numeric">Indicators</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td data-title="Source">urlhaus_recent_urls</td>
+                  <td class="numeric" data-title="Indicators">1,635</td>
+                </tr>
+                <tr>
+                  <td data-title="Source">malwarebazaar_recent</td>
+                  <td class="numeric" data-title="Indicators">769</td>
+                </tr>
+                <tr>
+                  <td data-title="Source">sslbl_ja3</td>
+                  <td class="numeric" data-title="Indicators">92</td>
+                </tr>
+                <tr>
+                  <td data-title="Source">feodo_ipblocklist</td>
+                  <td class="numeric" data-title="Indicators">1</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
 
-  <section id="top-tags">
-    <h2 class="section-title">Top Tags</h2>
-    <p class="section-subtitle">Most prevalent threat tags assigned to indicators in the latest sweep.</p>
-    <div class="table-wrapper">
-      <table>
-        <thead>
-          <tr>
-            <th scope="col">Tag</th>
-            <th scope="col" style="text-align:right">Indicators</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>malware</td>
-            <td style="text-align:right">2,405</td>
-          </tr>
-          <tr>
-            <td>Mirai</td>
-            <td style="text-align:right">496</td>
-          </tr>
-          <tr>
-            <td>sslbl</td>
-            <td style="text-align:right">92</td>
-          </tr>
-          <tr>
-            <td>tls</td>
-            <td style="text-align:right">92</td>
-          </tr>
-          <tr>
-            <td>fingerprint</td>
-            <td style="text-align:right">92</td>
-          </tr>
-          <tr>
-            <td>Rhadamanthys</td>
-            <td style="text-align:right">20</td>
-          </tr>
-          <tr>
-            <td>Ngioweb</td>
-            <td style="text-align:right">14</td>
-          </tr>
-          <tr>
-            <td>AgentTesla</td>
-            <td style="text-align:right">11</td>
-          </tr>
-          <tr>
-            <td>RemcosRAT</td>
-            <td style="text-align:right">10</td>
-          </tr>
-          <tr>
-            <td>XWorm</td>
-            <td style="text-align:right">9</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </section>
+        <section id="indicator-types" class="section">
+          <div class="section-heading">
+            <h2>Indicator types</h2>
+            <p>Breakdown of IOC formats to support filtering and response planning.</p>
+          </div>
+          <div class="table-card">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Type</th>
+                  <th scope="col" class="numeric">Indicators</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td data-title="Type">url</td>
+                  <td class="numeric" data-title="Indicators">1,635</td>
+                </tr>
+                <tr>
+                  <td data-title="Type">sha256</td>
+                  <td class="numeric" data-title="Indicators">769</td>
+                </tr>
+                <tr>
+                  <td data-title="Type">ja3</td>
+                  <td class="numeric" data-title="Indicators">92</td>
+                </tr>
+                <tr>
+                  <td data-title="Type">ipv4</td>
+                  <td class="numeric" data-title="Indicators">1</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
 
-  <section id="actions">
-    <h2 class="section-title">Data Actions</h2>
-    <p class="section-subtitle">Choose the format that best fits your workflow. Each action card explains what you get before you download.</p>
-    <div class="actions-grid">
-      <article class="action-card">
-        <h3>Download CSV</h3>
-        <p class="action-description">Exports all current indicators in comma-separated format. Ideal for spreadsheets, SIEM ingestion, and manual review.</p>
-        <div class="action-links">
-          <a class="button-link" href="iocs/latest.csv">Get CSV</a>
-        </div>
-      </article>
-      <article class="action-card">
-        <h3>Download TSV</h3>
-        <p class="action-description">Tab-delimited indicators for tooling that expects whitespace-separated values with consistent quoting.</p>
-        <div class="action-links">
-          <a class="button-link" href="iocs/latest.tsv">Get TSV</a>
-        </div>
-      </article>
-      <article class="action-card">
-        <h3>JSON Feed</h3>
-        <p class="action-description">Machine-readable JSON document containing the full indicator payload, suitable for scripting and automation.</p>
-        <div class="action-links">
-          <a class="button-link" href="iocs/latest.json">Download JSON</a>
-          <a class="button-link" href="iocs/latest.jsonl">Stream (JSONL)</a>
-        </div>
-      </article>
-      <article class="action-card">
-        <h3>STIX 2.1 Bundle</h3>
-        <p class="action-description">Standards-compliant STIX bundle for sharing threat intelligence with TIPs and platforms that ingest STIX objects.</p>
-        <div class="action-links">
-          <a class="button-link" href="iocs/stix2.json">Download STIX</a>
-        </div>
-      </article>
-      <article class="action-card">
-        <h3>Diagnostics Report</h3>
-        <p class="action-description">Dive deeper into collection health, failures, and per-source diagnostics to troubleshoot feed availability.</p>
-        <div class="action-links">
-          <a class="button-link" href="diagnostics/summary.md">View Diagnostics</a>
-        </div>
-      </article>
-      <article class="action-card">
-        <h3>Raw Data Directory</h3>
-        <p class="action-description">Browse the published IOC folder directly to integrate with external tooling or scripted downloads.</p>
-        <div class="action-links">
-          <a class="button-link" href="iocs/">Open Directory</a>
-        </div>
-      </article>
-    </div>
-  </section>
+        <section id="top-tags" class="section">
+          <div class="section-heading">
+            <h2>Top tags</h2>
+            <p>Most prevalent threat tags assigned to indicators in the latest sweep.</p>
+          </div>
+          <div class="table-card">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Tag</th>
+                  <th scope="col" class="numeric">Indicators</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td data-title="Tag">malware</td>
+                  <td class="numeric" data-title="Indicators">2,405</td>
+                </tr>
+                <tr>
+                  <td data-title="Tag">Mirai</td>
+                  <td class="numeric" data-title="Indicators">496</td>
+                </tr>
+                <tr>
+                  <td data-title="Tag">sslbl</td>
+                  <td class="numeric" data-title="Indicators">92</td>
+                </tr>
+                <tr>
+                  <td data-title="Tag">tls</td>
+                  <td class="numeric" data-title="Indicators">92</td>
+                </tr>
+                <tr>
+                  <td data-title="Tag">fingerprint</td>
+                  <td class="numeric" data-title="Indicators">92</td>
+                </tr>
+                <tr>
+                  <td data-title="Tag">Rhadamanthys</td>
+                  <td class="numeric" data-title="Indicators">20</td>
+                </tr>
+                <tr>
+                  <td data-title="Tag">Ngioweb</td>
+                  <td class="numeric" data-title="Indicators">14</td>
+                </tr>
+                <tr>
+                  <td data-title="Tag">AgentTesla</td>
+                  <td class="numeric" data-title="Indicators">11</td>
+                </tr>
+                <tr>
+                  <td data-title="Tag">RemcosRAT</td>
+                  <td class="numeric" data-title="Indicators">10</td>
+                </tr>
+                <tr>
+                  <td data-title="Tag">XWorm</td>
+                  <td class="numeric" data-title="Indicators">9</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
 
-  <footer class="footer">
-    <p>SwiftIOC automatically harvests, normalises, and publishes threat intelligence on a rolling basis. For implementation details, explore the repository README.</p>
-    <p><a href="diagnostics/summary.md" class="button-link">Diagnostics Summary</a> · <a href="diagnostics/REPORT.md" class="button-link">Full Report</a></p>
-  </footer>
-</div>
+        <section id="preview" class="section data-preview">
+          <div class="section-heading">
+            <h2>Live indicator preview</h2>
+            <p>Peek at the most recent indicators directly from the JSONL feed before downloading.</p>
+          </div>
+          <div
+            class="preview-panel"
+            data-preview-container
+            role="region"
+            aria-live="polite"
+            aria-busy="false"
+          >
+            <div class="preview-toolbar">
+              <label class="toolbar-group" for="preview-filter">
+                <span>Filter by type</span>
+                <select id="preview-filter" data-preview-filter disabled>
+                  <option value="all">All types</option>
+                </select>
+              </label>
+              <button type="button" class="button-link secondary" data-preview-refresh>
+                Refresh preview
+              </button>
+            </div>
+            <div class="preview-table-wrapper">
+              <table class="preview-table" data-preview-table hidden>
+                <thead>
+                  <tr>
+                    <th scope="col">Indicator</th>
+                    <th scope="col">Type</th>
+                    <th scope="col">Source</th>
+                    <th scope="col">First seen</th>
+                    <th scope="col">Confidence</th>
+                    <th scope="col">Tags</th>
+                  </tr>
+                </thead>
+                <tbody data-preview-body></tbody>
+              </table>
+              <div class="preview-status" data-preview-status role="status">Preparing live preview…</div>
+            </div>
+            <p class="preview-footnote">
+              The preview streams the first 12 indicators over HTTPS using lightweight streaming logic to
+              keep load times fast. Fetch the full dataset below when you need complete coverage.
+            </p>
+          </div>
+        </section>
+
+        <section id="actions" class="section">
+          <div class="section-heading">
+            <h2>Data actions</h2>
+            <p>Choose the format that best fits your workflow before exporting the latest dataset.</p>
+          </div>
+          <div class="actions-grid">
+            <article class="action-card">
+              <div>
+                <h3>Download CSV</h3>
+                <p class="action-description">
+                  Exports all current indicators in comma-separated format. Ideal for spreadsheets, SIEM
+                  ingestion, and manual review.
+                </p>
+              </div>
+              <div class="action-links">
+                <a class="button-link" href="iocs/latest.csv">Get CSV</a>
+              </div>
+            </article>
+            <article class="action-card">
+              <div>
+                <h3>Download TSV</h3>
+                <p class="action-description">
+                  Tab-delimited indicators for tooling that expects whitespace-separated values with
+                  consistent quoting.
+                </p>
+              </div>
+              <div class="action-links">
+                <a class="button-link" href="iocs/latest.tsv">Get TSV</a>
+              </div>
+            </article>
+            <article class="action-card">
+              <div>
+                <h3>JSON feed</h3>
+                <p class="action-description">
+                  Machine-readable JSON document containing the full indicator payload, suitable for
+                  scripting and automation.
+                </p>
+              </div>
+              <div class="action-links">
+                <a class="button-link" href="iocs/latest.json">Download JSON</a>
+                <a class="button-link secondary" href="iocs/latest.jsonl">Stream (JSONL)</a>
+              </div>
+            </article>
+            <article class="action-card">
+              <div>
+                <h3>STIX 2.1 bundle</h3>
+                <p class="action-description">
+                  Standards-compliant STIX bundle for sharing threat intelligence with TIPs and platforms
+                  that ingest STIX objects.
+                </p>
+              </div>
+              <div class="action-links">
+                <a class="button-link" href="iocs/stix2.json">Download STIX</a>
+              </div>
+            </article>
+            <article class="action-card">
+              <div>
+                <h3>Diagnostics report</h3>
+                <p class="action-description">
+                  Dive deeper into collection health, failures, and per-source diagnostics to troubleshoot
+                  feed availability.
+                </p>
+              </div>
+              <div class="action-links">
+                <a class="button-link" href="diagnostics/summary.md">View diagnostics</a>
+              </div>
+            </article>
+            <article class="action-card">
+              <div>
+                <h3>Raw data directory</h3>
+                <p class="action-description">
+                  Browse the published IOC folder directly to integrate with external tooling or scripted
+                  downloads.
+                </p>
+              </div>
+              <div class="action-links">
+                <a class="button-link secondary" href="iocs/">Open directory</a>
+              </div>
+            </article>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <p>
+          SwiftIOC automatically harvests, normalises, and publishes threat intelligence on a rolling
+          basis. For implementation details, explore the repository README.
+        </p>
+        <p class="footer-links">
+          <a href="diagnostics/summary.md" class="button-link secondary">Diagnostics summary</a>
+          <a href="diagnostics/REPORT.md" class="button-link secondary">Full report</a>
+        </p>
+      </footer>
+    </div>
+    <script defer src="assets/dashboard.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- rebuild the public dashboard with a new overview, navigation, and action layout
- refresh the shared stylesheet for faster, responsive rendering and improved accessibility details
- add a lightweight streaming preview widget that reads the JSONL feed and supports type filtering

## Testing
- not run (static content changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69113ab8c0a48327b013c9f07658e219)