### PR TITLE
Curate live preview around top-confidence source highlights

### DIFF
--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -570,6 +570,75 @@ tbody tr:hover {
   gap: 1.25rem;
 }
 
+.preview-summary {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+}
+
+.summary-card {
+  border: 1px solid var(--border-soft);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  background: rgba(15, 23, 42, 0.65);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-height: 110px;
+}
+
+.summary-label {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.summary-value {
+  margin: 0;
+  font-size: clamp(1.35rem, 2.3vw, 1.75rem);
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.summary-subvalue {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.preview-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.preview-meta-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.preview-meta-pill[data-state='cache'],
+.preview-meta-pill[data-state='cache-stale'] {
+  background: rgba(234, 179, 8, 0.18);
+  color: #facc15;
+}
+
+.preview-meta-relative {
+  color: rgba(226, 232, 240, 0.6);
+  margin-left: 0.35rem;
+}
+
 .preview-panel[aria-busy="true"] {
   outline: 2px solid rgba(56, 189, 248, 0.35);
 }
@@ -648,21 +717,45 @@ select:disabled,
 
 .preview-table {
   min-width: 720px;
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
 .preview-table td,
 .preview-table th {
   vertical-align: top;
-}
-
-.preview-table td {
-  font-size: 0.9rem;
+  padding: 0.75rem 0.9rem;
 }
 
 .preview-table td.indicator-cell {
   font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", ui-monospace, monospace;
   font-size: 0.85rem;
   word-break: break-all;
+}
+
+.preview-table thead th {
+  text-align: left;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.65);
+  background: rgba(15, 23, 42, 0.92);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.preview-table tbody td {
+  font-size: 0.9rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.preview-table tbody tr:nth-child(even) {
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.preview-table tbody tr:hover {
+  background: rgba(56, 189, 248, 0.12);
 }
 
 .indicator-wrapper {
@@ -841,6 +934,10 @@ select:disabled,
     min-width: 100%;
   }
 
+  .preview-summary {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+
   .step-card {
     grid-template-columns: 1fr;
   }
@@ -884,6 +981,15 @@ select:disabled,
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
+  }
+
+  .preview-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .preview-meta {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .copy-indicator {

--- a/public/index.html
+++ b/public/index.html
@@ -269,8 +269,8 @@
 
         <section id="preview" class="section data-preview">
           <div class="section-heading">
-            <h2>Live indicator preview</h2>
-            <p>Peek at the most recent indicators directly from the JSONL feed before downloading.</p>
+            <h2>Live source preview</h2>
+            <p>Review the strongest, highest-confidence signal from each reporting source before downloading.</p>
           </div>
           <div
             class="preview-panel"
@@ -279,6 +279,39 @@
             aria-live="polite"
             aria-busy="false"
           >
+            <div class="preview-summary" data-preview-summary hidden>
+              <article class="summary-card">
+                <p class="summary-label">Sources highlighted</p>
+                <p class="summary-value" data-preview-visible>—</p>
+                <p class="summary-subvalue">
+                  out of <span data-preview-total>—</span> reporting sources
+                </p>
+              </article>
+              <article class="summary-card">
+                <p class="summary-label">High-confidence sources</p>
+                <p class="summary-value" data-preview-high>—</p>
+                <p class="summary-subvalue">
+                  <span data-preview-high-percent>—</span> of highlighted
+                </p>
+              </article>
+              <article class="summary-card">
+                <p class="summary-label">Most common tag</p>
+                <p class="summary-value" data-preview-top-tag>—</p>
+                <p class="summary-subvalue" data-preview-top-tag-count>—</p>
+              </article>
+              <article class="summary-card">
+                <p class="summary-label">Freshest sighting</p>
+                <p class="summary-value" data-preview-newest>—</p>
+                <p class="summary-subvalue" data-preview-newest-relative></p>
+              </article>
+            </div>
+            <div class="preview-meta" data-preview-meta hidden>
+              <span class="preview-meta-pill" data-preview-origin>Live data</span>
+              <span class="preview-meta-detail">
+                Updated <time data-preview-refreshed>—</time>
+                <span class="preview-meta-relative" data-preview-relative></span>
+              </span>
+            </div>
             <div class="preview-toolbar">
               <div class="toolbar-controls">
                 <label class="toolbar-group" for="preview-filter">
@@ -302,9 +335,9 @@
                   </select>
                 </label>
               </div>
-              <div class="toolbar-actions">
-                <label class="toolbar-group" for="preview-search">
-                  <span>Search indicators</span>
+                <div class="toolbar-actions">
+                  <label class="toolbar-group" for="preview-search">
+                    <span>Search highlights</span>
                   <input
                     id="preview-search"
                     type="search"
@@ -336,9 +369,9 @@
               <div class="preview-status" data-preview-status role="status">Preparing live preview…</div>
             </div>
             <p class="preview-footnote">
-              The preview reuses a cached snapshot for instant loads, refreshes it in the background, and
-              shares the same dataset as the metrics above so there are no duplicate downloads. Grab the
-              full dataset below when you need complete coverage.
+              The preview surfaces one leader per source using cached data for instant loads, refreshes in
+              the background, and shares the same dataset as the metrics above. Grab the full dataset below
+              when you need complete coverage.
             </p>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- ensure the live preview surfaces the strongest, most recent indicator from each source before applying diversity rules
- update preview metrics to report highlighted sources, high-confidence share, and clearer tag messaging tied to the new selection logic
- refresh the preview copy so the UI explains the per-source focus and search label change

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917e0d70fdc832795d206f64dedea1e)