### PR TITLE
Fix feeds returning zero: repair sslbl_ja3 + NVD parsers, drop dead sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,10 +259,13 @@ apis:
     reference: https://urlhaus.abuse.ch/
     # Optional filter supplied via --urlhaus-status
 
+# RSS is supported (parse: rss) for feeds whose entries embed IOCs. Most
+# security-blog feeds only summarise posts, so they rarely yield indicators
+# and are left out of the defaults.
 rss:
-  - name: google_tag
-    url: https://blog.google/threat-analysis-group/rss/
-    reference: https://blog.google/threat-analysis-group/
+  - name: my_ioc_blog
+    url: https://example.com/feed.xml
+    reference: https://example.com/
 ```
 
 Each parser can accept additional keyword arguments defined under `options:`.

--- a/sources.example.yml
+++ b/sources.example.yml
@@ -53,12 +53,6 @@ apis:
     url: https://openphish.com/feed.txt
     reference: https://openphish.com/
 
-  - name: phishstats_api
-    kind: json
-    parse: phishstats
-    url: https://phishstats.info:2096/api/phishing?_limit=100
-    reference: https://phishstats.info/
-
   # --- Network / Malware IP Feeds ---
   - name: blocklist_de_ssh
     kind: txt
@@ -107,31 +101,12 @@ apis:
     url: https://raw.githubusercontent.com/stamparm/ipsum/master/levels/5.txt
     reference: https://github.com/stamparm/ipsum
 
-  # --- Vulnerability & Exploit Feeds ---
-  - name: exploitdb_recent
-    kind: rss
-    parse: rss
-    url: https://www.exploit-db.com/rss.xml
-    reference: https://www.exploit-db.com/
-
-rss:
-  - name: google_tag
-    url: https://blog.google/threat-analysis-group/rss/
-    reference: https://blog.google/threat-analysis-group/
-
-  - name: microsoft_msrc
-    url: https://msrc.microsoft.com/blog/feed
-    reference: https://msrc.microsoft.com/blog/
-
-  - name: cisco_talos
-    url: https://blog.talosintelligence.com/
-    reference: https://blog.talosintelligence.com/
-
-  - name: proofpoint_threatinsight
-    url: https://www.proofpoint.com/us/rss.xml
-    reference: https://www.proofpoint.com/us/blog/threat-insight
-
-  - name: bleepingcomputer_security
-    url: https://www.bleepingcomputer.com/feed/
-    reference: https://www.bleepingcomputer.com/
+# RSS support is built in (parse: rss). Security-blog feeds are intentionally
+# omitted from the defaults: their summaries rarely contain machine-readable
+# IOCs, so they mostly report zero. Add your own IOC-rich feeds here, e.g.:
+#
+# rss:
+#   - name: my_ioc_blog
+#     url: https://example.com/feed.xml
+#     reference: https://example.com/
 

--- a/swiftioc.py
+++ b/swiftioc.py
@@ -646,7 +646,10 @@ def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime) -> List[
     from urllib.parse import parse_qs, urlencode, urlparse
     parsed = urlparse(url)
     host = (parsed.hostname or "").lower()
-    if host == "nvd.nist.gov":
+    # Match the NVD host by parsed hostname, not a substring of the whole URL,
+    # so a lookalike like nvd.nist.gov.evil.com or ?x=nvd.nist.gov can't trip it.
+    # Use endswith so the real config host (services.nvd.nist.gov) still matches.
+    if host == "nvd.nist.gov" or host.endswith(".nvd.nist.gov"):
         query = parse_qs(parsed.query)
         if not any(k in query for k in ("lastModStartDate", "pubStartDate")):
             fmt = "%Y-%m-%dT%H:%M:%S.000"

--- a/swiftioc.py
+++ b/swiftioc.py
@@ -637,6 +637,22 @@ def fetch_cisa_kev(url: str, ref_url: str, source: str, ws: datetime) -> List[In
 
 @register_parser("nvd", "nist_nvd", "nist_nvd_recent")
 def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime) -> List[Indicator]:
+    now = now_utc()
+    # The NVD 2.0 API returns the *oldest* CVEs first (startIndex 0), so an
+    # unfiltered query yields 1999-era CVEs that the lookback window then drops,
+    # leaving zero. Constrain it to CVEs modified within the window (the API
+    # requires both bounds and caps the range at 120 days; a lookback window is
+    # always well inside that).
+    if "nvd.nist.gov" in url:
+        from urllib.parse import parse_qs, urlencode, urlparse
+        parsed = urlparse(url)
+        query = parse_qs(parsed.query)
+        if not any(k in query for k in ("lastModStartDate", "pubStartDate")):
+            fmt = "%Y-%m-%dT%H:%M:%S.000"
+            start = max(ws, now - timedelta(days=119))
+            query["lastModStartDate"] = [start.strftime(fmt)]
+            query["lastModEndDate"] = [now.strftime(fmt)]
+            url = parsed._replace(query=urlencode(query, doseq=True)).geturl()
     text = ensure_text(http_get(url, name=source))
     try:
         data = json.loads(text)
@@ -646,7 +662,6 @@ def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime) -> List[
     records = data.get("vulnerabilities") if isinstance(data, dict) else None
     if not isinstance(records, list):
         return []
-    now = now_utc()
     out: List[Indicator] = []
 
     def extract_severity(entry: Dict[str, Any]) -> Optional[str]:
@@ -952,22 +967,17 @@ def _fetch_sslbl_ja3(
         if not row:
             continue
 
-        header_token = row[0].strip().lower()
-        if header_token.startswith("#") or header_token in {"first_seen", "timestamp"}:
+        # abuse.ch SSLBL CSV columns: ja3_md5, firstseen, lastseen, listingreason.
+        # A valid JA3 hash in column 0 also filters out comment/header lines.
+        ja = row[0].strip()
+        if not JA3_RE.fullmatch(ja):
             continue
 
-        ja = row[1].strip() if len(row) > 1 else None
-        if not ja:
-            continue
-
-        if not JA3_RE.fullmatch(ja.strip()):
-            continue
-
-        first_seen = parse_dt(row[0]) if row[0] else None
+        first_seen = parse_dt(row[1]) if len(row) > 1 else None
         if not disable_window and first_seen and first_seen < ws:
             continue
 
-        desc = row[2] if len(row) > 2 else ""
+        desc = (row[3].strip() if len(row) > 3 else "")
 
         out.append(
             Indicator(

--- a/swiftioc.py
+++ b/swiftioc.py
@@ -643,9 +643,10 @@ def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime) -> List[
     # leaving zero. Constrain it to CVEs modified within the window (the API
     # requires both bounds and caps the range at 120 days; a lookback window is
     # always well inside that).
-    if "nvd.nist.gov" in url:
-        from urllib.parse import parse_qs, urlencode, urlparse
-        parsed = urlparse(url)
+    from urllib.parse import parse_qs, urlencode, urlparse
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if host == "nvd.nist.gov":
         query = parse_qs(parsed.query)
         if not any(k in query for k in ("lastModStartDate", "pubStartDate")):
             fmt = "%Y-%m-%dT%H:%M:%S.000"

--- a/tests/test_swiftioc.py
+++ b/tests/test_swiftioc.py
@@ -597,6 +597,41 @@ def test_csv_includes_score_column(tmp_path):
     assert row[header.index("score")] == "88"
 
 
+def test_sslbl_ja3_column_order(monkeypatch):
+    # abuse.ch CSV columns are ja3_md5, firstseen, lastseen, listingreason.
+    # Regression: the parser previously read ja3/first_seen in swapped columns
+    # and returned nothing.
+    payload = (
+        "################ comment banner ################\n"
+        "# ja3_md5,firstseen,lastseen,listingreason\n"
+        "b386946a5a44d1ddcc843bc75336dfce,2017-07-14 18:08:15,2019-07-27 20:42:54,Dridex\n"
+    )
+    monkeypatch.setattr(si, "http_get", lambda *a, **k: payload)
+    out = si.fetch_sslbl_ja3("http://x", "ref", "sslbl_ja3", si.now_utc().replace(year=2000))
+    assert len(out) == 1
+    assert out[0].type == "ja3"
+    assert out[0].indicator == "b386946a5a44d1ddcc843bc75336dfce"
+    assert "Dridex" in out[0].tags
+
+
+def test_nvd_parser_requests_recent_window(monkeypatch):
+    # Regression: an unfiltered NVD query returns the oldest CVEs, which the
+    # window then drops. The parser must inject lastModStartDate/EndDate.
+    captured = {}
+
+    def fake_get(url, *a, **k):
+        captured["url"] = url
+        return json.dumps({"vulnerabilities": []})
+
+    monkeypatch.setattr(si, "http_get", fake_get)
+    si.fetch_nvd_recent(
+        "https://services.nvd.nist.gov/rest/json/cves/2.0/?resultsPerPage=200",
+        "ref", "nvd", si.now_utc(),
+    )
+    assert "lastModStartDate" in captured["url"]
+    assert "lastModEndDate" in captured["url"]
+
+
 def test_threatfox_export_endpoint_shape(monkeypatch):
     # The real export endpoint returns {"<ioc_id>": [entry, ...]} with
     # ioc_value/first_seen_utc/ip:port/md5_hash spellings and comma-string


### PR DESCRIPTION
## Summary
Diagnosed every source that was reporting **zero indicators** and split them into real bugs vs. dead/empty feeds.

### Real bugs — fixed (now return data)
- **`sslbl_ja3`** — abuse.ch changed the CSV to `ja3_md5,firstseen,lastseen,listingreason`, but the parser still read the hash/first_seen from **swapped columns**, so every row failed the JA3 regex. Fixed to read column 0 as the hash (which also naturally skips comment/header lines) and column 3 as the reason. **Live: 0 → 97 JA3 fingerprints.**
- **`nist_nvd_recent`** — the NVD 2.0 API returns the **oldest** CVEs first, so an unfiltered query yielded 1999-era CVEs that the lookback window then dropped. The parser now injects `lastModStartDate`/`lastModEndDate` from the window (the API caps the range at 120 days). **Live: 0 → 134 recent CVEs.**

### Dead / structurally-empty — removed from defaults
- **`phishstats_api`** — endpoint returns HTTP 522 (server down).
- **`google_tag`, `microsoft_msrc`, `cisco_talos`** — feeds no longer parse (0 entries; the Talos URL was the homepage, not a feed).
- **`proofpoint`, `bleepingcomputer`, `exploitdb`** — the RSS parses fine, but blog summaries contain **no machine-readable IOCs**, so they always report zero.

RSS stays fully supported (a commented example shows how to add IOC-rich feeds) — the low-yield blog feeds just don't belong in a curated "top IOCs" default.

## Verification
Both fixes tested against the live endpoints (97 JA3s, 134 CVEs). 2 regression tests added (sslbl column order, NVD date-window injection). 50 tests pass; `ruff` clean; `pyright` at the environmental baseline.

## Result
The nine `returned zero indicators` warnings are resolved: two feeds now produce data, seven dead/no-yield feeds are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
