### PR TITLE
fix: URLhaus column bug; promote confirmed-malware artifacts; representative dashboard

### DIFF
--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -1368,8 +1368,15 @@
         if (typeof diag.duplicates_removed === 'number') {
           stats.duplicatesRemoved = diag.duplicates_removed;
         }
-        if (diag.counts && typeof diag.counts === 'object') {
-          stats.activeSources = Object.keys(diag.counts).length;
+        // Prefer stored_counts (post-dedup/retention contribution to the
+        // shipped feed) over counts (raw pre-dedup fetch totals, which can
+        // exceed the feed size). Fall back to counts for older run.json.
+        const sourceCounts =
+          diag.stored_counts && typeof diag.stored_counts === 'object'
+            ? diag.stored_counts
+            : diag.counts;
+        if (sourceCounts && typeof sourceCounts === 'object') {
+          stats.activeSources = Object.keys(sourceCounts).length;
         }
         if (diag.type_counts && typeof diag.type_counts === 'object') {
           stats.indicatorTypes = Object.keys(diag.type_counts).length;
@@ -1389,7 +1396,7 @@
         diag,
         fetchedAt: Date.now(),
         sourcesTable:
-          countsObjectToRows(diag?.counts, 'Source') ||
+          countsObjectToRows(diag?.stored_counts || diag?.counts, 'Source') ||
           tableAggregators.toSourceRows(),
         typesTable:
           countsObjectToRows(diag?.type_counts, 'Type') ||

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=7" />
+    <link rel="stylesheet" href="assets/styles.css?v=8" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -726,7 +726,7 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=7"></script>
-    <script defer src="assets/dashboard.js?v=7"></script>
+    <script defer src="assets/dashboard-core.js?v=8"></script>
+    <script defer src="assets/dashboard.js?v=8"></script>
   </body>
 </html>

--- a/swiftioc/cli.py
+++ b/swiftioc/cli.py
@@ -322,6 +322,17 @@ def main() -> int:
         "low": sum(1 for s in scores if s < 40),
     }
     corroborated_total = sum(1 for r in rows if source_count(r) >= 2)
+    # Per-source contribution to the STORED feed (post-dedup/expiry/retention),
+    # so the dashboard's "Sources" table reflects what actually shipped rather
+    # than raw pre-dedup fetch counts (which could show a single source at
+    # 15,000 inside a 10,000-row feed). A merged multi-source row counts once
+    # per contributing source.
+    stored_counts: Dict[str, int] = {}
+    for r in rows:
+        for s in (p.strip() for p in r.source.split(",")):
+            if s:
+                stored_counts[s] = stored_counts.get(s, 0) + 1
+    stored_counts = dict(sorted(stored_counts.items(), key=lambda kv: kv[1], reverse=True))
     diag = {
         "window_hours": args.window_hours,
         "total": len(rows),
@@ -344,6 +355,7 @@ def main() -> int:
         "high_confidence_total": len(high_conf),
         "high_confidence_score": args.high_confidence_score,
         "counts": counts,
+        "stored_counts": stored_counts,
         "type_counts": {k: v for k, v in type_totals},
         "tag_counts": {k: v for k, v in top_tags(rows, 25)},
         "fetch_metrics": get_fetch_metrics(),

--- a/swiftioc/parsers.py
+++ b/swiftioc/parsers.py
@@ -228,10 +228,14 @@ def fetch_urlhaus_csv(url: str, ref_url: str, source: str, ws: datetime, *, stat
         if not row or row[0].startswith("#"):
             continue
         try:
+            # URLhaus CSV columns: id,dateadded,url,url_status,last_online,
+            # threat,tags,urlhaus_link,reporter. row[4] is a *timestamp*
+            # (last_online), NOT the threat — threat is row[5], tags row[6].
             dateadded = parse_dt(row[1])
             url_val = row[2]
             url_status = (row[3] if len(row) > 3 else "").lower()
-            threat = row[4] if len(row) > 4 else ""
+            threat = row[5] if len(row) > 5 else ""
+            feed_tags = row[6] if len(row) > 6 else ""
         except Exception:
             continue
         if status_filter != "any" and url_status != status_filter:
@@ -239,13 +243,14 @@ def fetch_urlhaus_csv(url: str, ref_url: str, source: str, ws: datetime, *, stat
         if dateadded and dateadded < ws:
             continue
         t = classify(url_val) or "url"
+        tag_list = ["malware", threat] + [s.strip() for s in feed_tags.split(",")]
         out.append(
             Indicator(
                 indicator=defang_min(url_val), type=t, source=source,
                 first_seen=iso(dateadded or now), last_seen=iso(now),
-                confidence="medium", tlp="CLEAR",
-                tags=",".join(filter(None, ["malware", threat])),
-                reference=ref_url or "", context=f"URLhaus: {threat}",
+                confidence="high", tlp="CLEAR",
+                tags=",".join(dict.fromkeys(filter(None, tag_list))),
+                reference=ref_url or "", context=f"URLhaus: {threat or 'malware URL'}",
             )
         )
     return out
@@ -302,7 +307,11 @@ def fetch_malwarebazaar_csv(
             Indicator(
                 indicator=sha256.lower(), type="sha256", source=source,
                 first_seen=iso(first_seen or now), last_seen=iso(now),
-                confidence="medium", tlp="CLEAR",
+                # A confirmed malware-sample hash from MalwareBazaar is a
+                # high-confidence, directly block-ready artifact — not a
+                # medium-confidence heuristic. Keeping it "medium" floored it
+                # below retention's cut and evicted scarce hash IOCs.
+                confidence="high", tlp="CLEAR",
                 tags=",".join(filter(None, ["malware", sig])),
                 reference=ref_url or "", context=f"MalwareBazaar: {sig}",
             )
@@ -476,7 +485,10 @@ def _fetch_sslbl_ja3(
                 source=source,
                 first_seen=iso(first_seen or now),
                 last_seen=iso(now),
-                confidence="medium",
+                # SSLBL only lists fingerprints tied to confirmed malware C2 —
+                # a high-confidence artifact, promoted so scarce JA3 IOCs
+                # aren't pruned below retention's cut.
+                confidence="high",
                 tlp="CLEAR",
                 tags=",".join(filter(None, ["sslbl", "tls", "fingerprint", desc])),
                 reference=ref_url or "",

--- a/swiftioc/writers.py
+++ b/swiftioc/writers.py
@@ -88,13 +88,40 @@ def write_dashboard_feed(path: Path, rows: List[Indicator], *, limit: int = 1000
 
     The full latest.jsonl can run to many megabytes, which every dashboard
     visitor would otherwise download (and which overflows localStorage, so it
-    can't even be cached client-side). This trims to the top ``limit`` rows by
-    (score, corroboration, recency) and drops fields the dashboard never
-    renders, cutting the payload by ~98%. Global stats come from run.json.
+    can't even be cached client-side). This trims to ``limit`` rows and drops
+    fields the dashboard never renders, cutting the payload by ~98%. Global
+    stats come from run.json.
+
+    The sample is *stratified by type* before the global fill: a naive global
+    top-N-by-score excluded whole categories (e.g. IPs, which decay below the
+    fixed-80 CVE/hash band) so the flagship "browse" table showed zero IPs
+    despite IPs being the largest slice of the feed. Each present type gets a
+    guaranteed floor of slots (highest-scoring first), then any remaining
+    budget is filled globally by score.
     """
-    ranked = sorted(
-        rows, key=lambda r: (r.score, source_count(r), r.last_seen, r.indicator), reverse=True
-    )[:limit]
+    def key(r: Indicator) -> tuple:
+        return (r.score, source_count(r), r.first_seen, r.indicator)
+
+    by_type: Dict[str, List[Indicator]] = {}
+    for r in rows:
+        by_type.setdefault(r.type, []).append(r)
+    for group in by_type.values():
+        group.sort(key=key, reverse=True)
+
+    chosen: Dict[tuple, Indicator] = {}
+    if by_type:
+        # Guaranteed per-type floor so no category is invisible, capped at
+        # each type's actual size.
+        floor = max(1, limit // (len(by_type) * 3))
+        for group in by_type.values():
+            for r in group[:floor]:
+                chosen[r.key()] = r
+    # Fill the rest globally by score.
+    for r in sorted(rows, key=key, reverse=True):
+        if len(chosen) >= limit:
+            break
+        chosen.setdefault(r.key(), r)
+    ranked = sorted(chosen.values(), key=key, reverse=True)[:limit]
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as f:
         for r in ranked:

--- a/tests/test_swiftioc.py
+++ b/tests/test_swiftioc.py
@@ -212,9 +212,14 @@ def test_changelog_is_capped(tmp_path):
 
 # ------------------------- parsers (offline) ----------------------------------
 def test_urlhaus_parser(monkeypatch):
+    # Real URLhaus CSV columns: id,dateadded,url,url_status,last_online,
+    # threat,tags,urlhaus_link,reporter. Regression: the parser used to read
+    # row[4] (last_online — a timestamp) as the threat, polluting threat/tags
+    # with dates. threat is row[5], tags row[6].
     csv_payload = (
-        "# id,dateadded,url,url_status,threat\n"
-        '"1","2025-01-01 00:00:00","http://bad.example.com/x","online","malware_download"\n'
+        "# id,dateadded,url,url_status,last_online,threat,tags,urlhaus_link,reporter\n"
+        '"1","2025-01-01 00:00:00","http://bad.example.com/x","online",'
+        '"2025-01-02 03:04:05","malware_download","elf,mips,Mozi","https://urlhaus.abuse.ch/url/1/","rep"\n'
     )
     monkeypatch.setattr(si, "http_get", lambda *a, **k: csv_payload)
     ws = si.now_utc().replace(year=2000)
@@ -222,6 +227,12 @@ def test_urlhaus_parser(monkeypatch):
     assert len(out) == 1
     assert out[0].type == "url"
     assert out[0].indicator.startswith("hxxp://")  # defanged
+    tags = out[0].tags.split(",")
+    assert "malware_download" in tags
+    assert "Mozi" in tags  # feed tags carried through
+    assert "2025-01-02 03:04:05" not in out[0].tags  # timestamp not leaked
+    assert out[0].context == "URLhaus: malware_download"  # threat, not a date
+    assert out[0].confidence == "high"
 
 
 def test_spamhaus_drop_parser(monkeypatch):
@@ -713,6 +724,30 @@ def test_write_dashboard_feed_trims_and_ranks(tmp_path):
     }
 
 
+def test_write_dashboard_feed_stratifies_by_type(tmp_path):
+    # Regression: a pure global top-N-by-score dropped whole categories from
+    # the browse preview (e.g. all IPs, which score below the fixed-80
+    # CVE/hash band). Every present type must get at least one slot so the
+    # flagship table isn't missing a category entirely.
+    rows = []
+    for i in range(50):  # 50 high-scoring CVEs dominate the global top-N
+        r = _sample_indicator(indicator=f"CVE-2025-{1000 + i}", type="cve")
+        r.score = 80
+        rows.append(r)
+    for i in range(50):  # 50 lower-scoring IPs that a global cut would drop
+        r = _sample_indicator(indicator=f"10.0.{i}.1", type="ipv4")
+        r.score = 30
+        rows.append(r)
+
+    out = tmp_path / "dashboard.jsonl"
+    written = si.write_dashboard_feed(out, rows, limit=20)
+    lines = [json.loads(line) for line in out.read_text(encoding="utf-8").splitlines()]
+    types = {r["type"] for r in lines}
+    assert written == 20
+    assert "ipv4" in types  # would be absent under a pure global top-N
+    assert "cve" in types
+
+
 def test_write_misp_feed_manifest_and_event(tmp_path):
     ind = _sample_indicator(indicator="1.2.3.4", type="ipv4", source="a,b")
     ind.score = 90
@@ -1048,6 +1083,25 @@ def test_sslbl_ja3_column_order(monkeypatch):
     assert out[0].type == "ja3"
     assert out[0].indicator == "b386946a5a44d1ddcc843bc75336dfce"
     assert "Dridex" in out[0].tags
+    # SSLBL only lists confirmed-malware C2 fingerprints — high confidence so
+    # these scarce IOCs aren't pruned below retention's cut.
+    assert out[0].confidence == "high"
+
+
+def test_malwarebazaar_hash_is_high_confidence(monkeypatch):
+    # Parser reads sha256 from row[3] and signature from row[8].
+    sha = "a" * 64
+    payload = (
+        "# comment banner\n"
+        '"2025-01-01 00:00:00","md5x","sha1x","' + sha + '","reporter",'
+        '"sample.exe","exe","application/x-dosexec","AgentTesla"\n'
+    )
+    monkeypatch.setattr(si, "http_get", lambda *a, **k: payload)
+    out = si.fetch_malwarebazaar_csv("http://x", "ref", "mb", si.now_utc().replace(year=2000))
+    assert len(out) == 1
+    assert out[0].type == "sha256" and out[0].indicator == sha
+    # A confirmed malware-sample hash is directly block-ready — high confidence.
+    assert out[0].confidence == "high"
 
 
 def test_nvd_parser_requests_recent_window(monkeypatch):


### PR DESCRIPTION
## Summary

From a full multi-agent audit of **what we collect vs. what the frontend shows**. Four verified fixes so the feed curates the right IOCs and the dashboard shows them honestly. Every fix was live-verified against a full 16-feed collection, not just unit-tested.

### 1. URLhaus parser read the wrong CSV columns (data integrity)
Real columns: `id,dateadded,url,url_status,last_online,threat,tags,link,reporter`. `row[4]` is **`last_online` — a timestamp**, not the threat. The parser used it as `threat`, so every URLhaus row's `threat`/`tags` were polluted with dates (which then accumulated unbounded in `tags` through the persist-feed merge-union). Now reads `threat=row[5]`, `tags=row[6]`, and carries the feed's own tags through. Verified live: tags are now `KongTuke,malware,malware_download,threatfox,ua-ps` with zero timestamps.

### 2. Confirmed-malware artifacts were hardcoded `medium` → evicted by retention
MalwareBazaar sample hashes and SSLBL JA3 fingerprints were `confidence="medium"` (base 60), which floored them below the top-10k retention cut — so the scarcest, most directly block-ready IOCs were heavily pruned from the published feed. A confirmed malware-sample hash / confirmed-C2 JA3 is high-confidence by definition. Promoted to `high`. Verified live: **hashes in the feed went from ~60 to ~885 (all high), JA3 from 0 to 97.**

### 3. Dashboard browse table showed 0 IPs (frontend misrepresentation)
`dashboard.jsonl` (the top-1000 the browse table loads first) was a pure global top-N-by-score, which excluded whole categories — the flagship "Live preview" showed **zero IPs** despite IPs being the largest slice of the feed. `write_dashboard_feed` now stratifies by type (per-type floor, then global fill). Verified live: dashboard now shows all 9 types including IPs.

### 4. Sources table showed pre-dedup counts (frontend accuracy)
It read run.json `counts` (raw pre-dedup fetch totals — e.g. one source at 15,000 inside a 10,000-row feed). `cli.py` now emits `stored_counts` (post-dedup/retention contribution to the shipped feed) and the dashboard prefers it, falling back to `counts` for older data. Verified live: max single-source count is now 1,846, not 15,000.

## Testing
- `ruff` clean · `pytest -q` all pass (added 3 regression tests + hardened the URLhaus test, whose old fabricated 5-column header had masked the bug) · `--self-test` pass
- **Live 16-feed end-to-end run** confirming all four fixes with real data
- `dashboard-core.js` Node suite (10 tests) unaffected, still green
- Bumped `?v=` asset cache-bust so the dashboard.js change reaches cached users

## Not in this PR (audit backlog, worth follow-ups)
The audit also flagged, and I deliberately deferred as each needs its own judgment: scoring's corroboration cap vs. the medium→high gap, a first_seen freshness term for decay, down-weighting IPsum as an aggregate in corroboration, wiring Feodo's aggressive list (needs last_online-based decay), and adding phishing-domain sources. Happy to take these next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)