### PR TITLE
fix(tests): satisfy pyright in _load_summarizer (green up main after #49)

### DIFF
--- a/tests/test_swiftioc.py
+++ b/tests/test_swiftioc.py
@@ -395,6 +395,7 @@ def _load_summarizer():
 
     path = Path(__file__).resolve().parent.parent / "scripts" / "summarize_iocs.py"
     spec = importlib.util.spec_from_file_location("summarize_iocs", path)
+    assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module


### PR DESCRIPTION
PR #49 merged with a failing `Lint, audit, and self-test` check. The `_load_summarizer` test helper used `importlib.util.spec_from_file_location` (returns `ModuleSpec | None`) and `spec.loader` (Optional) without a None-guard, producing 3 pyright errors. I'd run pyright only on selected files, not the full CI invocation, so it slipped through.

**Fix:** assert `spec` and `spec.loader` are non-None before use.

Verified with the exact CI commands: `pyright` (no args) reports only the pre-existing 8-error environmental baseline (urllib3 Retry / dateutil stubs, which don't appear in CI's fresh install), `ruff check .` clean, all 42 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)