### PR TITLE
Fix IOC data path resolution for GitHub Pages

### DIFF
--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -5,7 +5,10 @@
    *  CONFIG & CONSTANTS
    * ========================================================================= */
 
-  const IOC_ROOT = document.body?.dataset.iocRoot || '.';
+  const resolveIocUrl = (path) => {
+    const base = document.body?.dataset.iocRoot || './';
+    return new URL(path, new URL(base, window.location.href)).toString();
+  };
 
   const DEFAULT_PREVIEW_LIMIT = 12;
   const PREVIEW_LOOKAHEAD_MULTIPLIER = 12;
@@ -14,8 +17,8 @@
     240
   );
 
-  const INDICATORS_JSONL_URL = `${IOC_ROOT}/iocs/latest.jsonl`;
-  const INDICATORS_JSON_FALLBACK_URL = `${IOC_ROOT}/iocs/latest.json`;
+  const INDICATORS_JSONL_URL = resolveIocUrl('iocs/latest.jsonl');
+  const INDICATORS_JSON_FALLBACK_URL = resolveIocUrl('iocs/latest.json');
   const PREVIEW_STREAM_URL = INDICATORS_JSONL_URL;
 
   const DATASET_STORAGE_KEY = 'swiftioc-dashboard-cache-v1';


### PR DESCRIPTION
## Summary
- add robust IOC URL resolver so GitHub Pages uses the correct dataset paths
- point JSON/JSONL fetches to the resolved URLs for consistent data loading

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ec2d57fc8327a3f7e2880e92a346)