### PR TITLE
Include full CISA KEV catalog regardless of window

### DIFF
--- a/swiftioc.py
+++ b/swiftioc.py
@@ -312,7 +312,7 @@ def fetch_cisa_kev(url: str, ref_url: str, source: str, ws: datetime) -> List[In
     for it in data.get("vulnerabilities", []) or []:
         cve = it.get("cveID")
         pub = parse_dt(it.get("dateAdded"))
-        if not cve or (pub and pub < ws):
+        if not cve:
             continue
         out.append(
             Indicator(


### PR DESCRIPTION
## Summary
- remove the date window filter from the CISA KEV parser so indicators are always returned

## Testing
- python swiftioc.py --sources sources.example.yml --out-dir /tmp/out --max-per-source 3 --window-hours 48 --skip-rss --save-raw-dir /tmp/swiftioc_raw --verbose

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69226c4b41ec8327b0a5395a568d42c5)