### PR TITLE
Dashboard: surface score/corroboration, threat-score bar, table bars

### DIFF
--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -334,8 +334,11 @@
     let duplicatesRemoved = 0;
     let corroborated = 0;
     let highScore = 0;
+    let highConfidence = 0;
     let scoreSum = 0;
     let scoredCount = 0;
+    // Score bands for the distribution bar: critical / high / medium / low.
+    const scoreBands = { critical: 0, high: 0, medium: 0, low: 0 };
     const sources = new Set();
     const types = new Set();
     const tags = new Map();
@@ -388,7 +391,8 @@
         if (key) sources.add(key);
       });
 
-      if (sourceParts.length >= 2) {
+      const multiSource = sourceParts.length >= 2;
+      if (multiSource) {
         corroborated += 1;
       }
 
@@ -396,6 +400,15 @@
         scoreSum += row.score;
         scoredCount += 1;
         if (row.score >= 80) highScore += 1;
+        if (row.score >= 80) scoreBands.critical += 1;
+        else if (row.score >= 60) scoreBands.high += 1;
+        else if (row.score >= 40) scoreBands.medium += 1;
+        else scoreBands.low += 1;
+      }
+
+      // Block-ready: high score OR confirmed by multiple independent sources.
+      if ((typeof row.score === 'number' && row.score >= 80) || multiSource) {
+        highConfidence += 1;
       }
 
       if (type) {
@@ -464,6 +477,8 @@
         duplicatesRemoved,
         corroborated,
         highScore,
+        highConfidence,
+        scoreBands,
         avgScore: scoredCount > 0 ? Math.round(scoreSum / scoredCount) : null,
         hasScores: scoredCount > 0,
         activeSources: sources.size,
@@ -527,10 +542,11 @@
       const entries = Array.from(map.entries());
       const total = entries.reduce((sum, [, count]) => sum + count, 0) || 1;
 
+      const max = entries.reduce((m, [, count]) => Math.max(m, count), 0) || 1;
       return entries
         .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
         .map(([label, count]) => {
-          const share = `${((count / total) * 100).toFixed(1)}%`;
+          const pct = (count / total) * 100;
           return [
             {
               title: labelKey,
@@ -543,8 +559,11 @@
             },
             {
               title: 'Share',
-              value: share,
+              value: `${pct.toFixed(1)}%`,
               numeric: true,
+              // Bar width is relative to the largest row so small feeds stay
+              // visible; the label still shows the true share of total.
+              bar: (count / max) * 100,
             },
           ];
         });
@@ -591,7 +610,19 @@
           const td = document.createElement('td');
           td.dataset.title = cell.title;
           if (cell.numeric) td.classList.add('numeric');
-          td.textContent = cell.value;
+          if (typeof cell.bar === 'number') {
+            // Share cell: proportion bar behind a right-aligned value.
+            td.classList.add('has-bar');
+            const fill = document.createElement('span');
+            fill.className = 'cell-bar';
+            fill.style.width = `${Math.max(2, Math.min(100, cell.bar))}%`;
+            const val = document.createElement('span');
+            val.className = 'cell-bar-value';
+            val.textContent = cell.value;
+            td.append(fill, val);
+          } else {
+            td.textContent = cell.value;
+          }
           tr.appendChild(td);
         });
         tbody.appendChild(tr);
@@ -1233,6 +1264,60 @@
    *  GLOBAL STATS + TABLES
    * ========================================================================= */
 
+  const SCORE_BAND_META = [
+    { key: 'critical', label: 'Critical', hint: 'score 80–100' },
+    { key: 'high', label: 'High', hint: 'score 60–79' },
+    { key: 'medium', label: 'Medium', hint: 'score 40–59' },
+    { key: 'low', label: 'Low', hint: 'score < 40' },
+  ];
+
+  const renderScoreDistribution = (stats) => {
+    const root = qs('[data-score-distribution]');
+    if (!root) return;
+
+    const bands = stats.scoreBands;
+    const total = bands
+      ? SCORE_BAND_META.reduce((sum, b) => sum + (bands[b.key] || 0), 0)
+      : 0;
+
+    if (!bands || total === 0) {
+      root.hidden = true;
+      return;
+    }
+    root.hidden = false;
+
+    const bar = qs('[data-score-bar]', root);
+    const legend = qs('[data-score-legend]', root);
+    if (bar) bar.innerHTML = '';
+    if (legend) legend.innerHTML = '';
+
+    SCORE_BAND_META.forEach((meta) => {
+      const count = bands[meta.key] || 0;
+      if (!count) return;
+      const pct = (count / total) * 100;
+
+      if (bar) {
+        const seg = document.createElement('span');
+        seg.className = `score-seg score-seg-${meta.key}`;
+        seg.style.width = `${pct}%`;
+        seg.title = `${meta.label}: ${formatNumber(count)} (${pct.toFixed(1)}%)`;
+        bar.appendChild(seg);
+      }
+
+      if (legend) {
+        const item = document.createElement('span');
+        item.className = 'score-legend-item';
+        const swatch = document.createElement('span');
+        swatch.className = `score-swatch score-seg-${meta.key}`;
+        const text = document.createElement('span');
+        text.textContent = `${meta.label} ${formatNumber(count)}`;
+        item.append(swatch, text);
+        item.title = meta.hint;
+        legend.appendChild(item);
+      }
+    });
+  };
+
   const applyStats = (stats, dataset) => {
     if (!stats) return;
 
@@ -1253,6 +1338,19 @@
     setStatText('duplicates-removed', formatNumber(stats.duplicatesRemoved));
     setStatText('active-sources', formatNumber(stats.activeSources));
     setStatText('indicator-types', formatNumber(stats.indicatorTypes));
+
+    // Differentiator metrics: block-ready + cross-source-confirmed volume.
+    setStatText('high-confidence', formatNumber(stats.highConfidence ?? 0));
+    setStatText('corroborated', formatNumber(stats.corroborated ?? 0));
+    setStatText('avg-score', stats.avgScore != null ? String(stats.avgScore) : '—');
+    const hcPct =
+      stats.total > 0 ? ((stats.highConfidence ?? 0) / stats.total) * 100 : 0;
+    setStatText('high-confidence-caption', `${hcPct.toFixed(1)}% of the feed`);
+    const corrPct =
+      stats.total > 0 ? ((stats.corroborated ?? 0) / stats.total) * 100 : 0;
+    setStatText('corroborated-caption', `${corrPct.toFixed(1)}% multi-source`);
+
+    renderScoreDistribution(stats);
 
     const feedsText =
       stats.activeSources != null

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -527,6 +527,117 @@ code {
     "Courier New", monospace;
 }
 
+/* Accent metric card (the high-confidence differentiator) */
+
+.metric-card-accent {
+  border-color: rgba(239, 68, 68, 0.5);
+  background: radial-gradient(circle at 0 0, rgba(239, 68, 68, 0.16), transparent 55%),
+    radial-gradient(circle at 100% 100%, rgba(239, 68, 68, 0.12), transparent 55%),
+    var(--card-bg-soft);
+}
+
+.metric-card-accent .metric-value {
+  color: #fecaca;
+}
+
+/* Score distribution bar */
+
+.score-distribution {
+  margin-bottom: 1.1rem;
+  padding: 0.6rem 0.85rem 0.7rem;
+  border-radius: var(--radius-card);
+  border: 1px solid var(--border-soft);
+  background: var(--card-bg-soft);
+  box-shadow: var(--shadow-subtle);
+}
+
+.score-distribution-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.35rem 0.75rem;
+  margin-bottom: 0.4rem;
+}
+
+.score-distribution-title {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.score-legend {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.75rem;
+  font-size: 0.72rem;
+  color: var(--text-soft);
+}
+
+.score-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.score-swatch {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.score-bar {
+  display: flex;
+  width: 100%;
+  height: 0.7rem;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(148, 163, 184, 0.14);
+}
+
+.score-seg {
+  height: 100%;
+  transition: width 0.4s ease;
+}
+
+.score-seg-critical {
+  background: #ef4444;
+}
+.score-seg-high {
+  background: #f97316;
+}
+.score-seg-medium {
+  background: #eab308;
+}
+.score-seg-low {
+  background: #64748b;
+}
+
+/* Proportion bars inside summary tables (Share column) */
+
+td.has-bar {
+  position: relative;
+  overflow: hidden;
+}
+
+td.has-bar .cell-bar {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 62%;
+  border-radius: 4px;
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0.45), rgba(59, 130, 246, 0.18));
+  z-index: 0;
+}
+
+td.has-bar .cell-bar-value {
+  position: relative;
+  z-index: 1;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Confidence badge colors */
 
 .confidence-high {

--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,7 @@
       gtag('config', 'G-T7L8XCEG0S');
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css" />
+    <link rel="stylesheet" href="assets/styles.css?v=2" />
 
     <style>
       /* Page-specific layout refinements for the main dashboard */
@@ -569,8 +569,9 @@
           <div>
             <h1 class="section-title">SwiftIOC IOC Snapshot</h1>
             <p class="page-header-subtitle">
-              Live highlight of the latest SwiftIOC collection run: quick filters,
-              source breakdowns, and export options.
+              Scored, cross-source-corroborated, self-refreshing threat
+              indicators — ranked so the most dangerous, most-confirmed IOCs
+              surface first.
             </p>
           </div>
         </div>
@@ -603,30 +604,50 @@
 
       <section class="metrics-strip" aria-label="Top metrics">
         <article class="metric-card">
-          <p class="metric-label">Generated at</p>
-          <p class="metric-value" data-stat="generated-at">—</p>
-          <p class="metric-caption">Timestamp of this IOC bundle</p>
-        </article>
-
-        <article class="metric-card">
           <p class="metric-label">Total indicators</p>
           <p class="metric-value" data-stat="total-indicators">—</p>
-          <p class="metric-caption">After duplicate removal</p>
+          <p class="metric-caption" data-stat="feeds-online">
+            Across active sources
+          </p>
         </article>
 
-        <article class="metric-card">
-          <p class="metric-label">Active sources</p>
-          <p class="metric-value" data-stat="active-sources">—</p>
-          <p class="metric-caption" data-stat="feeds-online">
-            Sources active in this run
+        <article class="metric-card metric-card-accent">
+          <p class="metric-label">High-confidence</p>
+          <p class="metric-value" data-stat="high-confidence">—</p>
+          <p class="metric-caption" data-stat="high-confidence-caption">
+            Score ≥80 or 2+ sources
           </p>
         </article>
 
         <article class="metric-card">
-          <p class="metric-label">Types observed</p>
-          <p class="metric-value" data-stat="indicator-types">—</p>
-          <p class="metric-caption">IPs, domains, hashes, URLs, …</p>
+          <p class="metric-label">Corroborated</p>
+          <p class="metric-value" data-stat="corroborated">—</p>
+          <p class="metric-caption" data-stat="corroborated-caption">
+            Confirmed by 2+ sources
+          </p>
         </article>
+
+        <article class="metric-card">
+          <p class="metric-label">Avg score</p>
+          <p class="metric-value" data-stat="avg-score">—</p>
+          <p class="metric-caption">
+            <span data-stat="indicator-types">—</span> indicator types
+          </p>
+        </article>
+      </section>
+
+      <section
+        class="score-distribution"
+        data-score-distribution
+        hidden
+        aria-label="Score distribution"
+      >
+        <div class="score-distribution-head">
+          <span class="score-distribution-title">Threat score distribution</span>
+          <span class="score-legend" data-score-legend></span>
+        </div>
+        <div class="score-bar" data-score-bar role="img"
+          aria-label="Proportion of indicators by score band"></div>
       </section>
 
       <main class="dashboard-main">
@@ -997,6 +1018,6 @@
       </section>
     </div>
 
-    <script defer src="assets/dashboard.js"></script>
+    <script defer src="assets/dashboard.js?v=2"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
Redesigns the GitHub Pages dashboard to **lead with the differentiators** (score, corroboration, high-confidence) instead of generic counts.

### What changed
- **Metrics strip** now shows **Total · High-confidence · Corroborated · Avg score** (each with a % caption), replacing the old Generated/Total/Sources/Types set. High-confidence (score ≥80 or 2+ sources — the block-ready count) gets an accent card. Generated time still lives in the status banner.
- **Threat score distribution bar** — a segmented critical/high/medium/low breakdown with a legend, driven by the collector's 0–100 scores.
- **Proportion bars** behind the Share column of the Sources/Types/Tags tables for at-a-glance scanning.
- **Hero copy** restated to the value prop: *scored, cross-source-corroborated, self-refreshing indicators ranked most-dangerous-first.*
- **Versioned asset URLs** (`styles.css?v=2`, `dashboard.js?v=2`) so returning visitors get fresh CSS/JS after a deploy. This fixes a real bug I hit while testing — the browser served the cached old stylesheet against the new markup, silently breaking styles.

### Verification
Driven in-browser against fresh scored data (20,710 indicators):
- Metrics render correctly (High-confidence 2,414 / 11.7%, Corroborated 772, Avg score 62).
- Score-distribution bar + legend populate (critical 1,642 / high 19,068); computed colors and dimensions confirmed (red critical segment, 0.7rem bar).
- Table proportion bars render; accent card border/value colors correct.
- No console errors; no horizontal overflow at desktop (4-col) or mobile (stacked) widths.

### Notes
- Backward compatible: rows without a `score` fall back to the confidence label, so the currently-committed pre-scoring `latest.jsonl` still renders until the next scheduled collection populates scores.
- Pure front-end change (HTML/CSS/JS only) — no Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
