### PR TITLE
fix: main lookup box using wrong tiny styling; copy/share dead-ends; SEO gaps

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "public-static-site",
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["-m", "http.server", "8792", "--directory", "public"],
+      "port": 8792
+    }
+  ]
+}

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -158,6 +158,25 @@
     return success;
   };
 
+  // Clipboard access can fail silently in real browsers, not just this test
+  // harness — a background/unfocused tab, a corporate permission policy, or
+  // older Firefox without the async Clipboard API all reject or no-op the
+  // copy. Falling back to window.prompt() (pre-filled + auto-selected) means
+  // "Share view"/"Copy" never dead-ends the user with nothing to act on.
+  const copyOrPrompt = async (text, successMessage, promptLabel) => {
+    let copied = false;
+    try {
+      copied = await copyToClipboard(text);
+    } catch (error) {
+      copied = false;
+    }
+    if (copied) {
+      showToast(successMessage);
+    } else {
+      window.prompt(promptLabel, text);
+    }
+  };
+
   const safeHttpUrl = (value) => {
     const text = normaliseString(value);
     if (!text) return null;
@@ -2095,14 +2114,8 @@
       copy.setAttribute('aria-label', 'Copy indicator ' + (row.indicator || ''));
       copy.addEventListener('click', async () => {
         copy.disabled = true;
-        try {
-          await copyToClipboard(row.indicator);
-          showToast('Indicator copied to clipboard.');
-        } catch (error) {
-          showToast('Could not copy the indicator.');
-        } finally {
-          copy.disabled = false;
-        }
+        await copyOrPrompt(row.indicator, 'Indicator copied to clipboard.', 'Copy this indicator:');
+        copy.disabled = false;
       });
       const toggle = document.createElement('button');
       toggle.type = 'button';
@@ -2580,12 +2593,7 @@
     });
     shareButton?.addEventListener('click', async () => {
       const url = writeUrl({ includeSearch: true });
-      try {
-        await copyToClipboard(url.toString());
-        showToast('Shareable dashboard view copied.');
-      } catch (error) {
-        showToast('Could not copy the dashboard URL.');
-      }
+      await copyOrPrompt(url.toString(), 'Shareable dashboard view copied.', 'Copy this shareable link:');
     });
     refreshButton?.addEventListener('click', () => load({ forceRefresh: true }));
     retryButton?.addEventListener('click', () => load({ forceRefresh: true }));
@@ -2851,12 +2859,7 @@
         };
         actions.appendChild(
           makeAction('Copy indicator', async () => {
-            try {
-              await copyToClipboard(row.indicator);
-              showToast('Indicator copied to clipboard.');
-            } catch (error) {
-              showToast('Could not copy the indicator.');
-            }
+            await copyOrPrompt(row.indicator, 'Indicator copied to clipboard.', 'Copy this indicator:');
           })
         );
         actions.appendChild(
@@ -2867,12 +2870,7 @@
             const url = new URL(window.location.href);
             url.hash = `ioc=${encodeURIComponent(row.indicator)}`;
             window.history.replaceState(null, '', url);
-            try {
-              await copyToClipboard(url.toString());
-              showToast('Shareable IOC lookup copied.');
-            } catch (error) {
-              showToast('Could not copy the lookup URL.');
-            }
+            await copyOrPrompt(url.toString(), 'Shareable IOC lookup copied.', 'Copy this shareable link:');
           })
         );
         if (row.reference) {

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -880,7 +880,13 @@ td.has-bar .cell-bar-value {
   align-items: stretch;
 }
 
-.lookup-input {
+/* input.lookup-input (not just .lookup-input): the base `input[type='search']`
+   rule above is an attribute selector, which outranks a bare class selector
+   on specificity regardless of source order — a class-only selector here
+   silently lost every declaration to it, so the hero lookup box rendered as
+   a cramped 12.48px toolbar-style pill instead of its intended prominent
+   sizing. */
+input.lookup-input {
   flex: 1;
   min-width: 0;
   font-size: 0.85rem;
@@ -894,7 +900,7 @@ td.has-bar .cell-bar-value {
   transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
-.lookup-input:focus-visible {
+input.lookup-input:focus-visible {
   border-color: rgba(96, 165, 250, 0.95);
   box-shadow: var(--focus-ring);
 }
@@ -1941,12 +1947,12 @@ h1.section-title {
   gap: 0.65rem;
 }
 
-.lookup-input,
+input.lookup-input,
 .lookup-form .button-link {
   min-height: 3.35rem;
 }
 
-.lookup-input {
+input.lookup-input {
   padding-inline: 1rem;
   border-color: var(--border-control);
   border-radius: 0.75rem;

--- a/public/index.html
+++ b/public/index.html
@@ -10,13 +10,21 @@
     />
     <meta name="keywords" content="threat intelligence feed, malicious IP list, IOC feed, indicators of compromise, C2 IP blocklist, open source threat intel, STIX feed, free IOC download" />
     <meta name="theme-color" content="#0f172a" />
+    <link rel="canonical" href="https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="SwiftIOC — Free Live IOC Feed" />
     <meta
       property="og:description"
       content="The latest malicious IPs, domains, URLs, and hashes — scored, corroborated across sources, and updated automatically. Free CSV / JSON / STIX downloads."
     />
+    <meta property="og:url" content="https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/" />
     <meta name="twitter:card" content="summary" />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="SwiftIOC — Newest High-Confidence IOCs"
+      href="feed.xml"
+    />
     <!-- Start the data fetch as early as possible: the dashboard feed and the
          run aggregates are the page's real content. -->
     <link rel="preload" href="iocs/dashboard.jsonl" as="fetch" crossorigin="anonymous" />
@@ -38,7 +46,40 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=6" />
+    <link rel="stylesheet" href="assets/styles.css?v=7" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Dataset",
+        "name": "SwiftIOC Threat Intelligence Feed",
+        "description": "Free, open-source, continuously updated feed of scored, cross-source-corroborated indicators of compromise (malicious IPs, domains, URLs, and file hashes) aggregated from CISA KEV, NVD, abuse.ch, Spamhaus, DShield/SANS ISC, and other public threat intelligence sources.",
+        "url": "https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/",
+        "license": "https://opensource.org/licenses/MIT",
+        "isAccessibleForFree": true,
+        "creator": {
+          "@type": "Organization",
+          "name": "SwiftIOC",
+          "url": "https://github.com/PKHarsimran/SwiftIOC-Automated-Threat-Intelligence-Collector"
+        },
+        "distribution": [
+          {
+            "@type": "DataDownload",
+            "encodingFormat": "text/csv",
+            "contentUrl": "https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/iocs/high_confidence.csv"
+          },
+          {
+            "@type": "DataDownload",
+            "encodingFormat": "application/json",
+            "contentUrl": "https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/iocs/latest.json"
+          },
+          {
+            "@type": "DataDownload",
+            "encodingFormat": "application/stix+json",
+            "contentUrl": "https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/iocs/stix2.json"
+          }
+        ]
+      }
+    </script>
   </head>
   <body data-ioc-root=".">
     <a class="skip-link" href="#live-preview">Skip to IOC results</a>
@@ -685,7 +726,7 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=6"></script>
-    <script defer src="assets/dashboard.js?v=6"></script>
+    <script defer src="assets/dashboard-core.js?v=7"></script>
+    <script defer src="assets/dashboard.js?v=7"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Audited the live dashboard (`public/index.html`, `dashboard.js`, `styles.css`) by loading it in a real browser and driving it end-to-end. Found and fixed three real issues, plus a batch of SEO gaps.

### 1. The main "Check an indicator" search box has been mis-styled this whole time

`#ioc-lookup-input` — the single most prominent interactive element on the page — was rendering as a cramped 12.48px toolbar-style pill instead of its intended large input. Root cause: the global reset rule

```css
select, input[type='search'], input[type='text'] { font-size: 0.78rem; ... }
```

is an attribute selector (specificity `0,0,1,1`), which beats a bare class selector like `.lookup-input` (`0,0,1,0`) **regardless of source order**. Neither of `.lookup-input`'s two declaration blocks (desktop + the mobile override) ever actually applied. Fixed by raising specificity to `input.lookup-input` everywhere it's declared.

This also fixes a real mobile bug as a side effect: at 12.48px the box was under iOS Safari's 16px auto-zoom-on-focus threshold — tapping it would zoom the whole page in. It now correctly computes to 16px.

### 2. "Share view" and "Copy" could dead-end with nothing to act on

Clicking Share/Copy sometimes just showed "Could not copy the ___" with no way to actually get the text. I reproduced this live — not a test-harness fluke, a genuine `NotAllowedError: Document is not focused` from the Clipboard API, the same class of failure real users hit from a background tab, a corporate clipboard permission policy, or older Firefox without the async Clipboard API. Added a shared `copyOrPrompt()` fallback (used by all four copy/share call sites) that falls back to `window.prompt()` pre-filled with the text on failure, so the action never leaves the user stuck.

### 3. SEO gaps for a site that explicitly markets itself around discoverability

Missing `<link rel="canonical">`, `og:url`, an RSS autodiscovery `<link>` (the site already publishes `feed.xml`, just never advertised it), and any structured data. Added a `Dataset` JSON-LD block describing the feed and its CSV/JSON/STIX exports.

### Housekeeping

- Bumped the `?v=` cache-busting query on all three static assets — otherwise users with a cached `dashboard.js`/`styles.css` wouldn't get any of this until their cache expired.
- Added `.claude/launch.json` so `public/` can be previewed locally with a static server (used to do this audit; leaving it for future sessions).

## Testing

- Live-loaded the dashboard in a real browser and drove it end-to-end via DOM/computed-style inspection and simulated interaction: search, sort, facet filters (type/source/tag/score-band/age-band), clear-filters, row-detail expand, and the copy/share flows (including a mocked clipboard-rejection path to prove the `window.prompt()` fallback actually fires with the right text).
- Confirmed the lookup-box fix computes correctly at both desktop and mobile (375px) viewports, on a clean server process (ruled out a local dev-cache false negative along the way).
- Existing `public/assets/dashboard-core.test.js` Node test suite (10 tests) — unaffected file, still passes unchanged.
- **Screenshot/visual capture was unavailable this session** (a Browser-pane tool/infrastructure issue — reproduced even on `about:blank` and a brand-new tab, unrelated to this page's code) — every fix was verified through the DOM/computed-style/network layer instead of pixels. Flagging this explicitly rather than claiming a visual review that didn't happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)