### PR TITLE
Improve live preview table usability

### DIFF
--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -1529,7 +1529,8 @@
         }, 1600);
       });
 
-      indicatorWrapper.appendChild(copyButton);
+      indicatorCopy.appendChild(copyButton);
+      indicatorWrapper.appendChild(indicatorCopy);
       indicatorCell.appendChild(indicatorWrapper);
       tr.appendChild(indicatorCell);
 
@@ -1863,7 +1864,7 @@
         const value = parseInt(limitSelect.value, 10);
         if (!Number.isNaN(value) && value > 0) {
           state.limit = value;
-          applyFilter();
+          loadPreview({ silent: true });
         }
       });
     }

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -666,6 +666,41 @@ code {
   gap: 0.45rem;
 }
 
+/* Keep the live preview table tidy on wide screens */
+.preview-table {
+  table-layout: auto;
+}
+
+.preview-table th:nth-child(2),
+.preview-table th:nth-child(3),
+.preview-table th:nth-child(4),
+.preview-table th:nth-child(5),
+.preview-table td:nth-child(2),
+.preview-table td:nth-child(3),
+.preview-table td:nth-child(4),
+.preview-table td:nth-child(5) {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.preview-table td:nth-child(2),
+.preview-table td:nth-child(3),
+.preview-table th:nth-child(2),
+.preview-table th:nth-child(3) {
+  max-width: 10.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preview-indicator {
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.preview-indicator-copy {
+  flex-shrink: 0;
+}
+
 /* Scrollbar polish for the heavy IOC views */
 .preview-table-wrapper,
 .table-card {


### PR DESCRIPTION
## Summary
- reload the live preview when row-limit selections change so more indicators are shown
- tidy copy button layout within the indicator cell
- constrain preview table columns to prevent wrapping and overflowing on GitHub preview

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69225b64094c832795d360cb32f2534e)