### PR TITLE
Speed up dashboard loads with cached dataset refresh

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -336,8 +336,9 @@
               <div class="preview-status" data-preview-status role="status">Preparing live preview…</div>
             </div>
             <p class="preview-footnote">
-              The preview streams the first 12 indicators over HTTPS using lightweight streaming logic to
-              keep load times fast. Fetch the full dataset below when you need complete coverage.
+              The preview reuses a cached snapshot for instant loads, refreshes it in the background, and
+              shares the same dataset as the metrics above so there are no duplicate downloads. Grab the
+              full dataset below when you need complete coverage.
             </p>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- persist the shared dataset in session storage with background refresh notifications so repeat visits render instantly
- update the live preview to surface cached snapshot messaging and auto-refresh once fresh data arrives
- refresh the preview footnote to describe the caching behaviour and background updates

## Testing
- node -e "new Function(require('fs').readFileSync('public/assets/dashboard.js', 'utf8'))"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69149ce95ad08327b1c7e09243ca0b03)