### PR TITLE
Add universal parser for arbitrary feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,12 @@ rss:
 
 Each parser can accept additional keyword arguments defined under `options:`.
 Custom parsers are supported via Python dotted paths (for example,
-`parse: my_package.parsers:parse_feed`). 
+`parse: my_package.parsers:parse_feed`).
+
+For feeds without a dedicated adapter you can fall back to the universal
+collector by setting `parse: universal`. It will autodetect JSON, CSV, or plain
+text payloads, discover common timestamp/tag fields, and extract indicators via
+the same heuristics used for RSS content.
 
 ## 📋 CLI reference
 Run `python -m swiftioc --help` for the full list of switches. Highlights:


### PR DESCRIPTION
## Summary
- add shared indicator extraction helpers that safely wrap iocextract and reuse them in the RSS adapter
- introduce a universal parser (`universal`/`auto`/`generic`) that auto-detects JSON, CSV, or text feeds and extracts indicators with contextual metadata
- document the new parser option in the README for users without dedicated adapters

## Testing
- python -m py_compile swiftioc.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691352698b008327936a2d7e457ddb6d)