### PR TITLE
Retention: curate stored feed to recent + top IOCs (KEVIntel-style)

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -113,12 +113,17 @@ jobs:
           # --persist-feed makes this a living feed: the latest.jsonl committed
           # by the previous run (checked out above) is merged in, re-observed
           # indicators refresh, and stale ones decay until they expire.
+          # Retention keeps the published feed curated ("top IOCs", KEVIntel
+          # style): drop anything not seen in 30 days, then keep the top 10k by
+          # score/recency so the committed feed stays high-signal and small.
           python swiftioc.py -vv \
             --out-dir "$OUT_DIR" \
             --sources "$SOURCES_FILE" \
             --window-hours "$WINDOW_HOURS" \
             --urlhaus-status "$URLHAUS_STATUS" \
             --persist-feed \
+            --max-age-days 30 \
+            --max-store 10000 \
             --log-file "$DIAG_DIR/run.log" \
             --log-format json \
             --log-file-level DEBUG \

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ high-fidelity IOCs from authoritative sources. The project emphasises:
   are confirmed by 2+ independent sources, strongest-first. This is the
   block-ready subset for SIEM/firewall ingestion where false positives are
   costly.
+- **Retention / "top IOCs" curation** – `--max-age-days` drops indicators not
+  seen recently and `--max-store` keeps only the top N by score and recency, so
+  the published feed stays small, fresh, and high-signal (think *KEV catalogue,
+  but for indicators*) instead of an unbounded dump. The scheduled workflow
+  curates to the last 30 days and the top 10,000 indicators.
 - **Concurrent collection** – sources are fetched in parallel (configurable via
   `--max-workers`), so a full run completes in a fraction of the time of a
   sequential fetch without changing the deterministic output.
@@ -284,6 +289,8 @@ Run `python -m swiftioc --help` for the full list of switches. Highlights:
 | `--persist-feed` | Living feed: merge the previously published `latest.jsonl`, decay scores by age, expire stale entries. |
 | `--min-score N` | Expire indicators whose decayed score falls below `N` (default `20`). |
 | `--high-confidence-score N` | Score at/above which an indicator enters the curated `high_confidence` feed (default `80`; multi-source indicators always qualify). |
+| `--max-age-days N` | Retention: drop indicators whose `last_seen` is older than `N` days. |
+| `--max-store N` | Retention: keep only the top `N` indicators by score/recency (KEVIntel-style curation; keeps the stored feed small and high-signal). |
 | `--urlhaus-status {any,online,offline}` | Filter URLhaus indicators by status. |
 | `--source-window name=N` | Override the lookback window for specific sources. |
 | `--grace-on-404 name…` | Treat HTTP 404 for listed sources as a non-fatal empty result. |

--- a/swiftioc.py
+++ b/swiftioc.py
@@ -318,6 +318,39 @@ def high_confidence_rows(rows: List[Indicator], *, min_score: int = 80) -> List[
     return [r for r in rows if r.score >= min_score or source_count(r) >= 2]
 
 
+def apply_retention(
+    rows: List[Indicator],
+    *,
+    max_age_days: Optional[int] = None,
+    max_store: Optional[int] = None,
+    now: Optional[datetime] = None,
+) -> Tuple[List[Indicator], int, int]:
+    """Curate the stored feed to the most recent + top-scoring indicators.
+
+    This is the "top IOCs" retention (KEVIntel-style): first drop anything not
+    seen within ``max_age_days``, then keep only the ``max_store`` strongest by
+    (score, corroboration, recency). Returns ``(rows, aged_out, pruned)``.
+    Both bounds are optional and off by default.
+    """
+    now = now or now_utc()
+    aged_out = 0
+    if max_age_days is not None:
+        cutoff = now - timedelta(days=max_age_days)
+        before = len(rows)
+        rows = [r for r in rows if (parse_dt(r.last_seen) or now) >= cutoff]
+        aged_out = before - len(rows)
+    pruned = 0
+    if max_store is not None and len(rows) > max_store:
+        rows = sorted(
+            rows,
+            key=lambda r: (r.score, source_count(r), r.last_seen, r.indicator),
+            reverse=True,
+        )
+        pruned = len(rows) - max_store
+        rows = rows[:max_store]
+    return rows, aged_out, pruned
+
+
 def load_previous_feed(path: Path) -> List[Indicator]:
     """Load a previously published latest.jsonl so the feed can persist.
 
@@ -1822,6 +1855,10 @@ def main() -> int:
                     help="Living feed: merge the previously published latest.jsonl, decay scores by age, expire stale entries")
     ap.add_argument("--min-score", type=int, default=20,
                     help="Expire indicators whose decayed score falls below this (default 20)")
+    ap.add_argument("--max-age-days", type=int, default=None,
+                    help="Retention: drop indicators whose last_seen is older than N days")
+    ap.add_argument("--max-store", type=int, default=None,
+                    help="Retention: keep only the top N indicators by score/recency (KEVIntel-style curation)")
     ap.add_argument("--high-confidence-score", type=int, default=80,
                     help="Score at/above which an indicator enters the curated high_confidence feed (default 80)")
     ap.add_argument("--urlhaus-status", choices=["any", "online", "offline"], default="any")
@@ -1937,6 +1974,18 @@ def main() -> int:
     if expired:
         logger.info("Expired %d indicators below score threshold %d", expired, args.min_score)
 
+    # Retention — keep the stored feed to the most recent + highest-signal
+    # indicators ("top IOCs", KEVIntel-style). Applied here, before writing,
+    # so the persisted latest.jsonl stays bounded run over run instead of
+    # growing without limit.
+    rows, aged_out, pruned_over_cap = apply_retention(
+        rows, max_age_days=args.max_age_days, max_store=args.max_store, now=score_now
+    )
+    if aged_out:
+        logger.info("Aged out %d indicators last seen over %d days ago", aged_out, args.max_age_days)
+    if pruned_over_cap:
+        logger.info("Retained top %d indicators (pruned %d over --max-store)", args.max_store, pruned_over_cap)
+
     # outputs
     write_csv(out_dir / "iocs" / "latest.csv", rows)
     write_tsv(out_dir / "iocs" / "latest.tsv", rows)
@@ -1983,6 +2032,11 @@ def main() -> int:
         "persist_feed": bool(args.persist_feed),
         "carried_forward": carried_forward,
         "expired_low_score": expired,
+        "aged_out": aged_out,
+        "pruned_over_cap": pruned_over_cap,
+        "stored": len(rows),
+        "max_age_days": args.max_age_days,
+        "max_store": args.max_store,
         "score_min": min(scores) if scores else None,
         "score_avg": round(sum(scores) / len(scores), 1) if scores else None,
         "score_max": max(scores) if scores else None,
@@ -2016,6 +2070,11 @@ def main() -> int:
         if args.persist_feed:
             report_lines.append(f"| Carried forward | {carried_forward} |")
             report_lines.append(f"| Expired (score < {args.min_score}) | {expired} |")
+        if args.max_age_days is not None:
+            report_lines.append(f"| Aged out (> {args.max_age_days}d) | {aged_out} |")
+        if args.max_store is not None:
+            report_lines.append(f"| Pruned over cap ({args.max_store}) | {pruned_over_cap} |")
+            report_lines.append(f"| Stored | {len(rows)} |")
         if scores:
             report_lines.append(f"| Score (min / avg / max) | {min(scores)} / {round(sum(scores) / len(scores), 1)} / {max(scores)} |")
         report_lines.append(f"| High-confidence indicators | {len(high_conf)} |")

--- a/tests/test_swiftioc.py
+++ b/tests/test_swiftioc.py
@@ -410,6 +410,44 @@ def test_high_confidence_rows_respects_threshold():
     assert si.high_confidence_rows([ind], min_score=70) == [ind]
 
 
+def test_apply_retention_age_and_cap():
+    from datetime import timedelta
+
+    now = si.now_utc()
+
+    def ind(name, score, sources, days_old):
+        r = _sample_indicator(indicator=name, type="ipv4", source=sources)
+        r.score = score
+        r.last_seen = si.iso(now - timedelta(days=days_old))
+        return r
+
+    rows = [
+        ind("1.1.1.1", 90, "a", 1),       # fresh, high
+        ind("2.2.2.2", 55, "a,b", 2),      # fresh, corroborated
+        ind("3.3.3.3", 80, "a", 40),       # stale -> aged out
+        ind("4.4.4.4", 30, "a", 3),        # fresh but weakest
+    ]
+
+    # Age filter drops the 40-day-old row.
+    kept, aged, pruned = si.apply_retention(rows, max_age_days=30, now=now)
+    assert aged == 1 and pruned == 0
+    assert "3.3.3.3" not in {r.indicator for r in kept}
+
+    # Cap keeps the top 2 by (score, corroboration, recency): 1.1.1.1 (90) and
+    # 2.2.2.2 (55, 2 sources) beat 4.4.4.4 (30).
+    kept2, aged2, pruned2 = si.apply_retention(rows, max_age_days=30, max_store=2, now=now)
+    assert aged2 == 1 and pruned2 == 1
+    assert {r.indicator for r in kept2} == {"1.1.1.1", "2.2.2.2"}
+    # Result is ranked strongest-first.
+    assert kept2[0].indicator == "1.1.1.1"
+
+
+def test_apply_retention_noop_by_default():
+    rows = [_sample_indicator(indicator=f"{i}.0.0.1", type="ipv4") for i in range(5)]
+    kept, aged, pruned = si.apply_retention(rows)
+    assert len(kept) == 5 and aged == 0 and pruned == 0
+
+
 def test_source_count():
     assert si.source_count(_sample_indicator(source="a")) == 1
     assert si.source_count(_sample_indicator(source="a,b,c")) == 3


### PR DESCRIPTION
## Summary
Implements the **"KEVIntel for IOCs"** core: store only the *most recent + top* indicators, so the published feed is a focused, high-signal showcase instead of an unbounded 20k+ row dump.

## Changes
- **`apply_retention(rows, max_age_days, max_store)`** — a pure, tested helper that (1) drops indicators not seen within `max_age_days`, then (2) keeps only the top N by `(score, corroboration, recency)`, strongest-first. Both bounds are optional and **off by default** (backward compatible).
- New **`--max-age-days`** and **`--max-store`** CLI flags, applied *before* writing so the persisted living feed stays bounded run over run (rolling top-N).
- Diagnostics + run report gain `aged_out`, `pruned_over_cap`, `stored`, and the configured bounds.
- The scheduled **Collect** workflow now curates to the **last 30 days** and **top 10,000** indicators.

## Why
This is the piece that turns SwiftIOC from a raw aggregator into a curated product:
- **Only top & recent stored** — exactly the requested behavior.
- **Small, fast feed** — a 20,726-indicator run curated down to 2,000 rows was **846 KB vs ~9 MB**, so the committed feed and the dashboard load stay light.
- **High-signal** — corroborated / high-score / fresh indicators float to the top; the long tail of single-source scanner noise is pruned.

## Verification
End-to-end against a live 7-feed run: 20,726 collected → `stored: 2000`, `pruned_over_cap: 18726`, ordered strongest-first (top scores 80, tail 68). 48 tests pass (2 new: age+cap ranking, default no-op). `ruff` clean; `pyright` at the pre-existing environmental baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
