### PR TITLE
Keep dashboard one-screen grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,214 +1,402 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>SwiftIOC GitHub Pages</title>
     <meta
       name="description"
-      content="Jump straight into the SwiftIOC GitHub Pages dashboard with fresh indicators, downloads, and diagnostics."
-    >
-    <meta http-equiv="refresh" content="3; url=public/">
-    <link rel="canonical" href="public/">
-    <meta name="theme-color" content="#0f172a">
+      content="Compact SwiftIOC GitHub Pages launcher with quick actions, diagnostics, and a cancellable redirect."
+    />
+    <link rel="canonical" href="public/" />
+    <meta name="theme-color" content="#0f172a" />
     <style>
       :root {
         color-scheme: dark light;
         font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
       }
+
+      * {
+        box-sizing: border-box;
+      }
+
       body {
         margin: 0;
-        padding: clamp(1.25rem, 3vw, 2.5rem);
-        display: flex;
+        padding: clamp(0.75rem, 2vw, 1.5rem);
         min-height: 100vh;
-        align-items: center;
-        justify-content: center;
-        background: radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.12), transparent 55%),
-          radial-gradient(circle at 80% 10%, rgba(168, 85, 247, 0.12), transparent 50%),
-          #0f172a;
+        height: 100vh;
+        display: grid;
+        place-items: center;
+        background: radial-gradient(circle at 15% 15%, rgba(59, 130, 246, 0.08), transparent 55%),
+          radial-gradient(circle at 85% 10%, rgba(168, 85, 247, 0.08), transparent 50%),
+          linear-gradient(145deg, #0b1222, #0f172a 50%, #0b1222);
         color: #e2e8f0;
+        overflow: hidden;
       }
+
       a {
-        color: #38bdf8;
+        color: inherit;
       }
+
       .card {
-        width: min(960px, 100%);
-        background: rgba(15, 23, 42, 0.9);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
-        border-radius: 1.25rem;
+        width: min(1180px, 100%);
+        height: calc(100vh - clamp(1.5rem, 4vw, 2.75rem));
+        background: rgba(11, 18, 34, 0.9);
+        padding: clamp(1.2rem, 2.5vw, 2rem);
+        border-radius: 1.4rem;
         box-shadow: 0 24px 55px rgba(15, 23, 42, 0.55);
         display: grid;
-        gap: clamp(1rem, 2vw, 1.5rem);
-        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        grid-template-rows: auto 1fr auto;
+        gap: clamp(0.75rem, 1.5vw, 1.1rem);
+        overflow: hidden;
       }
+
       .card-header {
-        grid-column: 1 / -1;
-        display: flex;
-        flex-direction: column;
-        gap: 0.6rem;
+        display: grid;
+        gap: 0.7rem;
       }
-      h1 {
-        font-size: clamp(1.6rem, 3vw, 2rem);
-        margin: 0;
-      }
-      p {
-        margin: 0;
-        line-height: 1.6;
-        color: rgba(226, 232, 240, 0.82);
-      }
-      .pill {
+
+      .badge {
         display: inline-flex;
         align-items: center;
-        gap: 0.4rem;
-        padding: 0.35rem 0.75rem;
-        background: rgba(56, 189, 248, 0.1);
+        gap: 0.45rem;
+        padding: 0.4rem 0.85rem;
+        background: rgba(56, 189, 248, 0.12);
         border-radius: 999px;
-        font-weight: 600;
-        color: #38bdf8;
+        font-weight: 700;
+        color: #7dd3fc;
         width: fit-content;
+        text-transform: uppercase;
+        letter-spacing: 0.02em;
+        font-size: 0.9rem;
       }
-      .pill::before {
+
+      .badge::before {
         content: "";
-        width: 8px;
-        height: 8px;
+        width: 9px;
+        height: 9px;
         border-radius: 50%;
         background: #22d3ee;
-        box-shadow: 0 0 0 6px rgba(56, 189, 248, 0.18);
+        box-shadow: 0 0 0 6px rgba(56, 189, 248, 0.14);
       }
+
+      .title-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.85rem;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(1.55rem, 2.6vw, 2rem);
+        color: #f8fafc;
+      }
+
+      p {
+        margin: 0;
+        line-height: 1.5;
+        color: rgba(226, 232, 240, 0.82);
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.4rem 0.75rem;
+        background: rgba(99, 102, 241, 0.16);
+        border-radius: 999px;
+        color: #c4d2ff;
+        font-weight: 700;
+      }
+
+      .progress-shell {
+        position: relative;
+        width: 100%;
+        height: 8px;
+        border-radius: 999px;
+        background: rgba(148, 163, 184, 0.25);
+        overflow: hidden;
+      }
+
+      .progress-bar {
+        position: absolute;
+        inset: 0;
+        width: 0%;
+        background: linear-gradient(90deg, #38bdf8, #a78bfa);
+        border-radius: 999px;
+        transition: width 0.15s ease;
+      }
+
       .actions {
         display: flex;
         flex-wrap: wrap;
-        gap: 0.75rem;
+        gap: 0.5rem;
       }
+
       .button-link {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        padding: 0.65rem 1.1rem;
-        border-radius: 999px;
-        font-weight: 700;
+        padding: 0.6rem 1rem;
+        border-radius: 0.95rem;
+        font-weight: 800;
         text-decoration: none;
-        transition: transform 0.2s ease, background 0.2s ease;
+        transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
+        border: 1px solid transparent;
       }
+
       .button-link.primary {
         background: #38bdf8;
         color: #0b1324;
         box-shadow: 0 14px 30px rgba(14, 165, 233, 0.35);
       }
+
       .button-link.secondary {
-        border: 1px solid rgba(148, 163, 184, 0.35);
+        border: 1px solid rgba(148, 163, 184, 0.4);
         background: rgba(15, 23, 42, 0.65);
-        color: inherit;
+        color: #e2e8f0;
       }
+
+      .button-link.ghost {
+        border: 1px dashed rgba(148, 163, 184, 0.45);
+        background: rgba(148, 163, 184, 0.08);
+        color: rgba(226, 232, 240, 0.82);
+      }
+
       .button-link:hover,
       .button-link:focus-visible {
-        background: rgba(56, 189, 248, 0.15);
         transform: translateY(-1px);
+        background: rgba(56, 189, 248, 0.15);
+        color: #f8fafc;
       }
+
       .button-link.primary:hover,
       .button-link.primary:focus-visible {
         background: #0ea5e9;
-        color: #f8fafc;
-      }
-      .list {
-        margin: 0;
-        padding: 0;
-        list-style: none;
-        display: grid;
-        gap: 0.6rem;
-      }
-      .list strong {
-        color: #f8fafc;
-      }
-      .link-grid {
-        display: grid;
-        gap: 0.75rem;
-      }
-      .note {
-        grid-column: 1 / -1;
-        padding: 1rem 1.25rem;
-        border-radius: 0.9rem;
-        background: rgba(56, 189, 248, 0.08);
-        border: 1px solid rgba(56, 189, 248, 0.25);
-      }
-      .footnote {
-        grid-column: 1 / -1;
-        font-size: 0.95rem;
-        color: rgba(226, 232, 240, 0.78);
       }
 
-      @media (max-width: 640px) {
+      .grid {
+        display: grid;
+        gap: clamp(0.75rem, 1.3vw, 1rem);
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        grid-auto-rows: 1fr;
+      }
+
+      .cardlet {
+        padding: 0.85rem 1rem;
+        background: rgba(15, 23, 42, 0.7);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        border-radius: 1rem;
+        display: grid;
+        gap: 0.35rem;
+        min-height: 150px;
+      }
+
+      .cardlet h2 {
+        margin: 0;
+        font-size: 1.05rem;
+        color: #e2e8f0;
+      }
+
+      .muted {
+        color: rgba(226, 232, 240, 0.72);
+        line-height: 1.4;
+      }
+
+      .link-row {
+        display: flex;
+        gap: 0.45rem;
+        flex-wrap: wrap;
+      }
+
+      .highlights {
+        display: grid;
+        gap: 0.25rem;
+      }
+
+      .highlights .chip {
+        background: rgba(45, 212, 191, 0.14);
+        color: #99f6e4;
+      }
+
+      @media (max-width: 820px) {
         body {
-          padding: 1.25rem;
+          padding: 0.75rem;
         }
 
         .card {
-          grid-template-columns: 1fr;
-          padding: 1.5rem;
-          border-radius: 1rem;
+          height: calc(100vh - 1.5rem);
+          grid-template-rows: auto 1fr auto;
         }
 
-        .card-header {
+        .title-row {
+          flex-direction: column;
+          align-items: flex-start;
           gap: 0.4rem;
         }
+      }
 
-        .actions {
-          width: 100%;
+      @media (max-height: 780px) {
+        body {
+          padding: 0.5rem;
         }
 
-        .actions .button-link {
-          flex: 1 1 45%;
-          min-width: 0;
-          text-align: center;
+        .card {
+          height: calc(100vh - 1rem);
+          transform: scale(0.96);
+          transform-origin: top center;
+        }
+
+        h1 {
+          font-size: clamp(1.35rem, 2vw, 1.75rem);
+        }
+
+        .button-link {
+          padding: 0.55rem 0.9rem;
         }
       }
     </style>
   </head>
   <body>
-    <div class="card">
-      <div class="card-header">
-        <span class="pill">GitHub Pages ready</span>
-        <h1>Redirecting to the SwiftIOC dashboard</h1>
+    <main class="card" id="top">
+      <header class="card-header">
+        <span class="badge">GitHub Pages</span>
+        <div class="title-row">
+          <h1>SwiftIOC is ready to launch</h1>
+          <span class="chip" id="redirect-chip" aria-live="polite">
+            <span id="redirect-label">Redirecting in</span> <strong id="countdown">3</strong>s
+          </span>
+        </div>
         <p>
-          You will land on the GitHub Pages experience that showcases the latest automated threat
-          intelligence collection run. Stay here to choose where to begin if you want to skip the redirect.
+          Skip the scroll and jump straight into the SwiftIOC experience. Open the dashboard, head to diagnostics,
+          or dive into downloads without re-reading the same info.
         </p>
-      </div>
-      <div class="link-grid">
-        <div>
-          <h2>Start with the dashboard</h2>
-          <p>
-            Explore live metrics, a curated preview of per-source highlights, and recommendations tailored for
-            GitHub Pages deployments.
-          </p>
-          <div class="actions">
-            <a class="button-link primary" href="public/">Open dashboard</a>
-            <a class="button-link secondary" href="public/#actions">Skip to downloads</a>
-          </div>
+        <div class="highlights" aria-label="Instant context">
+          <span class="chip">One screen</span>
+          <p class="muted">The launcher locks to your viewport, resizing cards to stay full-screen without vertical scrolling.</p>
         </div>
-        <div>
-          <h2>Shortcuts</h2>
-          <ul class="list">
-            <li><strong>Diagnostics:</strong> Inspect collection health via the <a href="public/diagnostics/summary.html">diagnostics summary</a>.</li>
-            <li><strong>Implementation:</strong> Review how the pipeline works in the <a href="README.md">README guide</a>.</li>
-            <li>
-              <strong>Repository:</strong> Open the project on GitHub to file issues or contribute via the
-              <a href="https://github.com/SecurityRiskAdvisors/SwiftIOC-Automated-Threat-Intelligence-Collector">public repo</a>.
-            </li>
-          </ul>
-          <div class="actions">
-            <a class="button-link secondary" href="https://github.com/SecurityRiskAdvisors/SwiftIOC-Automated-Threat-Intelligence-Collector">View repository</a>
-          </div>
+        <div class="progress-shell" aria-hidden="true">
+          <span class="progress-bar" id="progress-bar"></span>
         </div>
-      </div>
-      <div class="note">
-        <strong>Heads up:</strong> A three-second redirect is active. Use the buttons above if you want to
-        jump directly to the section that matters most.
-      </div>
-      <p class="footnote">
-        SwiftIOC publishes fresh indicators, deduplicates noise, and leaves everything in the open. Bookmark this
-        page to keep tabs on the GitHub Pages build and quickly reach data exports during incidents.
-      </p>
-    </div>
+        <div class="actions">
+          <a class="button-link primary" href="public/">Open dashboard</a>
+          <a class="button-link secondary" href="public/#actions">Skip to downloads</a>
+          <button class="button-link ghost" data-action="cancel-redirect" type="button">Stay here</button>
+        </div>
+      </header>
+
+      <section class="grid" aria-label="Quick actions">
+        <article class="cardlet">
+          <h2>Dashboard</h2>
+          <p class="muted">Live metrics, preview highlights, and curated indicators in one glance.</p>
+          <div class="link-row">
+            <a class="button-link secondary" href="public/">Open</a>
+            <a class="button-link ghost" href="public/#recommendations">Recommendations</a>
+          </div>
+        </article>
+        <article class="cardlet">
+          <h2>Downloads</h2>
+          <p class="muted">Jump directly to exports for rapid investigations or handoffs.</p>
+          <div class="link-row">
+            <a class="button-link secondary" href="public/#actions">Download sets</a>
+            <a class="button-link ghost" href="public/#feeds">Feeds</a>
+          </div>
+        </article>
+        <article class="cardlet">
+          <h2>Diagnostics</h2>
+          <p class="muted">Spot collection health, timing, and source status without digging.</p>
+          <div class="link-row">
+            <a class="button-link secondary" href="public/diagnostics/summary.html">Summary</a>
+            <a class="button-link ghost" href="public/diagnostics/index.html">Full diagnostics</a>
+          </div>
+        </article>
+        <article class="cardlet">
+          <h2>Repository</h2>
+          <p class="muted">File issues, contribute, or read how the pipeline works—quickly.</p>
+          <div class="link-row">
+            <a
+              class="button-link secondary"
+              href="https://github.com/SecurityRiskAdvisors/SwiftIOC-Automated-Threat-Intelligence-Collector"
+              >View repo</a
+            >
+            <a class="button-link ghost" href="README.md">README</a>
+          </div>
+        </article>
+        <article class="cardlet">
+          <h2>Collection highlights</h2>
+          <p class="muted">Fresh runs, deduplicated indicators, and quick exports ready for incident pivots.</p>
+          <div class="link-row">
+            <a class="button-link secondary" href="public/#feeds">Feeds</a>
+            <a class="button-link ghost" href="public/#actions">Exports</a>
+          </div>
+        </article>
+        <article class="cardlet">
+          <h2>Redirect control</h2>
+          <p class="muted">Pause or restart the countdown without losing the full-screen launcher view.</p>
+          <div class="link-row">
+            <button class="button-link secondary" data-action="restart-redirect" type="button">Restart redirect</button>
+            <button class="button-link ghost" data-action="cancel-redirect" type="button">Stay here</button>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <script>
+      const countdownEl = document.getElementById("countdown");
+      const redirectLabel = document.getElementById("redirect-label");
+      const progressBar = document.getElementById("progress-bar");
+      const cancelButtons = document.querySelectorAll("[data-action='cancel-redirect']");
+      const restartButtons = document.querySelectorAll("[data-action='restart-redirect']");
+      const target = "public/";
+
+      let remaining = 3.0;
+      let progressTimer = null;
+
+      const updateCountdown = () => {
+        countdownEl.textContent = Math.max(0, remaining).toFixed(1).replace(/\.0$/, "");
+        const percent = ((3 - remaining) / 3) * 100;
+        progressBar.style.width = `${Math.min(100, Math.max(0, percent))}%`;
+      };
+
+      const startTimers = () => {
+        clearTimers();
+        remaining = 3.0;
+        updateCountdown();
+        progressTimer = setInterval(() => {
+          remaining = Math.max(0, remaining - 0.1);
+          updateCountdown();
+          if (remaining <= 0) {
+            clearTimers();
+            window.location.href = target;
+          }
+        }, 100);
+      };
+
+      const clearTimers = () => {
+        if (progressTimer) clearInterval(progressTimer);
+        progressTimer = null;
+      };
+
+      cancelButtons.forEach((button) =>
+        button.addEventListener("click", () => {
+          clearTimers();
+          redirectLabel.textContent = "Redirect paused";
+          progressBar.style.width = "0%";
+          countdownEl.textContent = "";
+        })
+      );
+
+      restartButtons.forEach((button) =>
+        button.addEventListener("click", () => {
+          redirectLabel.textContent = "Redirecting in";
+          countdownEl.textContent = "3";
+          startTimers();
+        })
+      );
+
+      startTimers();
+    </script>
   </body>
 </html>

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -32,6 +32,7 @@ body {
   background: var(--bg-gradient);
   color: var(--text-color);
   -webkit-font-smoothing: antialiased;
+  overflow: hidden;
 }
 
 body::before {
@@ -60,12 +61,15 @@ body::before {
 }
 
 .page-wrapper {
-  max-width: 1240px;
-  margin: 0 auto;
-  padding: clamp(1.75rem, 3vw, 3.25rem) clamp(1.25rem, 3vw, 2.25rem) 5rem;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(2.25rem, 3vw, 3.5rem);
+  max-width: none;
+  width: 100%;
+  height: 100vh;
+  margin: 0;
+  padding: clamp(1.25rem, 2.5vw, 2.25rem) clamp(1rem, 2vw, 2rem) clamp(1.5rem, 3vw, 2.25rem);
+  display: grid;
+  grid-template-rows: auto auto 1fr auto;
+  gap: clamp(1rem, 1.4vw, 1.75rem);
+  overflow: hidden;
 }
 
 .page-header {
@@ -215,28 +219,47 @@ body::before {
 }
 
 .page-main {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-rows: repeat(5, minmax(0, 1fr));
+  grid-auto-flow: row dense;
+  gap: clamp(1rem, 1.4vw, 1.6rem);
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.page-main > section {
+  scroll-margin-top: 96px;
+  border: 1px solid var(--border-soft);
+  border-radius: 1.25rem;
+  background: var(--surface-color);
+  box-shadow: 0 16px 40px rgba(2, 6, 23, 0.42);
+  padding: clamp(1.1rem, 1.3vw, 1.5rem);
   display: flex;
   flex-direction: column;
-  gap: 3.5rem;
+  gap: 1rem;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .hero {
-  display: flex;
-  gap: 2.5rem;
-  align-items: stretch;
-  flex-wrap: wrap;
+  grid-column: span 2;
+  grid-row: span 2;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: 1.25rem;
+  align-items: start;
 }
 
 .hero-body {
-  flex: 2;
   min-width: 18rem;
   display: flex;
   flex-direction: column;
-  gap: 1.4rem;
+  gap: 1.1rem;
 }
 
 .hero-aside {
-  flex: 1;
   min-width: 16rem;
   display: flex;
   align-items: stretch;
@@ -379,19 +402,13 @@ button.button-link {
 .section {
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
-}
-
-.page-main > section {
-  scroll-margin-top: 110px;
+  gap: 1rem;
 }
 
 .section.section-alt {
-  border: 1px solid var(--border-soft);
-  border-radius: 1.6rem;
-  background: rgba(15, 23, 42, 0.72);
-  box-shadow: 0 24px 55px rgba(2, 6, 23, 0.45);
-  padding: 2.25rem 2rem;
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 1.1rem;
+  padding: 1.1rem 1.25rem 1.25rem;
 }
 
 .section-alt .section-heading {
@@ -407,6 +424,20 @@ button.button-link {
   margin: 0.65rem 0 0;
   color: var(--text-muted);
   max-width: 60ch;
+}
+
+.section-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 0;
+  flex: 1;
+}
+
+.section-scroll {
+  overflow: auto;
+  padding-right: 0.35rem;
+  scrollbar-width: thin;
 }
 
 .metrics-grid {
@@ -1024,7 +1055,17 @@ select:disabled,
   }
 
   .page-wrapper {
-    padding-bottom: 4rem;
+    padding-bottom: 2.5rem;
+  }
+
+  .page-main {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: repeat(7, minmax(0, 1fr));
+  }
+
+  .hero {
+    grid-column: span 2;
+    grid-row: span 2;
   }
 }
 
@@ -1033,12 +1074,9 @@ select:disabled,
     position: static;
   }
 
-  .hero {
-    flex-direction: column;
-  }
-
-  .hero-aside {
-    width: 100%;
+  .page-main {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: repeat(7, minmax(0, 1fr));
   }
 
   .preview-table {
@@ -1055,6 +1093,21 @@ select:disabled,
 }
 
 @media (max-width: 720px) {
+  body {
+    overflow: auto;
+  }
+
+  .page-wrapper {
+    height: auto;
+    min-height: 100vh;
+    grid-template-rows: auto auto auto auto;
+  }
+
+  .page-main {
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(auto-fit, minmax(260px, auto));
+  }
+
   .top-nav {
     flex-direction: column;
     align-items: flex-start;

--- a/public/index.html
+++ b/public/index.html
@@ -118,27 +118,29 @@
             <h2>Operational highlights</h2>
             <p>Key metrics that summarise the current indicator landscape across all enabled feeds.</p>
           </div>
-          <div class="metrics-grid">
-            <article class="metric-card">
-              <h3>Total indicators</h3>
-              <p class="metric-value" data-stat="total-indicators">—</p>
-              <p class="metric-detail">Unique IOCs collected during the latest cycle.</p>
-            </article>
-            <article class="metric-card">
-              <h3>Sources reporting</h3>
-              <p class="metric-value" data-stat="active-sources">—</p>
-              <p class="metric-detail">Active intelligence feeds that produced data this run.</p>
-            </article>
-            <article class="metric-card">
-              <h3>Indicator types</h3>
-              <p class="metric-value" data-stat="indicator-types">—</p>
-              <p class="metric-detail">Distinct IOC formats discovered across the feeds.</p>
-            </article>
-            <article class="metric-card">
-              <h3>Duplicates removed</h3>
-              <p class="metric-value" data-stat="duplicates-removed">—</p>
-              <p class="metric-detail">Indicators deduplicated to maintain a clean dataset.</p>
-            </article>
+          <div class="section-content section-scroll">
+            <div class="metrics-grid">
+              <article class="metric-card">
+                <h3>Total indicators</h3>
+                <p class="metric-value" data-stat="total-indicators">—</p>
+                <p class="metric-detail">Unique IOCs collected during the latest cycle.</p>
+              </article>
+              <article class="metric-card">
+                <h3>Sources reporting</h3>
+                <p class="metric-value" data-stat="active-sources">—</p>
+                <p class="metric-detail">Active intelligence feeds that produced data this run.</p>
+              </article>
+              <article class="metric-card">
+                <h3>Indicator types</h3>
+                <p class="metric-value" data-stat="indicator-types">—</p>
+                <p class="metric-detail">Distinct IOC formats discovered across the feeds.</p>
+              </article>
+              <article class="metric-card">
+                <h3>Duplicates removed</h3>
+                <p class="metric-value" data-stat="duplicates-removed">—</p>
+                <p class="metric-detail">Indicators deduplicated to maintain a clean dataset.</p>
+              </article>
+            </div>
           </div>
         </section>
 
@@ -147,28 +149,30 @@
             <h2>Collection timeline</h2>
             <p>Understand recency and overlap across sources to plan enrichment and response.</p>
           </div>
-          <div class="metrics-grid timeline-grid">
-            <article class="metric-card">
-              <h3>Earliest first seen</h3>
-              <p class="metric-value">
-                <span data-stat="earliest-first-seen-date">—</span>
-                <span class="metric-subvalue" data-stat="earliest-first-seen-time">—</span>
-              </p>
-              <p class="metric-detail">Oldest IOC sighting retained in the active window.</p>
-            </article>
-            <article class="metric-card">
-              <h3>Newest first seen</h3>
-              <p class="metric-value">
-                <span data-stat="newest-first-seen-date">—</span>
-                <span class="metric-subvalue" data-stat="newest-first-seen-time">—</span>
-              </p>
-              <p class="metric-detail">Most recent IOC discovery across all sources.</p>
-            </article>
-            <article class="metric-card">
-              <h3>Multi-source overlaps</h3>
-              <p class="metric-value" data-stat="multi-source-overlaps">—</p>
-              <p class="metric-detail">Indicators independently confirmed by more than one feed.</p>
-            </article>
+          <div class="section-content section-scroll">
+            <div class="metrics-grid timeline-grid">
+              <article class="metric-card">
+                <h3>Earliest first seen</h3>
+                <p class="metric-value">
+                  <span data-stat="earliest-first-seen-date">—</span>
+                  <span class="metric-subvalue" data-stat="earliest-first-seen-time">—</span>
+                </p>
+                <p class="metric-detail">Oldest IOC sighting retained in the active window.</p>
+              </article>
+              <article class="metric-card">
+                <h3>Newest first seen</h3>
+                <p class="metric-value">
+                  <span data-stat="newest-first-seen-date">—</span>
+                  <span class="metric-subvalue" data-stat="newest-first-seen-time">—</span>
+                </p>
+                <p class="metric-detail">Most recent IOC discovery across all sources.</p>
+              </article>
+              <article class="metric-card">
+                <h3>Multi-source overlaps</h3>
+                <p class="metric-value" data-stat="multi-source-overlaps">—</p>
+                <p class="metric-detail">Indicators independently confirmed by more than one feed.</p>
+              </article>
+            </div>
           </div>
         </section>
 
@@ -180,53 +184,55 @@
               and measurable inside their existing tooling.
             </p>
           </div>
-          <ol class="step-list">
-            <li class="step-card">
-              <div class="step-badge" aria-hidden="true">1</div>
-              <div class="step-content">
-                <h3>Validate freshness and scope</h3>
-                <p>
-                  Start each review by confirming the collection window and overlaps so downstream teams
-                  know exactly how recent and comprehensive the data is.
-                </p>
-                <ul class="step-actions">
-                  <li>Compare <a href="#timeline">timeline</a> metrics with your detection coverage SLAs.</li>
-                  <li>Alert stakeholders if the multi-source overlap count drops unexpectedly.</li>
-                  <li>Bookmark the diagnostics summary for quick health checks during incidents.</li>
-                </ul>
-              </div>
-            </li>
-            <li class="step-card">
-              <div class="step-badge" aria-hidden="true">2</div>
-              <div class="step-content">
-                <h3>Promote the right exports</h3>
-                <p>
-                  Select the format that best aligns with your automation stack and make it part of a
-                  scheduled sync so analysts always see the latest indicators.
-                </p>
-                <ul class="step-actions">
-                  <li>Use the JSON feed for orchestration platforms and enrichment microservices.</li>
-                  <li>Stream the JSONL file into data lakes to preserve historical context.</li>
-                  <li>Create a GitHub Action that publishes CSV/TSV artifacts for SIEM uploads.</li>
-                </ul>
-              </div>
-            </li>
-            <li class="step-card">
-              <div class="step-badge" aria-hidden="true">3</div>
-              <div class="step-content">
-                <h3>Close the loop with feedback</h3>
-                <p>
-                  Track which sources and indicator types deliver the most value so you can iterate on the
-                  playbook and retire noisy feeds.
-                </p>
-                <ul class="step-actions">
-                  <li>Map <a href="#sources">source totals</a> to your internal asset or client groups.</li>
-                  <li>Collect analyst feedback directly inside pull requests for new source onboarding.</li>
-                  <li>Document high-confidence tags and share them with your threat hunting community.</li>
-                </ul>
-              </div>
-            </li>
-          </ol>
+          <div class="section-content section-scroll">
+            <ol class="step-list">
+              <li class="step-card">
+                <div class="step-badge" aria-hidden="true">1</div>
+                <div class="step-content">
+                  <h3>Validate freshness and scope</h3>
+                  <p>
+                    Start each review by confirming the collection window and overlaps so downstream teams
+                    know exactly how recent and comprehensive the data is.
+                  </p>
+                  <ul class="step-actions">
+                    <li>Compare <a href="#timeline">timeline</a> metrics with your detection coverage SLAs.</li>
+                    <li>Alert stakeholders if the multi-source overlap count drops unexpectedly.</li>
+                    <li>Bookmark the diagnostics summary for quick health checks during incidents.</li>
+                  </ul>
+                </div>
+              </li>
+              <li class="step-card">
+                <div class="step-badge" aria-hidden="true">2</div>
+                <div class="step-content">
+                  <h3>Promote the right exports</h3>
+                  <p>
+                    Select the format that best aligns with your automation stack and make it part of a
+                    scheduled sync so analysts always see the latest indicators.
+                  </p>
+                  <ul class="step-actions">
+                    <li>Use the JSON feed for orchestration platforms and enrichment microservices.</li>
+                    <li>Stream the JSONL file into data lakes to preserve historical context.</li>
+                    <li>Create a GitHub Action that publishes CSV/TSV artifacts for SIEM uploads.</li>
+                  </ul>
+                </div>
+              </li>
+              <li class="step-card">
+                <div class="step-badge" aria-hidden="true">3</div>
+                <div class="step-content">
+                  <h3>Close the loop with feedback</h3>
+                  <p>
+                    Track which sources and indicator types deliver the most value so you can iterate on the
+                    playbook and retire noisy feeds.
+                  </p>
+                  <ul class="step-actions">
+                    <li>Map <a href="#sources">source totals</a> to your internal asset or client groups.</li>
+                    <li>Collect analyst feedback directly inside pull requests for new source onboarding.</li>
+                    <li>Document high-confidence tags and share them with your threat hunting community.</li>
+                  </ul>
+                </div>
+              </li>
+            </ol>
+          </div>
         </section>
 
         <section id="sources" class="section">
@@ -234,20 +240,22 @@
             <h2>Per-source totals</h2>
             <p>See which feeds are contributing the most intelligence at a glance.</p>
           </div>
-          <div class="table-card">
-            <table>
-              <thead>
-                <tr>
-                  <th scope="col">Source</th>
-                  <th scope="col" class="numeric">Indicators</th>
-                </tr>
-              </thead>
-              <tbody data-table="sources">
-                <tr>
-                  <td data-title="Source" colspan="2">Loading sources…</td>
-                </tr>
-              </tbody>
-            </table>
+          <div class="section-content section-scroll">
+            <div class="table-card">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Source</th>
+                    <th scope="col" class="numeric">Indicators</th>
+                  </tr>
+                </thead>
+                <tbody data-table="sources">
+                  <tr>
+                    <td data-title="Source" colspan="2">Loading sources…</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
         </section>
 
@@ -256,20 +264,22 @@
             <h2>Indicator types</h2>
             <p>Breakdown of IOC formats to support filtering and response planning.</p>
           </div>
-          <div class="table-card">
-            <table>
-              <thead>
-                <tr>
-                  <th scope="col">Type</th>
-                  <th scope="col" class="numeric">Indicators</th>
-                </tr>
-              </thead>
-              <tbody data-table="types">
-                <tr>
-                  <td data-title="Type" colspan="2">Loading indicator types…</td>
-                </tr>
-              </tbody>
-            </table>
+          <div class="section-content section-scroll">
+            <div class="table-card">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Type</th>
+                    <th scope="col" class="numeric">Indicators</th>
+                  </tr>
+                </thead>
+                <tbody data-table="types">
+                  <tr>
+                    <td data-title="Type" colspan="2">Loading indicator types…</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
         </section>
 
@@ -278,20 +288,22 @@
             <h2>Top tags</h2>
             <p>Most prevalent threat tags assigned to indicators in the latest sweep.</p>
           </div>
-          <div class="table-card">
-            <table>
-              <thead>
-                <tr>
-                  <th scope="col">Tag</th>
-                  <th scope="col" class="numeric">Indicators</th>
-                </tr>
-              </thead>
-              <tbody data-table="tags">
-                <tr>
-                  <td data-title="Tag" colspan="2">Loading tags…</td>
-                </tr>
-              </tbody>
-            </table>
+          <div class="section-content section-scroll">
+            <div class="table-card">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Tag</th>
+                    <th scope="col" class="numeric">Indicators</th>
+                  </tr>
+                </thead>
+                <tbody data-table="tags">
+                  <tr>
+                    <td data-title="Tag" colspan="2">Loading tags…</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
         </section>
 
@@ -300,6 +312,7 @@
             <h2>Live source preview</h2>
             <p>Review the strongest, highest-confidence signal from each reporting source before downloading.</p>
           </div>
+          <div class="section-content section-scroll">
           <div
             class="preview-panel"
             data-preview-container
@@ -402,6 +415,7 @@
               when you need complete coverage.
             </p>
           </div>
+          </div>
         </section>
 
         <section id="actions" class="section">
@@ -409,7 +423,8 @@
             <h2>Data actions</h2>
             <p>Choose the format that best fits your workflow before exporting the latest dataset.</p>
           </div>
-          <div class="actions-grid">
+          <div class="section-content section-scroll">
+            <div class="actions-grid">
             <article class="action-card">
               <div>
                 <h3>Download CSV</h3>
@@ -483,6 +498,7 @@
                 <a class="button-link secondary" href="iocs/">Open directory</a>
               </div>
             </article>
+            </div>
           </div>
         </section>
 
@@ -494,7 +510,8 @@
               improvements tailored for GitHub Pages hosting.
             </p>
           </div>
-          <div class="recommendations-grid">
+          <div class="section-content section-scroll">
+            <div class="recommendations-grid">
             <article class="recommendation-card">
               <h3>Automate publishing</h3>
               <p>
@@ -539,6 +556,7 @@
                 <li>Mirror the sitemap generation inside the SwiftIOC pipeline for zero-maintenance updates.</li>
               </ul>
             </article>
+            </div>
           </div>
         </section>
 
@@ -547,7 +565,8 @@
             <h2>Frequently asked questions</h2>
             <p>Share these quick answers with stakeholders rolling out the GitHub Pages dashboard.</p>
           </div>
-          <div class="faq-group">
+          <div class="section-content section-scroll">
+            <div class="faq-group">
             <details>
               <summary>How often should the dashboard refresh?</summary>
               <p>
@@ -571,6 +590,7 @@
                 helps triage whether the problem stems from data quality or hosting.
               </p>
             </details>
+            </div>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- lock the dashboard shell to a full-viewport grid so cards fill a fixed matrix without page scrolling
- increase grid capacity to keep every section visible at once with internal scroll areas for dense content
- add responsive fallbacks that relax the viewport lock on small screens to preserve usability

## Testing
- not run (static content)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e31788af48327a6b32b4b890e9a21)