### PR TITLE
Fix dashboard tables using dataset aggregates

### DIFF
--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -1040,28 +1040,24 @@
       );
     }
 
-    if (stats.sourcesTable) {
-      populateTable(
-        'sources',
-        stats.sourcesTable,
-        'No active sources in this run.'
-      );
+    const sourceRows = stats.sourcesTable || dataset?.sourcesTable || [];
+    const typeRows = stats.typesTable || dataset?.typesTable || [];
+    const tagRows = stats.tagsTable || dataset?.tagsTable || [];
+
+    if (sourceRows.length) {
+      populateTable('sources', sourceRows, 'No active sources in this run.');
     }
 
-    if (stats.typesTable) {
+    if (typeRows.length) {
       populateTable(
         'types',
-        stats.typesTable,
+        typeRows,
         'No indicator types could be derived.'
       );
     }
 
-    if (stats.tagsTable) {
-      populateTable(
-        'tags',
-        stats.tagsTable,
-        'No tags were present across indicators.'
-      );
+    if (tagRows.length) {
+      populateTable('tags', tagRows, 'No tags were present across indicators.');
     }
   };
 


### PR DESCRIPTION
## Summary
- ensure dashboard tables fallback to dataset aggregates when stats object lacks table data
- avoid empty source/type/tag tables on the GitHub Pages dashboard

## Testing
- python - <<'PY'
import json
from collections import Counter
from itertools import islice

counts = Counter()
with open('public/iocs/latest.jsonl', 'r', encoding='utf-8') as f:
    for line in f:
        if not line.strip():
            continue
        obj = json.loads(line)
        src = obj.get('source') or 'unknown'
        counts[src] += 1

for label, count in islice(counts.most_common(3), 3):
    print(label, count)

print('total sources', len(counts))
PY


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922516870d08327a60b32bd6742b4e4)