### PR TITLE
Dashboard: Top threats showcase (KEVIntel-style)

### DIFF
--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -2289,11 +2289,125 @@
   };
 
   /* ==========================================================================
+   *  TOP THREATS SHOWCASE
+   * ========================================================================= */
+
+  const TOP_THREATS_LIMIT = 6;
+
+  const scoreBandClass = (score) => {
+    if (typeof score !== 'number') return 'threat-medium';
+    if (score >= 80) return 'threat-critical';
+    if (score >= 60) return 'threat-high';
+    if (score >= 40) return 'threat-medium';
+    return 'threat-low';
+  };
+
+  const makeThreatPill = (cls, text) => {
+    const span = document.createElement('span');
+    span.className = `threat-pill ${cls}`;
+    span.textContent = text;
+    return span;
+  };
+
+  const makeThreatCard = (row) => {
+    const card = document.createElement('article');
+    card.className = `threat-card ${scoreBandClass(row.score)}`;
+
+    const scoreBox = document.createElement('div');
+    scoreBox.className = 'threat-score';
+    const num = document.createElement('span');
+    num.className = 'threat-score-num';
+    num.textContent =
+      typeof row.score === 'number'
+        ? String(row.score)
+        : (row.confidence ? row.confidence[0].toUpperCase() : '—');
+    const lbl = document.createElement('span');
+    lbl.className = 'threat-score-label';
+    lbl.textContent = 'score';
+    scoreBox.append(num, lbl);
+
+    const body = document.createElement('div');
+    body.className = 'threat-body';
+
+    const ind = document.createElement('div');
+    ind.className = 'threat-indicator';
+    ind.textContent = row.indicator || '—';
+    if (row.indicator) ind.title = row.indicator;
+    body.appendChild(ind);
+
+    const pills = document.createElement('div');
+    pills.className = 'threat-pills';
+    pills.appendChild(makeThreatPill('type', row.type || 'unknown'));
+    if ((row.sourceCount || 0) >= 2) {
+      const p = makeThreatPill('confirmed', `${row.sourceCount}× confirmed`);
+      if (Array.isArray(row.sourceList)) p.title = row.sourceList.join(', ');
+      pills.appendChild(p);
+    }
+    const rel = formatRelativeTimeFromNow(row.bestTimestamp);
+    if (rel) pills.appendChild(makeThreatPill('time', rel));
+    body.appendChild(pills);
+
+    if (row.tags && row.tags.length) {
+      const tags = document.createElement('div');
+      tags.className = 'threat-tags';
+      row.tags.slice(0, 3).forEach((t) => {
+        const s = document.createElement('span');
+        s.textContent = t;
+        tags.appendChild(s);
+      });
+      body.appendChild(tags);
+    }
+
+    card.append(scoreBox, body);
+    return card;
+  };
+
+  const initialiseTopThreats = () => {
+    const section = qs('[data-top-threats-section]');
+    const grid = qs('[data-top-threats]');
+    if (!section || !grid) return;
+
+    const render = (dataset) => {
+      const entries = (dataset && dataset.entries) || [];
+      // Only a scored feed makes a meaningful "top threats" ranking; hide the
+      // showcase for legacy pre-scoring data instead of showing blank boxes.
+      if (!entries.length || !entries.some((e) => typeof e.score === 'number')) {
+        section.hidden = true;
+        return;
+      }
+      const ranked = entries
+        .slice()
+        .sort((a, b) => {
+          const sa = typeof a.score === 'number' ? a.score : -1;
+          const sb = typeof b.score === 'number' ? b.score : -1;
+          if (sa !== sb) return sb - sa;
+          const ca = a.sourceCount || 0;
+          const cb = b.sourceCount || 0;
+          if (ca !== cb) return cb - ca;
+          return (b.bestTimestamp || 0) - (a.bestTimestamp || 0);
+        })
+        .slice(0, TOP_THREATS_LIMIT);
+
+      grid.innerHTML = '';
+      ranked.forEach((row) => grid.appendChild(makeThreatCard(row)));
+      section.hidden = false;
+    };
+
+    subscribeToDataset((dataset) => {
+      if (dataset && !isCacheOrigin(dataset.origin)) render(dataset);
+    });
+    loadDataset({})
+      .then(({ dataset }) => render(dataset))
+      .catch((error) => console.warn('Top threats failed to load', error));
+  };
+
+  /* ==========================================================================
    *  BOOTSTRAP
    * ========================================================================= */
 
   initialiseTableToggles();
   initialiseStatusBanner();
+  initialiseTopThreats();
   loadStats();
   initialisePreview();
 })();

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -638,6 +638,164 @@ td.has-bar .cell-bar-value {
   font-variant-numeric: tabular-nums;
 }
 
+/* Top threats showcase */
+
+.top-threats {
+  margin-bottom: 1.2rem;
+}
+
+.section-heading {
+  margin-bottom: 0.7rem;
+}
+
+.section-heading .panel-subtitle {
+  margin-top: 0.1rem;
+}
+
+.top-threats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(275px, 1fr));
+  gap: 0.75rem;
+}
+
+.threat-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.7rem;
+  padding: 0.7rem 0.8rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--border-soft);
+  background:
+    radial-gradient(circle at 0 0, rgba(239, 68, 68, 0.08), transparent 60%),
+    var(--card-bg-strong);
+  box-shadow: var(--shadow-subtle);
+  overflow: hidden;
+  transition: transform 0.16s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.threat-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--threat-accent, var(--accent));
+}
+
+.threat-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-soft);
+  border-color: rgba(148, 163, 184, 0.75);
+}
+
+.threat-score {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.1rem;
+  padding: 0.35rem 0.2rem;
+  border-radius: 0.7rem;
+  background: color-mix(in srgb, var(--threat-accent, var(--accent)) 20%, transparent);
+  border: 1px solid color-mix(in srgb, var(--threat-accent, var(--accent)) 45%, transparent);
+}
+
+.threat-score-num {
+  font-size: 1.35rem;
+  font-weight: 750;
+  line-height: 1;
+  color: var(--threat-accent, var(--text-strong));
+  font-variant-numeric: tabular-nums;
+}
+
+.threat-score-label {
+  font-size: 0.56rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-soft);
+  margin-top: 0.15rem;
+}
+
+.threat-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.threat-indicator {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.82rem;
+  color: var(--text-strong);
+  word-break: break-all;
+  line-height: 1.35;
+  max-height: 2.7em;
+  overflow: hidden;
+}
+
+.threat-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  align-items: center;
+}
+
+.threat-pill {
+  font-size: 0.62rem;
+  padding: 0.1rem 0.42rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text-soft);
+  white-space: nowrap;
+}
+
+.threat-pill.type {
+  background: rgba(59, 130, 246, 0.16);
+  border-color: rgba(59, 130, 246, 0.4);
+  color: #dbeafe;
+}
+
+.threat-pill.confirmed {
+  background: rgba(239, 68, 68, 0.16);
+  border-color: rgba(239, 68, 68, 0.45);
+  color: #fecaca;
+  font-weight: 600;
+}
+
+.threat-pill.time {
+  background: transparent;
+  border-color: transparent;
+  color: var(--text-muted);
+  padding-inline: 0;
+}
+
+.threat-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.threat-tags span {
+  font-size: 0.6rem;
+  padding: 0.04rem 0.34rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.14);
+  color: var(--accent-soft);
+}
+
+/* Score-band accents (drive the card via --threat-accent) */
+.threat-critical { --threat-accent: #ef4444; }
+.threat-high { --threat-accent: #f97316; }
+.threat-medium { --threat-accent: #eab308; }
+.threat-low { --threat-accent: #64748b; }
+
+@media (max-width: 540px) {
+  .top-threats-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Confidence badge colors */
 
 .confidence-high {

--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
       gtag('config', 'G-T7L8XCEG0S');
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=2" />
+    <link rel="stylesheet" href="assets/styles.css?v=3" />
 
     <style>
       /* Page-specific layout refinements for the main dashboard */
@@ -653,6 +653,21 @@
           aria-label="Proportion of indicators by score band"></div>
       </section>
 
+      <section
+        class="top-threats"
+        data-top-threats-section
+        hidden
+        aria-labelledby="top-threats-heading"
+      >
+        <div class="section-heading">
+          <h2 id="top-threats-heading" class="panel-title">🔥 Top threats right now</h2>
+          <p class="panel-subtitle">
+            The highest-scoring, most cross-source-confirmed indicators from the latest run.
+          </p>
+        </div>
+        <div class="top-threats-grid" data-top-threats></div>
+      </section>
+
       <main class="dashboard-main">
         <section
           id="live-preview"
@@ -1021,6 +1036,6 @@
       </section>
     </div>
 
-    <script defer src="assets/dashboard.js?v=2"></script>
+    <script defer src="assets/dashboard.js?v=3"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
Adds a **"Top threats right now"** showcase to the dashboard — the KEVIntel-style above-the-fold view the site was missing. Previously the dashboard opened with a dense table + preview and no at-a-glance sense of *what's most dangerous*.

The showcase renders the **top 6 indicators**, ranked by score → cross-source corroboration → recency, as cards:
- Colour-banded **score badge** (critical/high/medium/low)
- The defanged indicator (monospace, wraps safely)
- A **type** pill, an **"N× confirmed"** badge for multi-source indicators (full source list on hover), a relative **first-seen** time, and the top tags
- Left accent bar + hover lift for presence without clutter
- Responsive grid (auto-fill, single column on phones)

## Implementation notes
- Renders from the **already-loaded dataset** (no extra network request) and refreshes on live data updates.
- **Hides gracefully** for legacy pre-scoring data, so it appears automatically once the next scored collection run lands.
- Assets cache-busted to `?v=3`.

## Verification
Driven in-browser against scored demo data: 6 cards render with correct score ordering (96 → 88 → 84 …), corroboration badges (`4× confirmed`), correct band colours/accents, **zero console errors**, and no horizontal overflow at desktop (4-col) or mobile (stacked) widths.

Front-end only (HTML/CSS/JS) — no Python, tests, or workflows changed.

## Note
The in-app browser pane renders at a reduced scale, so I verified everything via DOM/computed-style inspection rather than a full-page screenshot. If anything looks off aesthetically once it's live on Pages, tell me and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
