### PR TITLE
Document GitHub Pages dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ ready-to-use examples for rapid deployment in modern DevSecOps workflows.
 - [CLI reference](#-cli-reference)
 - [Outputs & diagnostics](#-outputs--diagnostics)
 - [Running in GitHub Actions](#-running-in-github-actions)
+- [GitHub Pages preview & publishing](#-github-pages-preview--publishing)
 - [Auto-generated IOC summary](#auto-generated-ioc-summary)
 
 ## 🔍 SwiftIOC at a glance
@@ -238,7 +239,33 @@ public/
 
 The diagnostics include per-source counts, duplicate statistics, earliest and
 latest timestamps, and any recorded failures. These summaries are useful for CI
-status checks and dashboards. 
+status checks and dashboards.
+
+## 🌍 GitHub Pages preview & publishing
+SwiftIOC ships with a Pages-ready dashboard so the collected indicators can be
+browsed without additional tooling. The project uses `public/` as both the
+artifact directory and the published site root:
+
+- `public/index.html` renders the live preview, source breakdowns, tag counts,
+  and export links using the JSON/JSONL outputs produced by `swiftioc.py`.
+- `index.html` at the repository root provides a branded landing page that
+  redirects to `public/` after a short delay while offering quick links for
+  manual navigation.
+
+To publish on GitHub Pages:
+
+1. Run the collector locally or in CI to populate `public/` (see
+   [Quick start](#-quick-start)).
+2. Commit the generated artifacts or upload them as a workflow artifact (as
+   shown in [Running in GitHub Actions](#-running-in-github-actions)).
+3. Enable GitHub Pages with the **GitHub Actions** source so deployments pick up
+   the latest `public/` output automatically.
+
+The dashboard prioritises freshness by sorting preview rows by newest timestamp
+first, then confidence, ensuring visitors see the latest IOCs at the top of the
+feed. Mobile breakpoints convert the preview table into card-style rows for a
+phone-friendly experience, and all metadata is defanged to stay safe for casual
+browsing.
 
 ## ⚙️ Running in GitHub Actions
 SwiftIOC runs cleanly inside GitHub Actions and emits artifacts that can be

--- a/public/index.html
+++ b/public/index.html
@@ -112,6 +112,7 @@
         width: 100%;
         border-collapse: collapse;
         font-size: 0.72rem;
+        transition: background 0.15s ease;
       }
 
       .preview-table th,
@@ -265,6 +266,91 @@
 
         .summary-tables .table-card {
           max-height: none;
+        }
+      }
+
+      @media (max-width: 760px) {
+        .dashboard-main {
+          gap: 0.75rem;
+        }
+
+        .preview-summary {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: 0.4rem;
+        }
+
+        .preview-summary-meta {
+          display: grid;
+          width: 100%;
+          gap: 0.35rem;
+        }
+
+        .preview-table-wrapper {
+          max-height: none;
+        }
+
+        .preview-table {
+          display: block;
+        }
+
+        .preview-table thead {
+          display: none;
+        }
+
+        .preview-table tbody {
+          display: grid;
+          gap: 0.65rem;
+        }
+
+        .preview-table tr {
+          display: grid;
+          gap: 0.4rem;
+          padding: 0.65rem 0.7rem;
+          border-radius: 0.9rem;
+          border: 1px solid var(--border-soft);
+          box-shadow: 0 14px 30px rgba(15, 23, 42, 0.65);
+          background: rgba(15, 23, 42, 0.98);
+        }
+
+        .preview-table tr:nth-child(2n) td,
+        .preview-table tr:hover td {
+          background: transparent;
+        }
+
+        .preview-indicator {
+          align-items: flex-start;
+          gap: 0.55rem;
+        }
+
+        .preview-indicator-main code {
+          white-space: normal;
+          word-break: break-word;
+        }
+
+        .preview-indicator-copy button {
+          width: 100%;
+          justify-content: center;
+        }
+
+        .preview-table td {
+          display: grid;
+          grid-template-columns: minmax(5rem, 6rem) minmax(0, 1fr);
+          align-items: baseline;
+          gap: 0.35rem;
+          padding: 0;
+          border: none;
+        }
+
+        .preview-table td[data-title]::before {
+          display: block;
+          font-weight: 600;
+          color: var(--text-soft);
+          letter-spacing: 0.01em;
+        }
+
+        td.numeric {
+          text-align: left;
         }
       }
 


### PR DESCRIPTION
## Summary
- add GitHub Pages publishing guidance and explain how the public dashboard is served
- highlight freshness ordering and mobile-friendly preview behavior in the documentation
- update the table of contents to include the new Pages section

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923083bb5f8832789b706ace4a4f2f0)