### PR TITLE
Surface scores & corroboration on the Pages dashboard, fix broken ThreatFox parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,11 +339,14 @@ To publish on GitHub Pages:
 3. Enable GitHub Pages with the **GitHub Actions** source so deployments pick up
    the latest `public/` output automatically.
 
-The dashboard prioritises freshness by sorting preview rows by newest timestamp
-first, then confidence, ensuring visitors see the latest IOCs at the top of the
-feed. Mobile breakpoints convert the preview table into card-style rows for a
-phone-friendly experience, and all metadata is defanged to stay safe for casual
-browsing.
+The dashboard ranks preview rows by the collector's 0–100 relevance score
+(corroboration + freshness baked in), then by how many independent sources
+confirm each indicator, so the most dangerous and most corroborated IOCs sit at
+the top of the feed. A "Show" filter isolates high-score (≥80), corroborated
+(2+ sources), or new (last 48h) indicators, and multi-source rows carry a
+`×N confirmed` badge. Mobile breakpoints convert the preview table into
+card-style rows for a phone-friendly experience, and all metadata is defanged
+to stay safe for casual browsing.
 
 ## ⚙️ Running in GitHub Actions
 SwiftIOC runs cleanly inside GitHub Actions and emits artifacts that can be

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -107,6 +107,15 @@
   const clamp = (value, min, max) =>
     Math.min(max, Math.max(min, value));
 
+  // Compact label for a possibly multi-source row: "feodo +2".
+  const primarySourceLabel = (row) => {
+    if (!row) return 'unknown';
+    const list = Array.isArray(row.sourceList) ? row.sourceList : [];
+    if (!list.length) return row.source || 'unknown';
+    if (list.length === 1) return list[0];
+    return `${list[0]} +${list.length - 1}`;
+  };
+
   const parseTimestamp = (value) => {
     if (value == null) return null;
 
@@ -323,6 +332,10 @@
   const createStatsAccumulator = () => {
     let total = 0;
     let duplicatesRemoved = 0;
+    let corroborated = 0;
+    let highScore = 0;
+    let scoreSum = 0;
+    let scoredCount = 0;
     const sources = new Set();
     const types = new Set();
     const tags = new Map();
@@ -365,8 +378,24 @@
       const type = normaliseString(row.type);
       const indicator = normaliseString(row.indicator);
 
-      if (source) {
-        sources.add(source);
+      // Multi-source rows carry comma-separated feeds; count each feed as a
+      // distinct source instead of treating "feodo,threatfox" as one.
+      const sourceParts = Array.isArray(row.sourceList)
+        ? row.sourceList
+        : uniqueStrings(source.split(','));
+      sourceParts.forEach((part) => {
+        const key = normaliseLower(part);
+        if (key) sources.add(key);
+      });
+
+      if (sourceParts.length >= 2) {
+        corroborated += 1;
+      }
+
+      if (typeof row.score === 'number') {
+        scoreSum += row.score;
+        scoredCount += 1;
+        if (row.score >= 80) highScore += 1;
       }
 
       if (type) {
@@ -433,6 +462,10 @@
       return {
         total,
         duplicatesRemoved,
+        corroborated,
+        highScore,
+        avgScore: scoredCount > 0 ? Math.round(scoreSum / scoredCount) : null,
+        hasScores: scoredCount > 0,
         activeSources: sources.size,
         indicatorTypes: types.size,
         tags,
@@ -465,9 +498,13 @@
       const source = normaliseString(row.source);
       const type = normaliseString(row.type);
 
-      if (source) {
-        bySource.set(source, (bySource.get(source) || 0) + 1);
-      }
+      // Credit each feed in a comma-separated multi-source value.
+      const sourceParts = Array.isArray(row.sourceList)
+        ? row.sourceList
+        : uniqueStrings(source.split(','));
+      sourceParts.forEach((part) => {
+        bySource.set(part, (bySource.get(part) || 0) + 1);
+      });
 
       if (type) {
         byType.set(type, (byType.get(type) || 0) + 1);
@@ -770,9 +807,28 @@
       row.confidence_score,
       row.confidenceScore,
       row.confidence_level,
-      row.confidenceLevel,
-      row.score
+      row.confidenceLevel
     );
+
+    // Numeric 0-100 relevance score emitted by the collector (confidence base
+    // + cross-source corroboration bonus, decayed by age). First-class: this
+    // is the primary ranking signal when present.
+    const parseScore = (value) => {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return clamp(Math.round(value), 0, 100);
+      }
+      const numeric = Number(normaliseString(value));
+      if (Number.isFinite(numeric) && numeric > 0) {
+        return clamp(Math.round(numeric), 0, 100);
+      }
+      return null;
+    };
+    const score = parseScore(row.score);
+
+    // The source field accumulates comma-separated feeds as the living feed
+    // merges runs; each independent feed corroborates the indicator.
+    const sourceList = uniqueStrings((sourceRaw || '').split(','));
+    const sourceCount = sourceList.length;
 
     const tagValues = [
       ...extractTags(row.tags),
@@ -816,8 +872,14 @@
       indicator,
       type: typeRaw || 'unknown',
       source: sourceRaw || 'unknown',
+      sourceList,
+      sourceCount,
+      score,
       confidence,
-      confidenceRank: confidenceRankForValue(confidence),
+      confidenceRank:
+        score != null
+          ? confidenceRankForValue(score)
+          : confidenceRankForValue(confidence),
       tags,
       tagsLower,
       firstSeen,
@@ -889,6 +951,16 @@
     });
 
     const compareRows = (a, b) => {
+      // Primary signal: the collector's 0-100 score (confidence +
+      // cross-source corroboration, decayed by age). Falls back to the
+      // coarse confidence rank for feeds without scores.
+      const scoreA = typeof a.score === 'number' ? a.score : -1;
+      const scoreB = typeof b.score === 'number' ? b.score : -1;
+      if (scoreA !== scoreB) return scoreB - scoreA;
+
+      const corroborationDiff = (b.sourceCount || 0) - (a.sourceCount || 0);
+      if (corroborationDiff !== 0) return corroborationDiff;
+
       const confidenceDiff = confidenceRankForRow(b) - confidenceRankForRow(a);
       if (confidenceDiff !== 0) return confidenceDiff;
 
@@ -1347,6 +1419,7 @@
 
     const filterSelect = qs('[data-preview-filter]', container);
     const tagFilterSelect = qs('[data-preview-tag-filter]', container);
+    const highlightSelect = qs('[data-preview-highlight]', container);
     const limitSelect = qs('[data-preview-limit]', container);
     const searchInput = qs('[data-preview-search]', container);
     const refreshButton = qs('[data-preview-refresh]', container);
@@ -1357,6 +1430,10 @@
     const summaryHighEl = qs('[data-preview-high]', container);
     const summaryHighPercentEl = qs(
       '[data-preview-high-percent]',
+      container
+    );
+    const summaryCorroboratedEl = qs(
+      '[data-preview-corroborated]',
       container
     );
     const summaryTopTagEl = qs('[data-preview-top-tag]', container);
@@ -1375,6 +1452,7 @@
       rows: [],
       filter: 'all',
       tagFilter: 'all',
+      highlight: 'all',
       search: '',
       limit: DEFAULT_PREVIEW_LIMIT,
       origin: 'network',
@@ -1510,6 +1588,13 @@
       if (summaryHighEl)
         summaryHighEl.textContent = formatNumber(highCount);
 
+      if (summaryCorroboratedEl) {
+        const corroboratedCount = visibleRows.filter(
+          (row) => (row.sourceCount || 0) >= 2
+        ).length;
+        summaryCorroboratedEl.textContent = formatNumber(corroboratedCount);
+      }
+
       if (summaryHighPercentEl) {
         const percent =
           totalRows > 0 ? ((highCount / totalRows) * 100).toFixed(1) : '0.0';
@@ -1593,9 +1678,21 @@
       };
 
       indicatorMeta.appendChild(makeMetaPill('type', row.type || 'unknown'));
-      indicatorMeta.appendChild(makeMetaPill('source', row.source || 'unknown'));
       indicatorMeta.appendChild(
-        makeMetaPill('confidence', row.confidence || 'n/a')
+        makeMetaPill('source', primarySourceLabel(row))
+      );
+      if ((row.sourceCount || 0) >= 2) {
+        indicatorMeta.appendChild(
+          makeMetaPill('corroborated', `${row.sourceCount}× confirmed`)
+        );
+      }
+      indicatorMeta.appendChild(
+        makeMetaPill(
+          'confidence',
+          typeof row.score === 'number'
+            ? `score ${row.score}`
+            : row.confidence || 'n/a'
+        )
       );
 
       indicatorMain.appendChild(indicatorMeta);
@@ -1681,18 +1778,47 @@
       };
 
       tr.appendChild(makeCell('Type', row.type));
-      tr.appendChild(makeCell('Source', row.source));
+
+      const sourceCell = makeCell('Sources', primarySourceLabel(row));
+      if ((row.sourceCount || 0) >= 2 && Array.isArray(row.sourceList)) {
+        sourceCell.title = row.sourceList.join(', ');
+      }
+      tr.appendChild(sourceCell);
+
       tr.appendChild(
         makeCell('First seen', row.firstSeenDisplay ?? row.firstSeen)
       );
 
-      const confidenceClass = confidenceClassFor(row.confidence);
-      const confidenceLabel = row.confidence || '—';
-      tr.appendChild(
-        makeCell('Confidence', confidenceLabel, confidenceClass)
-      );
+      // Score column: the collector's 0-100 relevance score when present,
+      // otherwise the legacy confidence label.
+      const scoreValue =
+        typeof row.score === 'number' ? String(row.score) : row.confidence || '—';
+      const scoreClass =
+        typeof row.score === 'number'
+          ? confidenceClassFor(row.score)
+          : confidenceClassFor(row.confidence);
+      tr.appendChild(makeCell('Score', scoreValue, scoreClass));
 
       return tr;
+    };
+
+    const FRESH_WINDOW_SECONDS = 48 * 3600;
+
+    const matchesHighlight = (row, highlight) => {
+      if (highlight === 'all') return true;
+      if (highlight === 'high') {
+        if (typeof row.score === 'number') return row.score >= 80;
+        return confidenceRankForRow(row) >= 3;
+      }
+      if (highlight === 'corroborated') {
+        return (row.sourceCount || 0) >= 2;
+      }
+      if (highlight === 'new') {
+        const firstSeen = parseTimestamp(row.firstSeen);
+        if (!firstSeen) return false;
+        return Date.now() / 1000 - firstSeen.time <= FRESH_WINDOW_SECONDS;
+      }
+      return true;
     };
 
     const filterRows = () => {
@@ -1701,6 +1827,10 @@
       const searchTerm = state.search.toLowerCase().trim();
 
       return state.rows.filter((row) => {
+        if (!matchesHighlight(row, state.highlight)) {
+          return false;
+        }
+
         if (filter !== 'all' && row.type.toLowerCase() !== filter) {
           return false;
         }
@@ -1956,6 +2086,10 @@
             tagFilterSelect.options.length <= 1;
         }
 
+        if (highlightSelect) {
+          highlightSelect.disabled = state.rows.length === 0;
+        }
+
         if (searchInput) {
           searchInput.disabled = state.rows.length === 0;
           if (!searchInput.disabled) {
@@ -1976,6 +2110,7 @@
     const toggleControls = (disabled) => {
       if (filterSelect) filterSelect.disabled = disabled;
       if (tagFilterSelect) tagFilterSelect.disabled = disabled;
+      if (highlightSelect) highlightSelect.disabled = disabled;
       if (searchInput) searchInput.disabled = disabled;
       if (limitSelect) limitSelect.disabled = disabled;
       if (refreshButton) refreshButton.disabled = disabled;
@@ -1993,6 +2128,13 @@
     if (tagFilterSelect) {
       tagFilterSelect.addEventListener('change', () => {
         state.tagFilter = tagFilterSelect.value;
+        applyFilter();
+      });
+    }
+
+    if (highlightSelect) {
+      highlightSelect.addEventListener('change', () => {
+        state.highlight = highlightSelect.value;
         applyFilter();
       });
     }

--- a/public/index.html
+++ b/public/index.html
@@ -196,6 +196,13 @@
         color: #fef9c3;
       }
 
+      .preview-meta-pill.meta-corroborated {
+        background: rgba(239, 68, 68, 0.14);
+        border-color: rgba(239, 68, 68, 0.4);
+        color: #fecaca;
+        font-weight: 600;
+      }
+
       .preview-indicator-tags {
         display: inline-flex;
         flex-wrap: wrap;
@@ -662,6 +669,20 @@
                   </select>
                 </label>
 
+                <label class="toolbar-group" for="preview-highlight">
+                  <span>Show</span>
+                  <select
+                    id="preview-highlight"
+                    data-preview-highlight
+                    disabled
+                  >
+                    <option value="all">Everything</option>
+                    <option value="high">High score (≥80)</option>
+                    <option value="corroborated">Corroborated (2+ sources)</option>
+                    <option value="new">New (last 48h)</option>
+                  </select>
+                </label>
+
                 <label class="toolbar-group" for="preview-limit">
                   <span>Rows</span>
                   <select id="preview-limit" data-preview-limit>
@@ -699,9 +720,9 @@
                   <tr>
                     <th scope="col">Indicator</th>
                     <th scope="col">Type</th>
-                    <th scope="col">Source</th>
+                    <th scope="col">Sources</th>
                     <th scope="col">First seen</th>
-                    <th scope="col">Confidence</th>
+                    <th scope="col">Score</th>
                   </tr>
                 </thead>
                 <tbody data-preview-body></tbody>
@@ -723,8 +744,11 @@
                   highlighted
                 </span>
                 <span class="preview-summary-pill">
-                  <span data-preview-high>0</span> high-confidence
+                  <span data-preview-high>0</span> high-score
                   (<span data-preview-high-percent>0%</span>)
+                </span>
+                <span class="preview-summary-pill">
+                  <span data-preview-corroborated>0</span> corroborated by 2+ sources
                 </span>
                 <span class="preview-summary-pill">
                   Top tag:

--- a/scripts/summarize_iocs.py
+++ b/scripts/summarize_iocs.py
@@ -73,6 +73,50 @@ def summarize_tags(rows: Iterable[Dict[str, Any]], limit: int = 10) -> List[Tupl
     return [(tag, f"{count}") for tag, count in ordered]
 
 
+def summarize_scores(rows: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    """Aggregate the collector's 0-100 relevance scores when present."""
+    scores: List[int] = []
+    corroborated = 0
+    for row in rows:
+        value = row.get("score")
+        if isinstance(value, (int, float)) and value > 0:
+            scores.append(int(value))
+        sources = [s.strip() for s in (row.get("source") or "").split(",") if s.strip()]
+        if len(sources) >= 2:
+            corroborated += 1
+    if not scores:
+        return {"scored": 0, "corroborated": corroborated}
+    return {
+        "scored": len(scores),
+        "corroborated": corroborated,
+        "min": min(scores),
+        "avg": round(sum(scores) / len(scores), 1),
+        "max": max(scores),
+        "high": sum(1 for s in scores if s >= 80),
+    }
+
+
+def top_indicators_by_score(rows: Sequence[Dict[str, Any]], limit: int = 10) -> List[Tuple[str, str]]:
+    """Highest-scored indicators, corroboration-first on ties."""
+
+    def sort_key(row: Dict[str, Any]) -> Tuple[int, int, str]:
+        score = row.get("score")
+        numeric = int(score) if isinstance(score, (int, float)) else 0
+        sources = [s.strip() for s in (row.get("source") or "").split(",") if s.strip()]
+        return (-numeric, -len(sources), str(row.get("indicator") or ""))
+
+    ranked = sorted((r for r in rows if r.get("indicator")), key=sort_key)[:limit]
+    out: List[Tuple[str, str]] = []
+    for row in ranked:
+        score = row.get("score")
+        numeric = int(score) if isinstance(score, (int, float)) else 0
+        sources = [s.strip() for s in (row.get("source") or "").split(",") if s.strip()]
+        label = f"{row.get('type', '?')}: `{row.get('indicator')}`"
+        detail = f"score {numeric}, {len(sources)} source{'s' if len(sources) != 1 else ''}"
+        out.append((label, detail))
+    return out
+
+
 def summarize_overlaps(rows: Iterable[Dict[str, Any]], limit: int = 10) -> List[Tuple[str, str]]:
     overlaps: List[Tuple[str, str]] = []
     for row in rows:
@@ -150,6 +194,7 @@ def build_highlights(diag: Dict[str, Any] | None, rows: List[Dict[str, Any]]) ->
         earliest = earliest or derived_first
         newest = newest or derived_latest
     overlaps = summarize_overlaps(rows, limit=9999)
+    score_stats = summarize_scores(rows)
     highlight_rows: List[Tuple[str, str]] = [("Generated", generated)]
     if window is not None:
         highlight_rows.append(("Window (hours)", str(window)))
@@ -158,6 +203,12 @@ def build_highlights(diag: Dict[str, Any] | None, rows: List[Dict[str, Any]]) ->
     highlight_rows.append(("Sources reporting", f"{active_sources}"))
     highlight_rows.append(("Indicator types", f"{types_seen}"))
     highlight_rows.append(("Multi-source overlaps", f"{len(overlaps)}"))
+    if score_stats.get("scored"):
+        highlight_rows.append(
+            ("Score (min / avg / max)", f"{score_stats['min']} / {score_stats['avg']} / {score_stats['max']}")
+        )
+        highlight_rows.append(("High-score indicators (≥80)", f"{score_stats['high']}"))
+        highlight_rows.append(("Corroborated (2+ sources)", f"{score_stats['corroborated']}"))
     if earliest:
         highlight_rows.append(("Earliest first_seen", earliest))
     if newest:
@@ -174,6 +225,12 @@ def render_summary(diag: Dict[str, Any] | None, rows: List[Dict[str, Any]]) -> T
 
     sections: List[str] = ["## Highlights", ""]
     sections.extend(to_table(highlight_rows, ("Metric", "Value")))
+
+    top_scored = top_indicators_by_score(rows)
+    if top_scored:
+        sections.append("## Top indicators by score")
+        sections.append("")
+        sections.extend(to_table(top_scored, ("Indicator", "Score / corroboration")))
 
     sections.append("## Per-source totals")
     sections.append("")

--- a/swiftioc.py
+++ b/swiftioc.py
@@ -761,33 +761,78 @@ def fetch_malwarebazaar_csv(
 def fetch_threatfox_export_json(url: str, ref_url: str, source: str, ws: datetime) -> List[Indicator]:
     text = ensure_text(http_get(url, name=source))
     raw = json.loads(text)
+    data: List[Dict[str, Any]]
     if isinstance(raw, dict):
-        data = raw.get("data") or []
+        if isinstance(raw.get("data"), list):
+            # API POST response shape: {"query_status": ..., "data": [...]}
+            data = [row for row in raw["data"] if isinstance(row, dict)]
+        else:
+            # Export endpoint shape: {"<ioc_id>": [entry, ...], ...}
+            data = [
+                entry
+                for value in raw.values()
+                if isinstance(value, list)
+                for entry in value
+                if isinstance(entry, dict)
+            ]
+    elif isinstance(raw, list):
+        data = [row for row in raw if isinstance(row, dict)]
     else:
-        data = raw
+        data = []
     now = now_utc()
     out: List[Indicator] = []
-    tmap = {"ipv4": "ipv4", "ipv6": "ipv6", "domain": "domain", "url": "url", "md5": "md5", "sha1": "sha1", "sha256": "sha256"}
+    tmap = {
+        "ipv4": "ipv4", "ipv6": "ipv6", "domain": "domain", "url": "url",
+        "md5": "md5", "sha1": "sha1", "sha256": "sha256",
+        # Export endpoint spellings.
+        "md5_hash": "md5", "sha1_hash": "sha1", "sha256_hash": "sha256",
+        "sha512_hash": "sha512",
+    }
 
-    for row in data or []:
-        ioc = row.get("ioc")
+    def normalise_tags(value: Any) -> List[str]:
+        if isinstance(value, str):
+            return [t.strip() for t in value.split(",") if t.strip()]
+        if isinstance(value, (list, tuple)):
+            return [str(t).strip() for t in value if str(t).strip()]
+        return []
+
+    for row in data:
+        ioc = row.get("ioc") or row.get("ioc_value")
+        if not isinstance(ioc, str) or not ioc.strip():
+            continue
+        ioc = ioc.strip()
         itype = (row.get("ioc_type") or "").lower()
-        seen = parse_dt(row.get("first_seen"))
-        if not ioc or (seen and seen < ws):
+        seen = parse_dt(row.get("first_seen") or row.get("first_seen_utc"))
+        if seen and seen < ws:
             continue
-        t = tmap.get(itype)
-        if not t:
-            continue
+        if itype == "ip:port":
+            # "1.2.3.4:443" -> classify the bare address; keeps the value
+            # comparable with other IP feeds so corroboration can match.
+            host = ioc.rsplit(":", 1)[0]
+            t = classify(host)
+            if t not in {"ipv4", "ipv6"}:
+                continue
+            ioc = host
+        else:
+            t = tmap.get(itype)
+            if not t:
+                continue
+        # ThreatFox reports 0-100 confidence_level; map onto our bands.
+        level = row.get("confidence_level")
+        if isinstance(level, (int, float)):
+            confidence = "high" if level >= 75 else "medium" if level >= 40 else "low"
+        else:
+            confidence = "medium"
         val = defang_min(ioc) if t in {"url", "domain", "ipv4", "ipv6"} else ioc
-        tags = row.get("tags") or []
+        tags = normalise_tags(row.get("tags"))
         out.append(
             Indicator(
                 indicator=val, type=t, source=source,
                 first_seen=iso(seen or now), last_seen=iso(now),
-                confidence="medium", tlp="CLEAR",
+                confidence=confidence, tlp="CLEAR",
                 tags=",".join(sorted(set(["threatfox"] + tags))),
                 reference=ref_url or "",
-                context=row.get("malware") or row.get("threat_type") or "ThreatFox recent",
+                context=row.get("malware_printable") or row.get("malware") or row.get("threat_type") or "ThreatFox recent",
             )
         )
     return out

--- a/tests/test_swiftioc.py
+++ b/tests/test_swiftioc.py
@@ -388,6 +388,48 @@ def test_stix_bundle_validates_against_stix2_library(tmp_path):
     assert len(bundle.objects) == len(rows) + 2  # + identity + marking
 
 
+# ---------------- summarize_iocs helpers ----------------
+def _load_summarizer():
+    import importlib.util
+    from pathlib import Path
+
+    path = Path(__file__).resolve().parent.parent / "scripts" / "summarize_iocs.py"
+    spec = importlib.util.spec_from_file_location("summarize_iocs", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_summarizer_score_stats_and_top_table():
+    mod = _load_summarizer()
+    rows = [
+        {"indicator": "1.2.3.4", "type": "ipv4", "source": "a,b,c", "score": 96},
+        {"indicator": "5.6.7.8", "type": "ipv4", "source": "a", "score": 80},
+        {"indicator": "old.example", "type": "domain", "source": "a", "score": 21},
+        {"indicator": "unscored.example", "type": "domain", "source": "a"},
+    ]
+    stats = mod.summarize_scores(rows)
+    assert stats["scored"] == 3
+    assert stats["corroborated"] == 1
+    assert stats["min"] == 21 and stats["max"] == 96
+    assert stats["high"] == 2
+
+    top = mod.top_indicators_by_score(rows, limit=2)
+    assert len(top) == 2
+    assert "1.2.3.4" in top[0][0]  # highest score first
+    assert "score 96, 3 sources" == top[0][1]
+
+
+def test_summarizer_handles_scoreless_feed():
+    mod = _load_summarizer()
+    rows = [{"indicator": "x.example", "type": "domain", "source": "a"}]
+    stats = mod.summarize_scores(rows)
+    assert stats == {"scored": 0, "corroborated": 0}
+    # render_summary must not crash on legacy score-less data
+    summary_md, index_md, step_md = mod.render_summary({}, rows)
+    assert "Top indicators by score" in summary_md  # table still renders (score 0)
+
+
 # ---------------- scoring: corroboration + decay ("living feed") --------------
 def _iso_hours_ago(hours: float) -> str:
     from datetime import timedelta
@@ -486,6 +528,48 @@ def test_csv_includes_score_column(tmp_path):
     header = lines[0].split(",")
     row = lines[1].split(",")
     assert row[header.index("score")] == "88"
+
+
+def test_threatfox_export_endpoint_shape(monkeypatch):
+    # The real export endpoint returns {"<ioc_id>": [entry, ...]} with
+    # ioc_value/first_seen_utc/ip:port/md5_hash spellings and comma-string
+    # tags — all of which the parser previously dropped or crashed on.
+    payload = json.dumps(
+        {
+            "1848845": [
+                {
+                    "ioc_value": "nisosznd.jadoobet.club", "ioc_type": "domain",
+                    "threat_type": "payload_delivery", "malware_printable": "ClearFake",
+                    "first_seen_utc": "2026-07-12 02:20:08", "confidence_level": 100,
+                    "tags": "ClearFake,windows",
+                }
+            ],
+            "1848846": [
+                {
+                    "ioc_value": "203.0.113.9:4443", "ioc_type": "ip:port",
+                    "threat_type": "botnet_cc", "malware_printable": "Emotet",
+                    "first_seen_utc": "2026-07-12 01:00:00", "confidence_level": 50,
+                }
+            ],
+            "1848847": [
+                {
+                    "ioc_value": "d41d8cd98f00b204e9800998ecf8427e", "ioc_type": "md5_hash",
+                    "first_seen_utc": "2026-07-12 01:00:00", "confidence_level": 30,
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(si, "http_get", lambda *a, **k: payload)
+    ws = si.now_utc().replace(year=2000)
+    out = si.fetch_threatfox_export_json("http://x", "ref", "tf", ws)
+    by_type = {i.type: i for i in out}
+    assert set(by_type) == {"domain", "ipv4", "md5"}
+    assert by_type["domain"].confidence == "high"  # confidence_level 100
+    assert "clearfake" in by_type["domain"].tags.lower()
+    # ip:port strips the port so corroboration can match other IP feeds.
+    assert si.refang(by_type["ipv4"].indicator) == "203.0.113.9"
+    assert by_type["ipv4"].confidence == "medium"
+    assert by_type["md5"].confidence == "low"
 
 
 def test_threatfox_and_feodo_parsers(monkeypatch):


### PR DESCRIPTION
## Summary

Two tightly-related fixes: the GitHub Pages dashboard now **surfaces the scoring/corroboration system** (it was completely blind to it), and the **ThreatFox parser is fixed** — it was silently contributing zero indicators against the real export endpoint.

### Dashboard: show the most dangerous, most confirmed, newest first
- **Score-first ranking** — the preview now sorts by the collector's 0–100 relevance score, then by corroboration count, then recency. Previously the numeric score was a dead fallback that never triggered, and sorting used a coarse 3-bucket confidence.
- **Corroboration surfaced** — multi-source values like `feodo,threatfox` were counted as *one fake source*, breaking the "Active sources" stat and the per-source table. Sources are now split and credited individually; corroborated rows show a red `N× confirmed` badge, a `feodo +2` source label (full list in tooltip), and the summary gains a "corroborated by 2+ sources" pill.
- **New "Show" filter** — High score (≥80) / Corroborated (2+ sources) / New (last 48h).
- The Confidence column becomes **Score** (colored by band, falls back to the confidence label for legacy rows).

### Data: ThreatFox parser was silently broken
The real export endpoint returns `{"<ioc_id>": [entry, ...]}` — not `{"data": [...]}` — with `ioc_value`/`first_seen_utc` field names, `ip:port`/`md5_hash`-style type spellings, and comma-string tags (which would have raised `TypeError`). The parser handled none of that, so **ThreatFox contributed 0 indicators in production**. After the fix, a live run collected **903** ThreatFox indicators. Bonus: `ip:port` entries strip the port so C2 IPs can corroborate against other IP feeds, and ThreatFox's 0–100 `confidence_level` now maps onto our confidence bands (feeding the score).

### Markdown summary
`summarize_iocs.py` highlights now include score min/avg/max, high-score count, corroborated count, and a new "Top indicators by score" table.

## Verification
- Served the built site locally and drove it in a real browser: score-first ordering (96 → 88 → 80 → 60), corroboration badges and `+N` labels rendered, per-feed source table splits correctly, the Corroborated filter isolated exactly the multi-source rows, zero console errors.
- Live collector run: ThreatFox 0 → 903 indicators; feed total 1,208 across 3 sources.
- 42 tests pass (3 new: ThreatFox export-shape regression, summarizer score stats, score-less legacy tolerance). `ruff`, `node --check`, and pyright (vs. baseline) clean.

## Reviewer notes
- Dashboard changes are backward compatible: rows without a `score` field fall back to the old confidence-based rank/labels, so the currently-committed (pre-scoring) `latest.jsonl` still renders fine until the next collection run.
- The ThreatFox fix keeps supporting the `{"data": [...]}` POST-API shape (used by existing tests/configs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
