### PR TITLE
Recover lost review fixes: valid MISP categories per type, RSS uses high-confidence subset

### DIFF
--- a/swiftioc.py
+++ b/swiftioc.py
@@ -1815,6 +1815,29 @@ MISP_ATTRIBUTE_TYPES = {
     "ja3s": "ja3-fingerprint-md5",
 }
 
+# MISP validates category/type combinations on feed import, so each type
+# needs its own valid category rather than a generic fallback — a TLS
+# fingerprint tagged "Payload delivery" (a hash/file category) can be
+# rejected or silently dropped. Per the MISP attribute vocabulary
+# (https://www.misp-project.org/datamodels/#attribute-types):
+MISP_CATEGORY_BY_TYPE = {
+    "ipv4": "Network activity",
+    "ipv4_cidr": "Network activity",
+    "ipv6": "Network activity",
+    "ipv6_cidr": "Network activity",
+    "domain": "Network activity",
+    "url": "Network activity",
+    "md5": "Payload delivery",
+    "sha1": "Payload delivery",
+    "sha256": "Payload delivery",
+    "sha512": "Payload delivery",
+    "email": "Network activity",
+    "cve": "External analysis",
+    "btc_address": "Financial fraud",
+    "ja3": "Network activity",
+    "ja3s": "Network activity",
+}
+
 
 def write_misp_feed(out_dir: Path, rows: List[Indicator], *, run_ts: str) -> int:
     """Write a MISP-compatible feed: manifest.json + one event JSON.
@@ -1838,7 +1861,7 @@ def write_misp_feed(out_dir: Path, rows: List[Indicator], *, run_ts: str) -> int
             {
                 "uuid": str(uuid.uuid5(STIX_NAMESPACE, f"misp-attr:{r.type}:{r.indicator}")),
                 "type": misp_type,
-                "category": "External analysis" if r.type == "cve" else "Network activity" if misp_type in {"ip-dst", "domain", "url"} else "Payload delivery",
+                "category": MISP_CATEGORY_BY_TYPE.get(r.type, "Payload delivery"),
                 "value": value,
                 "to_ids": misp_type != "vulnerability",
                 "timestamp": str(int((parse_dt(r.last_seen) or now_utc()).timestamp())),
@@ -2243,7 +2266,7 @@ def main() -> int:
         logger.info("MISP feed: %d attributes in %s/misp", misp_count, out_dir)
 
     rss_written = write_rss_feed(
-        out_dir / "feed.xml", rows, site_url=args.site_url, limit=args.rss_limit
+        out_dir / "feed.xml", high_conf, site_url=args.site_url, limit=args.rss_limit
     )
     logger.info("RSS feed: %d items written", rss_written)
 

--- a/tests/test_swiftioc.py
+++ b/tests/test_swiftioc.py
@@ -566,10 +566,12 @@ def test_write_misp_feed_manifest_and_event(tmp_path):
     cve.score = 80
     ja3 = _sample_indicator(indicator="a" * 32, type="ja3")
     ja3.score = 60
+    btc = _sample_indicator(indicator="bc1qtest00000000000000000000000000", type="btc_address")
+    btc.score = 50
 
     out_dir = tmp_path / "misp"
-    count = si.write_misp_feed(out_dir, [ind, cve, ja3], run_ts="2025-01-01T00:00:00Z")
-    assert count == 3
+    count = si.write_misp_feed(out_dir, [ind, cve, ja3, btc], run_ts="2025-01-01T00:00:00Z")
+    assert count == 4
 
     manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
     assert len(manifest) == 1
@@ -578,10 +580,18 @@ def test_write_misp_feed_manifest_and_event(tmp_path):
     assert event["uuid"] == event_uuid
     by_value = {a["value"]: a for a in event["Attribute"]}
     assert by_value["1.2.3.4"]["type"] == "ip-dst"
+    assert by_value["1.2.3.4"]["category"] == "Network activity"
     assert by_value["1.2.3.4"]["to_ids"] is True
     assert by_value["CVE-2025-0001"]["type"] == "vulnerability"
+    assert by_value["CVE-2025-0001"]["category"] == "External analysis"
     assert by_value["CVE-2025-0001"]["to_ids"] is False  # not an observable
+    # Regression: TLS fingerprints and BTC addresses previously fell through
+    # to the generic "Payload delivery" category, which MISP can reject as
+    # an invalid category/type combination on feed import.
     assert by_value["a" * 32]["type"] == "ja3-fingerprint-md5"
+    assert by_value["a" * 32]["category"] == "Network activity"
+    assert by_value["bc1qtest00000000000000000000000000"]["type"] == "btc"
+    assert by_value["bc1qtest00000000000000000000000000"]["category"] == "Financial fraud"
 
 
 def test_write_misp_feed_event_uuid_stable_across_runs(tmp_path):


### PR DESCRIPTION
## Summary
Recovers commit `bd1d6ff`, which addressed two Codex review findings on #64 but **never reached the remote** due to the git-push HTTP 500 failures that night — #64 merged without it.

1. **`MISP_CATEGORY_BY_TYPE`** — the category fallback assigned JA3/JA3S and BTC attributes `Payload delivery`; MISP validates category/type pairs on feed import and can reject those. Explicit per-type mapping now (ja3/ja3s → Network activity, btc → Financial fraud, hashes → Payload delivery, cve → External analysis).
2. **`write_rss_feed` now receives `high_conf`** instead of all rows, so `feed.xml` matches its documented promise (high-confidence subscription feed) and never publishes low-score/single-source noise.

Cherry-picked cleanly onto current main; extended MISP test asserts categories for ip/cve/ja3/btc. 65 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)