### PR TITLE
Fix MalwareBazaar hash column and repair retained hash types

### DIFF
--- a/swiftioc/parsers.py
+++ b/swiftioc/parsers.py
@@ -32,6 +32,7 @@ from .http_client import choose_ua, ensure_text, logger
 from .models import (
     DATE_FIELD_RE,
     JA3_RE,
+    SHA256_RE,
     TAGS_FIELD_RE,
     Indicator,
     classify,
@@ -283,24 +284,21 @@ def fetch_malwarebazaar_csv(
             raise
     out: List[Indicator] = []
     now = now_utc()
-    for row in csv.reader(io.StringIO(text)):
-        if not row or row[0].startswith("#"):
+    # Export columns: first_seen_utc, sha256_hash, md5_hash, sha1_hash,
+    # reporter, file_name, file_type_guess, mime_type, signature, ...
+    # Spaces precede quoted fields in the live export; skipinitialspace
+    # keeps commas in quoted filenames from shifting subsequent columns.
+    for row in csv.reader(io.StringIO(text), skipinitialspace=True):
+        if len(row) < 2 or row[0].strip().startswith("#"):
             continue
-        try:
-            first_seen = parse_dt(row[0].strip())
-            sha256 = (row[3] if len(row) > 3 else "").strip().strip('"')
-            sig_raw = ""
-            if len(row) > 8:
-                sig_raw = row[8]
-            elif len(row) > 7:
-                sig_raw = row[7]
-            sig = sig_raw.strip().strip('"')
-            if sig.lower() in {"", "n/a", "na", "none"}:
-                sig = ""
-        except Exception:
+        first_seen = parse_dt(row[0].strip())
+        sha256 = row[1].strip()
+        if not SHA256_RE.fullmatch(sha256):
             continue
-        if not sha256:
-            continue
+        # Column 7 is MIME type, never a fallback malware signature.
+        sig = row[8].strip() if len(row) > 8 else ""
+        if sig.lower() in {"", "n/a", "na", "none"}:
+            sig = ""
         if first_seen and first_seen < ws:
             continue
         out.append(

--- a/swiftioc/scoring.py
+++ b/swiftioc/scoring.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from .fp import is_false_positive
-from .models import Indicator, merge_conf, now_utc, parse_dt
+from .models import Indicator, classify, merge_conf, now_utc, parse_dt
 
 
 # ---------------- scoring: corroboration + age decay ----------------
@@ -122,7 +122,9 @@ def load_previous_feed(path: Path) -> List[Indicator]:
     Tolerant of missing files, malformed lines, and schema drift (unknown
     keys are ignored; rows missing required fields are skipped). Entries that
     the current false-positive rules would reject are dropped on load, so an
-    improved FP list retroactively cleans the carried-forward feed.
+    improved FP list retroactively cleans the carried-forward feed. File
+    hashes are validated and reclassified to repair legacy type mismatches
+    (notably MalwareBazaar SHA-1 values previously labeled as SHA-256).
     """
     if not path.exists():
         return []
@@ -142,6 +144,14 @@ def load_previous_feed(path: Path) -> List[Indicator]:
             ind = Indicator(**{k: v for k, v in data.items() if k in field_names})
         except TypeError:
             continue
+        if ind.type in {"md5", "sha1", "sha256", "sha512"}:
+            if not isinstance(ind.indicator, str):
+                continue
+            actual_type = classify(ind.indicator)
+            if actual_type not in {"md5", "sha1", "sha256", "sha512"}:
+                continue
+            ind.type = actual_type
+            ind.indicator = ind.indicator.strip().lower()
         if is_false_positive(ind.type, ind.indicator):
             continue
         out.append(ind)
@@ -159,6 +169,7 @@ def merge_with_previous(current: List[Indicator], previous: List[Indicator]) -> 
     Returns (merged, carried_forward).
     """
     uniq: Dict[Tuple[str, str], Indicator] = {i.key(): i for i in current}
+    current_keys = set(uniq)
     carried = 0
     for prev in previous:
         k = prev.key()
@@ -176,9 +187,16 @@ def merge_with_previous(current: List[Indicator], previous: List[Indicator]) -> 
         merged_sources = set(filter(None, cur.source.split(","))) | set(filter(None, prev.source.split(",")))
         cur.source = ",".join(sorted(merged_sources))
         cur.confidence = merge_conf(cur.confidence, prev.confidence)
-        # Re-observed this run: one more sighting on top of the accumulated
-        # history. max() guards against a malformed/reset previous count.
-        cur.sightings = max(prev.sightings, 1) + 1
+        if k in current_keys:
+            # Multiple legacy rows can converge after hash-type repair.
+            # Count this run once, retaining the largest historical count.
+            cur.sightings = max(cur.sightings, max(prev.sightings, 1) + 1)
+        else:
+            # Duplicate previous-only rows are not a fresh observation.
+            p_last = parse_dt(prev.last_seen)
+            c_last = parse_dt(cur.last_seen)
+            if p_last and (c_last is None or p_last > c_last):
+                cur.last_seen = prev.last_seen
+            cur.sightings = max(cur.sightings, prev.sightings, 1)
     merged = sorted(uniq.values(), key=lambda r: (r.type, r.indicator, r.source))
     return merged, carried
-

--- a/tests/test_malwarebazaar.py
+++ b/tests/test_malwarebazaar.py
@@ -1,0 +1,163 @@
+"""Regression coverage for issue #82 using MalwareBazaar's export schema."""
+import csv
+import io
+import json
+from dataclasses import asdict
+from datetime import datetime, timezone
+
+import pytest
+import requests
+
+import swiftioc as si
+
+
+SHA256 = "a" * 64
+SHA1 = "05714d2ee45e7f1b669a7ce9799ed81793235a30"
+WINDOW = datetime(2026, 9, 1, tzinfo=timezone.utc)
+
+
+def export_row(sha256=SHA256, signature="Mirai", date="2026-09-02 15:43:45"):
+    # Match the live export's comma-space delimiters and quoted fields.
+    fields = [date, sha256, "b" * 32, SHA1, "reporter",
+              'sample, "quoted".exe', "exe", "application/x-dosexec"]
+    if signature is not None:
+        fields.append(signature)
+    return ", ".join('"' + value.replace('"', '""') + '"' for value in fields) + "\n"
+
+
+def parse(monkeypatch, payload):
+    monkeypatch.setattr(si, "http_get", lambda *a, **k: payload)
+    return si.fetch_malwarebazaar_csv("https://feed.invalid", "ref", "mb", WINDOW)
+
+
+def test_real_column_order_and_quoted_filename(monkeypatch, tmp_path):
+    payload = (
+        '# MalwareBazaar export\n'
+        '# "first_seen_utc","sha256_hash","md5_hash","sha1_hash"\n'
+        + export_row(sha256=SHA256.upper())
+    )
+    rows = parse(monkeypatch, payload)
+    assert len(rows) == 1
+    ind = rows[0]
+    assert (ind.indicator, ind.type) == (SHA256, "sha256")
+    assert ind.first_seen == "2026-09-02T15:43:45Z"
+    assert ind.tags == "malware,Mirai"
+    assert ind.context == "MalwareBazaar: Mirai"
+    assert ind.confidence == "high"
+    csv_path = tmp_path / "latest.csv"
+    si.write_csv(csv_path, rows)
+    record = next(csv.DictReader(io.StringIO(csv_path.read_text())))
+    assert (record["indicator"], record["type"]) == (SHA256, "sha256")
+
+
+@pytest.mark.parametrize("value", ["", "none", "n/a", SHA1, "b" * 32, "g" * 64, "a" * 63, "a" * 65])
+def test_rejects_invalid_sha256_without_using_other_hash_columns(monkeypatch, value):
+    assert parse(monkeypatch, export_row(sha256=value)) == []
+
+
+@pytest.mark.parametrize("signature", [None, "", "n/a", "NA", "None"])
+def test_absent_signature_does_not_become_mime_type(monkeypatch, signature):
+    rows = parse(monkeypatch, export_row(signature=signature))
+    assert len(rows) == 1
+    assert rows[0].tags == "malware"
+    assert rows[0].context == "MalwareBazaar: "
+
+
+def test_skips_old_rows_headers_and_short_rows(monkeypatch):
+    payload = (
+        '\n# comment\nfirst_seen_utc,sha256_hash,md5_hash,sha1_hash\nshort\n'
+        + export_row(date="2026-08-31 23:59:59")
+        + export_row(date="2026-09-01 00:00:00")
+    )
+    rows = parse(monkeypatch, payload)
+    assert len(rows) == 1
+    assert rows[0].first_seen == "2026-09-01T00:00:00Z"
+
+
+def test_fallback_uses_same_validated_parser(monkeypatch):
+    calls = []
+
+    def get(url, **kwargs):
+        calls.append(url)
+        if url == "primary":
+            response = requests.Response()
+            response.status_code = 404
+            raise requests.HTTPError(response=response)
+        return export_row()
+
+    monkeypatch.setattr(si, "http_get", get)
+    rows = si.fetch_malwarebazaar_csv("primary", "ref", "mb", WINDOW, fallback_url="fallback")
+    assert calls == ["primary", "fallback"]
+    assert [(r.type, r.indicator) for r in rows] == [("sha256", SHA256)]
+
+
+def legacy_record(value, kind="sha256"):
+    return {
+        "indicator": value, "type": kind, "source": "malwarebazaar_recent",
+        "first_seen": "2026-09-02T15:43:45Z", "last_seen": "2026-09-04T09:13:44Z",
+        "confidence": "high", "tlp": "CLEAR", "tags": "malware,Mirai",
+        "reference": "https://bazaar.abuse.ch/", "context": "MalwareBazaar: Mirai",
+        "score": 80, "sightings": 3,
+    }
+
+
+def test_previous_feed_repairs_issue_82_and_preserves_history(tmp_path):
+    path = tmp_path / "latest.jsonl"
+    original = legacy_record(SHA1)
+    path.write_text(json.dumps(original) + "\n")
+    rows = si.load_previous_feed(path)
+    assert len(rows) == 1
+    assert asdict(rows[0]) == {**original, "type": "sha1"}
+    # Repair is idempotent and keeps old observations without inventing SHA256.
+    path.write_text(json.dumps(asdict(rows[0])) + "\n")
+    assert si.load_previous_feed(path) == rows
+    merged, carried = si.merge_with_previous([], rows)
+    assert carried == 1
+    assert merged == rows
+    stix_path = tmp_path / "stix.json"
+    si.write_stix(stix_path, rows)
+    bundle = json.loads(stix_path.read_text())
+    patterns = [obj["pattern"] for obj in bundle["objects"] if obj["type"] == "indicator"]
+    assert len(patterns) == 1
+    assert "SHA-1" in patterns[0] and SHA1 in patterns[0]
+    assert "SHA-256" not in patterns[0]
+
+
+def test_previous_feed_drops_invalid_hashes_and_keeps_fingerprints(tmp_path):
+    path = tmp_path / "latest.jsonl"
+    records = [
+        legacy_record("none"), legacy_record("g" * 64), legacy_record(None),
+        legacy_record(SHA256), legacy_record("b" * 32, "md5"),
+        legacy_record("c" * 32, "ja3"), legacy_record("d" * 32, "ja3s"),
+    ]
+    path.write_text("".join(json.dumps(row) + "\n" for row in records))
+    rows = si.load_previous_feed(path)
+    assert [(r.type, r.indicator) for r in rows] == [
+        ("sha256", SHA256), ("md5", "b" * 32), ("ja3", "c" * 32), ("ja3s", "d" * 32),
+    ]
+
+
+@pytest.mark.parametrize("fresh", [False, True])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_repaired_duplicate_hashes_merge_without_extra_sightings(tmp_path, fresh, reverse):
+    legacy = legacy_record(SHA1)
+    existing = {
+        **legacy_record(SHA1, "sha1"), "source": "other",
+        "first_seen": "2026-09-01T00:00:00Z",
+        "last_seen": "2026-09-05T00:00:00Z", "sightings": 7,
+    }
+    records = [legacy, existing]
+    if reverse:
+        records.reverse()
+    path = tmp_path / "latest.jsonl"
+    path.write_text("".join(json.dumps(r) + "\n" for r in records))
+    current = [si.Indicator(**{
+        **existing, "last_seen": "2026-09-07T00:00:00Z", "sightings": 1,
+    })] if fresh else []
+    merged, carried = si.merge_with_previous(current, si.load_previous_feed(path))
+    assert len(merged) == 1
+    assert carried == (0 if fresh else 1)
+    assert merged[0].first_seen == existing["first_seen"]
+    assert merged[0].last_seen == ("2026-09-07T00:00:00Z" if fresh else existing["last_seen"])
+    assert merged[0].sightings == (8 if fresh else 7)
+    assert merged[0].source == "malwarebazaar_recent,other"

--- a/tests/test_swiftioc.py
+++ b/tests/test_swiftioc.py
@@ -1089,11 +1089,11 @@ def test_sslbl_ja3_column_order(monkeypatch):
 
 
 def test_malwarebazaar_hash_is_high_confidence(monkeypatch):
-    # Parser reads sha256 from row[3] and signature from row[8].
+    # MalwareBazaar columns: first_seen_utc, sha256_hash, md5_hash, sha1_hash.
     sha = "a" * 64
     payload = (
         "# comment banner\n"
-        '"2025-01-01 00:00:00","md5x","sha1x","' + sha + '","reporter",'
+        f'"2025-01-01 00:00:00","{sha}","{"b" * 32}","{"c" * 40}","reporter",'
         '"sample.exe","exe","application/x-dosexec","AgentTesla"\n'
     )
     monkeypatch.setattr(si, "http_get", lambda *a, **k: payload)


### PR DESCRIPTION
Correct CSV parsing and validate SHA-256 values. Repair retained hash types and preserve duplicate observation history.

Fixes #82

<!-- Thanks for contributing to SwiftIOC! -->

## Summary
<!-- What does this PR change, and why? -->

## Type of change
- [x] Bug fix
- [x] New feed parser / source
- [x] New feature or enhancement
- [x] Docs / tooling / CI
- [x] Refactor (no behavior change)

## Checklist
- [x] `ruff check .` passes
- [x] `pyright` passes
- [x] `python -m swiftioc --self-test` passes
- [x] `pytest -q` passes
- [x] Added/updated tests for the change (offline; network monkeypatched)
- [x] Updated docs (`README.md` / `sources.example.yml`) if behavior or config changed

## Notes for reviewers
<!-- Anything specific to look at, trade-offs, follow-ups. -->
