### PR TITLE
Fix review findings and dashboard export links

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Run `python -m swiftioc --help` for the full list of switches. Highlights:
 | `--grace-on-404 name…` | Treat HTTP 404 for listed sources as a non-fatal empty result. |
 | `--fail-on-empty name…` | Fail the run if any listed sources return zero indicators. |
 | `--fail-if-stale name=N` | Fail when the newest indicator from `name` is older than `N` hours. |
+| `--warn-if-volume-drop name=N` | Warn when a source returns at least `N` percent fewer rows than the prior run. |
 | `--save-raw-dir PATH` | Persist raw feed responses for later inspection. |
 | `--diag-json PATH` | Write diagnostics JSON (defaults to `<out-dir>/diagnostics/run.json`). |
 | `--report PATH` | Write Markdown run report (defaults to `<out-dir>/diagnostics/REPORT.md`). |

--- a/index.html
+++ b/index.html
@@ -302,8 +302,7 @@
               class="button-link secondary"
               href="https://github.com/PKHarsimran/SwiftIOC-Automated-Threat-Intelligence-Collector"
               >View repo</a
-            >
-            <a class="button-link ghost" href="README.md">README</a>
+            <a class="button-link ghost" href="https://github.com/PKHarsimran/SwiftIOC-Automated-Threat-Intelligence-Collector#readme">README</a>
           </div>
         </article>
         <article class="cardlet">

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -156,4 +156,9 @@ test('dashboard markup keeps IDs and labelled controls consistent', () => {
       html.indexOf('src="assets/dashboard.js'),
     'Pure helpers must load before the dashboard controller'
   );
+  assert.equal(
+    /<\/a>\s*>\s*<a\b/.test(html),
+    false,
+    'Export links must not render stray greater-than characters'
+  );
 });

--- a/public/index.html
+++ b/public/index.html
@@ -667,7 +667,6 @@
               download
               title="Only score ≥80 or indicators confirmed by 2+ sources — block-ready"
               >★ High-confidence CSV</a
-            >
             <a
               class="button-link exports-highlight"
               href="iocs/high_confidence.jsonl"
@@ -677,42 +676,36 @@
               download
               title="Only score ≥80 or indicators confirmed by 2+ sources — block-ready"
               >★ High-confidence JSONL</a
-            >
             <a
               class="button-link"
               href="iocs/latest.csv"
               rel="nofollow"
               download
               >CSV</a
-            >
             <a
               class="button-link"
               href="iocs/latest.tsv"
               rel="nofollow"
               download
               >TSV</a
-            >
             <a
               class="button-link"
               href="iocs/latest.json"
               rel="nofollow"
               download
               >JSON</a
-            >
             <a
               class="button-link"
               href="iocs/latest.jsonl"
               rel="nofollow"
               download
               >JSONL</a
-            >
             <a
               class="button-link"
               href="iocs/stix2.json"
               rel="nofollow"
               download
               >STIX 2.1 bundle</a
-            >
           </div>
           <p class="panel-footnote">
             The ★ high-confidence feeds contain only indicators scoring ≥80 or

--- a/scripts/ioc_timeline.py
+++ b/scripts/ioc_timeline.py
@@ -66,8 +66,15 @@ def lookup(db_path: Path, indicator: str) -> Optional[dict]:
         row = con.execute("SELECT * FROM indicators WHERE indicator = ?", (variant,)).fetchone()
         if row:
             break
+    if row:
+        # Preserve the collection schedule so --at can check the last actual
+        # feed snapshot at or before a requested day. first_run/last_run alone
+        # cannot distinguish continuous presence from an IOC that disappeared
+        # and later reappeared.
+        result = dict(row)
+        result["_run_timestamps"] = [r[0] for r in con.execute("SELECT run_ts FROM runs ORDER BY run_ts")]
     con.close()
-    return dict(row) if row else None
+    return result if row else None
 
 
 def render(row: dict, at: Optional[datetime]) -> str:
@@ -87,11 +94,15 @@ def render(row: dict, at: Optional[datetime]) -> str:
         # date (e.g. first_run_ts at 14:00 UTC) still counts as present.
         at_start_ts = int(at.replace(tzinfo=timezone.utc).timestamp())
         at_end_ts = at_start_ts + 86399
-        prior = [(ts, sc) for ts, sc in series if ts <= at_end_ts]
-        if row["first_run_ts"] <= at_end_ts and at_start_ts <= row["last_run_ts"] and prior:
-            lines.append(f"On {at.date()}: ✔ present, score {prior[-1][1]}")
+        runs = row.get("_run_timestamps", [])
+        snapshot = max((ts for ts in runs if ts <= at_end_ts), default=None)
+        scores_by_run = dict(series)
+        if snapshot is not None and snapshot in scores_by_run:
+            lines.append(f"On {at.date()}: ✔ present, score {scores_by_run[snapshot]}")
         elif at_end_ts < row["first_run_ts"]:
             lines.append(f"On {at.date()}: ✘ not yet reported (first appeared {_fmt_ts(row['first_run_ts'])[:10]})")
+        elif snapshot is None or (series and snapshot < series[0][0]):
+            lines.append(f"On {at.date()}: ? presence is outside the indexed score history")
         else:
             lines.append(f"On {at.date()}: ✘ not present in the feed at that time")
     return "\n".join(lines)

--- a/swiftioc/cli.py
+++ b/swiftioc/cli.py
@@ -121,6 +121,8 @@ def main() -> int:
     ap.add_argument("--source-window", action="append", default=[], help="Override lookback per source: name=HOURS")
     ap.add_argument("--fail-on-empty", nargs="*", default=None, help="Fail if any listed sources return zero")
     ap.add_argument("--fail-if-stale", action="append", default=[], help="Fail if source newest first_seen older than HOURS: name=HOURS")
+    ap.add_argument("--warn-if-volume-drop", action="append", default=[],
+                    help="Warn if a source's count drops by PERCENT versus the previous run: name=PERCENT")
     ap.add_argument("--grace-on-404", action="append", default=[], help="Treat 404 on these sources as empty but non-fatal: name")
 
     # logging / diag
@@ -198,6 +200,17 @@ def main() -> int:
     with args.sources.open("r", encoding="utf-8") as f:
         cfg = yaml.safe_load(f) or {}
 
+    out_dir: Path = args.out_dir
+    previous_counts: Dict[str, int] = {}
+    previous_diag = out_dir / "diagnostics" / "run.json"
+    if previous_diag.exists():
+        try:
+            raw_previous = json.loads(previous_diag.read_text(encoding="utf-8"))
+            if isinstance(raw_previous, dict) and isinstance(raw_previous.get("counts"), dict):
+                previous_counts = {str(k): int(v) for k, v in raw_previous["counts"].items()}
+        except (OSError, ValueError, TypeError):
+            logger.warning("Could not read previous source counts from %s", previous_diag)
+
     # collect
     rows, counts, stats = collect_from_yaml(
         cfg,
@@ -216,8 +229,6 @@ def main() -> int:
     # retention) below, and duplicates_removed must reflect cross-source
     # dedup alone, not get conflated with those later mutations.
     deduped_count = len(rows)
-
-    out_dir: Path = args.out_dir
 
     # Living feed: merge the previously published feed so indicators persist
     # across runs. Re-observed entries refresh (score resets to full); entries
@@ -312,6 +323,16 @@ def main() -> int:
     raw_total = stats.get("raw_total", deduped_count)
     duplicates_removed = max(raw_total - deduped_count, 0)
     empty_sources = sorted([name for name, count in counts.items() if count == 0])
+    volume_drops = []
+    for name, threshold in parse_name_int_pairs(args.warn_if_volume_drop, "--warn-if-volume-drop").items():
+        previous = previous_counts.get(name)
+        current = counts.get(name)
+        if previous is None or previous <= 0 or current is None:
+            continue
+        drop_pct = round((previous - current) * 100 / previous, 1)
+        if drop_pct >= threshold:
+            volume_drops.append({"source": name, "previous": previous, "current": current, "drop_percent": drop_pct})
+            logger.warning("%s volume dropped %.1f%% (%d -> %d)", name, drop_pct, previous, current)
     scores = [r.score for r in rows]
     # Full-feed aggregates the dashboard renders without downloading the whole
     # feed: score bands, corroboration count, and top tags.
@@ -362,6 +383,7 @@ def main() -> int:
         "earliest_first_seen": earliest,
         "newest_first_seen": latest,
         "empty_sources": empty_sources,
+        "volume_drops": volume_drops,
         "failures": stats.get("failures", []),
         "version": 3,
         "ts": run_ts,
@@ -419,6 +441,8 @@ def main() -> int:
             issues.append(f"- ⚠️ **{src}**: {err}")
         for src in empty_sources:
             issues.append(f"- ⚠️ **{src}** returned zero indicators")
+        for drop in volume_drops:
+            issues.append(f"- ⚠️ **{drop['source']}** volume dropped {drop['drop_percent']}% ({drop['previous']} → {drop['current']})")
         if issues:
             report_lines.extend(["## Issues", "", *issues, ""])
         args.report.write_text("\n".join(report_lines), encoding="utf-8")
@@ -465,6 +489,8 @@ def main() -> int:
         issues_summary.append(f"- ⚠️ **{src}**: {err}")
     for src in empty_sources:
         issues_summary.append(f"- ⚠️ **{src}** returned zero indicators")
+    for drop in volume_drops:
+        issues_summary.append(f"- ⚠️ **{drop['source']}** volume dropped {drop['drop_percent']}% ({drop['previous']} → {drop['current']})")
     if issues_summary:
         summary_lines.extend(["", "#### Issues", "", *issues_summary])
     summary_lines.append("")

--- a/swiftioc/http_client.py
+++ b/swiftioc/http_client.py
@@ -188,8 +188,11 @@ def http_get(url: str, *, name: str, kind: str = "text", timeout: int = 20) -> s
         _validate_redirect_target(current_url)
         r = s.get(current_url, headers=headers, timeout=timeout, stream=True, allow_redirects=False)
 
-    dt = time.perf_counter() - t0
     raw = _read_capped(r, MAX_RESPONSE_BYTES)
+    # Measure the complete fetch, including streamed response-body download.
+    # Recording the time immediately after receiving headers made a slow
+    # large feed look artificially fast in the dashboard diagnostics.
+    dt = time.perf_counter() - t0
     # Record telemetry before raise_for_status so failed statuses are captured.
     _FETCH_METRICS[name] = {
         "ms": round(dt * 1000),
@@ -228,4 +231,3 @@ def load_feedparser() -> Any:
         return _FEEDPARSER
     except ModuleNotFoundError as e:
         raise SystemExit("Missing 'feedparser'. Install it or run with --skip-rss") from e
-

--- a/swiftioc/http_client.py
+++ b/swiftioc/http_client.py
@@ -43,8 +43,9 @@ _SESSION: Optional[requests.Session] = None
 _FEEDPARSER = None
 _SAVE_RAW_DIR: Optional[Path] = None
 HTTP_DEBUG = False
-# Per-fetch telemetry ({name: {ms, bytes, status}}) filled by http_get, drained
-# into diagnostics so the dashboard can show a feed-health / latency panel.
+# Per-source telemetry ({name: {ms, bytes, status, requests}}) filled by
+# http_get, drained into diagnostics so the dashboard can show a feed-health /
+# latency panel. A parser may make several paginated or fallback requests.
 _FETCH_METRICS: Dict[str, Dict[str, Any]] = {}
 
 
@@ -194,10 +195,12 @@ def http_get(url: str, *, name: str, kind: str = "text", timeout: int = 20) -> s
     # large feed look artificially fast in the dashboard diagnostics.
     dt = time.perf_counter() - t0
     # Record telemetry before raise_for_status so failed statuses are captured.
+    previous = _FETCH_METRICS.get(name, {})
     _FETCH_METRICS[name] = {
-        "ms": round(dt * 1000),
-        "bytes": len(raw),
+        "ms": previous.get("ms", 0) + round(dt * 1000),
+        "bytes": previous.get("bytes", 0) + len(raw),
         "status": r.status_code,
+        "requests": previous.get("requests", 0) + 1,
     }
     if HTTP_DEBUG:
         logger.debug("HTTP %s %.2fs %s [%s]", r.status_code, dt, current_url, name)

--- a/swiftioc/http_client.py
+++ b/swiftioc/http_client.py
@@ -141,6 +141,13 @@ def _validate_redirect_target(url: str) -> None:
         raise requests.exceptions.RequestException(f"Refusing redirect to a non-public host: {url!r}")
 
 
+def _origin(url: str) -> tuple[str, str, int]:
+    """Return a normalized HTTP origin for redirect credential handling."""
+    parsed = urlparse(url)
+    default_port = 443 if parsed.scheme.lower() == "https" else 80
+    return (parsed.scheme.lower(), (parsed.hostname or "").lower(), parsed.port or default_port)
+
+
 def _read_capped(r: requests.Response, max_bytes: int) -> bytes:
     """Read a streamed response body, aborting before it exceeds max_bytes.
 
@@ -188,7 +195,15 @@ def http_get(
         hops += 1
         if not location or hops > MAX_REDIRECTS:
             raise requests.exceptions.TooManyRedirects(f"Exceeded {MAX_REDIRECTS} redirects fetching {url!r}")
-        current_url = urljoin(current_url, location)
+        next_url = urljoin(current_url, location)
+        if _origin(next_url) != _origin(current_url):
+            # A redirect is untrusted until its target is validated. Never
+            # forward credentials (for example an NVD API key) to another
+            # origin, even when that host resolves to a public address.
+            for key in list(request_headers):
+                if key.lower() in {"apikey", "authorization", "cookie", "proxy-authorization"}:
+                    del request_headers[key]
+        current_url = next_url
         _validate_redirect_target(current_url)
         r = s.get(current_url, headers=request_headers, timeout=timeout, stream=True, allow_redirects=False)
 

--- a/swiftioc/http_client.py
+++ b/swiftioc/http_client.py
@@ -171,13 +171,16 @@ def _read_capped(r: requests.Response, max_bytes: int) -> bytes:
     return b"".join(chunks)
 
 
-def http_get(url: str, *, name: str, kind: str = "text", timeout: int = 20) -> str | bytes:
+def http_get(
+    url: str, *, name: str, kind: str = "text", timeout: int = 20, headers: Optional[Dict[str, str]] = None,
+) -> str | bytes:
     s = ensure_session()
-    headers = choose_ua()
+    request_headers = choose_ua()
+    request_headers.update(headers or {})
     t0 = time.perf_counter()
 
     current_url = url
-    r = s.get(current_url, headers=headers, timeout=timeout, stream=True, allow_redirects=False)
+    r = s.get(current_url, headers=request_headers, timeout=timeout, stream=True, allow_redirects=False)
     hops = 0
     while r.is_redirect or r.is_permanent_redirect:
         location = r.headers.get("Location")
@@ -187,7 +190,7 @@ def http_get(url: str, *, name: str, kind: str = "text", timeout: int = 20) -> s
             raise requests.exceptions.TooManyRedirects(f"Exceeded {MAX_REDIRECTS} redirects fetching {url!r}")
         current_url = urljoin(current_url, location)
         _validate_redirect_target(current_url)
-        r = s.get(current_url, headers=headers, timeout=timeout, stream=True, allow_redirects=False)
+        r = s.get(current_url, headers=request_headers, timeout=timeout, stream=True, allow_redirects=False)
 
     raw = _read_capped(r, MAX_RESPONSE_BYTES)
     # Measure the complete fetch, including streamed response-body download.

--- a/swiftioc/parsers.py
+++ b/swiftioc/parsers.py
@@ -167,8 +167,8 @@ def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime, *, api_k
                 next_url = page_url._replace(query=urlencode(page_query, doseq=True)).geturl()
                 try:
                     next_data = json.loads(ensure_text(_pkg.http_get(next_url, name=source, headers=request_headers)))
-                except json.JSONDecodeError:
-                    logger.warning("%s returned invalid JSON at startIndex %d", source, next_index)
+                except (json.JSONDecodeError, requests.exceptions.RequestException) as exc:
+                    logger.warning("%s pagination stopped at startIndex %d: %s", source, next_index, exc)
                     break
                 next_records = next_data.get("vulnerabilities") if isinstance(next_data, dict) else None
                 if not isinstance(next_records, list):

--- a/swiftioc/parsers.py
+++ b/swiftioc/parsers.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import csv
 import io
 import json
+import os
 import re
 from datetime import datetime, timedelta
 from importlib import import_module
@@ -28,7 +29,7 @@ import requests
 import swiftioc as _pkg
 
 from .extract import extract_indicators_from_text
-from .http_client import choose_ua, ensure_text, logger
+from .http_client import ensure_text, logger
 from .models import (
     DATE_FIELD_RE,
     JA3_RE,
@@ -114,7 +115,7 @@ def fetch_cisa_kev(url: str, ref_url: str, source: str, ws: datetime) -> List[In
 
 
 @register_parser("nvd", "nist_nvd", "nist_nvd_recent")
-def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime) -> List[Indicator]:
+def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime, *, api_key_env: Optional[str] = None) -> List[Indicator]:
     now = now_utc()
     # The NVD 2.0 API returns the *oldest* CVEs first (startIndex 0), so an
     # unfiltered query yields 1999-era CVEs that the lookback window then drops,
@@ -136,7 +137,9 @@ def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime) -> List[
             query["lastModStartDate"] = [start.strftime(fmt)]
             query["lastModEndDate"] = [now.strftime(fmt)]
             url = parsed._replace(query=urlencode(query, doseq=True)).geturl()
-    text = ensure_text(_pkg.http_get(url, name=source))
+    api_key = os.environ.get(api_key_env) if api_key_env else None
+    request_headers = {"apiKey": api_key} if api_key else None
+    text = ensure_text(_pkg.http_get(url, name=source, headers=request_headers))
     try:
         data = json.loads(text)
     except json.JSONDecodeError:
@@ -163,7 +166,7 @@ def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime) -> List[
                 page_query["startIndex"] = [str(next_index)]
                 next_url = page_url._replace(query=urlencode(page_query, doseq=True)).geturl()
                 try:
-                    next_data = json.loads(ensure_text(_pkg.http_get(next_url, name=source)))
+                    next_data = json.loads(ensure_text(_pkg.http_get(next_url, name=source, headers=request_headers)))
                 except json.JSONDecodeError:
                     logger.warning("%s returned invalid JSON at startIndex %d", source, next_index)
                     break
@@ -762,7 +765,11 @@ def fetch_rss(url: str, ref_url: str, source: str, ws: datetime, *, per_entry_ca
             return []
         raise
     try:
-        feed = fp.parse(url, request_headers=choose_ua())
+        # Fetch through the shared client so RSS gets the same retry, response
+        # cap, redirect validation, raw capture, and diagnostics as every
+        # other source. Passing a URL directly to feedparser bypassed all of
+        # those controls.
+        feed = fp.parse(ensure_text(_pkg.http_get(url, name=source)))
     except Exception as exc:
         logger.warning("RSS parse failed for %s: %s", source, exc)
         return []

--- a/swiftioc/parsers.py
+++ b/swiftioc/parsers.py
@@ -127,7 +127,8 @@ def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime) -> List[
     # Match the NVD host by parsed hostname, not a substring of the whole URL,
     # so a lookalike like nvd.nist.gov.evil.com or ?x=nvd.nist.gov can't trip it.
     # Use endswith so the real config host (services.nvd.nist.gov) still matches.
-    if host == "nvd.nist.gov" or host.endswith(".nvd.nist.gov"):
+    is_nvd_host = host == "nvd.nist.gov" or host.endswith(".nvd.nist.gov")
+    if is_nvd_host:
         query = parse_qs(parsed.query)
         if not any(k in query for k in ("lastModStartDate", "pubStartDate")):
             fmt = "%Y-%m-%dT%H:%M:%S.000"
@@ -144,6 +145,35 @@ def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime) -> List[
     records = data.get("vulnerabilities") if isinstance(data, dict) else None
     if not isinstance(records, list):
         return []
+    # NVD uses offset pagination. The configured page size is 200 but busy
+    # modification windows routinely exceed that, so only consuming the first
+    # page silently dropped valid CVEs. Keep every page from this bounded time
+    # query while preserving the configured resultsPerPage value.
+    if is_nvd_host:
+        page_url = urlparse(url)
+        page_query = parse_qs(page_url.query)
+        try:
+            start_index = int(page_query.get("startIndex", ["0"])[0])
+            page_size = int(data.get("resultsPerPage") or page_query.get("resultsPerPage", [len(records)])[0])
+            total_results = int(data.get("totalResults") or len(records))
+        except (TypeError, ValueError):
+            start_index, page_size, total_results = 0, len(records), len(records)
+        if page_size > 0:
+            for next_index in range(start_index + page_size, start_index + total_results, page_size):
+                page_query["startIndex"] = [str(next_index)]
+                next_url = page_url._replace(query=urlencode(page_query, doseq=True)).geturl()
+                try:
+                    next_data = json.loads(ensure_text(_pkg.http_get(next_url, name=source)))
+                except json.JSONDecodeError:
+                    logger.warning("%s returned invalid JSON at startIndex %d", source, next_index)
+                    break
+                next_records = next_data.get("vulnerabilities") if isinstance(next_data, dict) else None
+                if not isinstance(next_records, list):
+                    logger.warning("%s returned no vulnerability list at startIndex %d", source, next_index)
+                    break
+                records.extend(next_records)
+                if not next_records:
+                    break
     out: List[Indicator] = []
 
     def extract_severity(entry: Dict[str, Any]) -> Optional[str]:
@@ -951,4 +981,3 @@ def fetch_universal(
         )
 
     return list(uniq.values())
-

--- a/swiftioc/parsers.py
+++ b/swiftioc/parsers.py
@@ -368,7 +368,16 @@ def fetch_threatfox_export_json(url: str, ref_url: str, source: str, ws: datetim
         if itype == "ip:port":
             # "1.2.3.4:443" -> classify the bare address; keeps the value
             # comparable with other IP feeds so corroboration can match.
-            host = ioc.rsplit(":", 1)[0]
+            # IPv6 endpoints are RFC 3986 bracketed ("[2001:db8::1]:443").
+            # Splitting that form leaves brackets around the address, which
+            # classify() correctly rejects; unwrap it before validation.
+            if ioc.startswith("["):
+                end = ioc.find("]")
+                if end == -1 or not ioc[end + 1 :].startswith(":"):
+                    continue
+                host = ioc[1:end]
+            else:
+                host = ioc.rsplit(":", 1)[0]
             t = classify(host)
             if t not in {"ipv4", "ipv6"}:
                 continue
@@ -424,6 +433,10 @@ def fetch_feodo_ipblocklist(
             ip = row[1].strip()
             family = row[5].strip() if len(row) > 5 else ""
         except Exception:
+            continue
+        # A malformed value was previously emitted with a hardcoded ipv4
+        # type, bypassing the normal false-positive/validation path.
+        if classify(ip) != "ipv4":
             continue
 
         if not disable_window and seen and seen < ws:
@@ -938,5 +951,4 @@ def fetch_universal(
         )
 
     return list(uniq.values())
-
 

--- a/swiftioc/writers.py
+++ b/swiftioc/writers.py
@@ -43,6 +43,9 @@ def _atomic_text_writer(path: Path, *, newline: Optional[str] = None):
     path.parent.mkdir(parents=True, exist_ok=True)
     handle = tempfile.NamedTemporaryFile("w", encoding="utf-8", newline=newline, dir=path.parent, delete=False)
     temp_path = Path(handle.name)
+    # NamedTemporaryFile defaults to 0600; preserve public read access after
+    # os.replace for deployments where the static server runs as another user.
+    os.chmod(temp_path, 0o644)
     try:
         with handle:
             yield handle
@@ -471,4 +474,3 @@ def write_changelog(path: Path, counts: Dict[str, int], total: int, *, max_entri
     entries = entries[-max_entries:]
     body = "# Changelog\n\n" + "\n\n".join(entries) + "\n"
     path.write_text(body, encoding="utf-8")
-

--- a/swiftioc/writers.py
+++ b/swiftioc/writers.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 
 import csv
 import json
+import os
 import re
+import tempfile
 import uuid
+from contextlib import contextmanager
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -27,6 +30,28 @@ STIX_HASH_NAMES = {"md5": "MD5", "sha1": "SHA-1", "sha256": "SHA-256", "sha512":
 
 # ---------------- writers ----------------
 CSV_HEADER = ["indicator", "type", "source", "first_seen", "last_seen", "confidence", "score", "sightings", "tlp", "tags", "reference", "context"]
+
+
+@contextmanager
+def _atomic_text_writer(path: Path, *, newline: Optional[str] = None):
+    """Write a complete replacement beside ``path`` before publishing it.
+
+    Consumers polling a public feed must see either the previous complete file
+    or the new complete file, never a partially-written export from a stopped
+    collection run.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = tempfile.NamedTemporaryFile("w", encoding="utf-8", newline=newline, dir=path.parent, delete=False)
+    temp_path = Path(handle.name)
+    try:
+        with handle:
+            yield handle
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
 
 
 _CSV_FORMULA_TRIGGERS = ("=", "+", "-", "@", "\t", "\r")
@@ -53,8 +78,7 @@ def _csv_row(r: Indicator) -> List[Any]:
 
 
 def write_csv(path: Path, rows: List[Indicator]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", newline="", encoding="utf-8") as f:
+    with _atomic_text_writer(path, newline="") as f:
         w = csv.writer(f)
         w.writerow(CSV_HEADER)
         for r in rows:
@@ -62,8 +86,7 @@ def write_csv(path: Path, rows: List[Indicator]) -> None:
 
 
 def write_tsv(path: Path, rows: List[Indicator]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", newline="", encoding="utf-8") as f:
+    with _atomic_text_writer(path, newline="") as f:
         w = csv.writer(f, delimiter="\t")
         w.writerow(CSV_HEADER)
         for r in rows:
@@ -71,14 +94,12 @@ def write_tsv(path: Path, rows: List[Indicator]) -> None:
 
 
 def write_json(path: Path, rows: List[Indicator]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
+    with _atomic_text_writer(path) as f:
         json.dump([asdict(r) for r in rows], f, ensure_ascii=False, indent=2)
 
 
 def write_jsonl(path: Path, rows: List[Indicator]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
+    with _atomic_text_writer(path) as f:
         for r in rows:
             f.write(json.dumps(asdict(r), ensure_ascii=False) + "\n")
 
@@ -122,8 +143,7 @@ def write_dashboard_feed(path: Path, rows: List[Indicator], *, limit: int = 1000
             break
         chosen.setdefault(r.key(), r)
     ranked = sorted(chosen.values(), key=key, reverse=True)[:limit]
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
+    with _atomic_text_writer(path) as f:
         for r in ranked:
             f.write(
                 json.dumps(
@@ -173,7 +193,6 @@ def _stix_pattern(itype: str, indicator: str) -> Optional[str]:
 
 
 def write_stix(path: Path, rows: List[Indicator]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
     now = iso(now_utc())
     common = {
         "created": now,
@@ -225,7 +244,7 @@ def write_stix(path: Path, rows: List[Indicator]) -> None:
             "x_swiftioc_source": r.source, "x_swiftioc_tlp": r.tlp, "x_swiftioc_reference": r.reference,
         })
     bundle = {"type": "bundle", "id": f"bundle--{uuid.uuid5(STIX_NAMESPACE, 'bundle:' + now)}", "objects": objects}
-    with path.open("w", encoding="utf-8") as f:
+    with _atomic_text_writer(path) as f:
         json.dump(bundle, f, ensure_ascii=False, indent=2)
 
 
@@ -452,5 +471,4 @@ def write_changelog(path: Path, counts: Dict[str, int], total: int, *, max_entri
     entries = entries[-max_entries:]
     body = "# Changelog\n\n" + "\n\n".join(entries) + "\n"
     path.write_text(body, encoding="utf-8")
-
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,3 +139,21 @@ def test_cli_main_duplicates_removed_not_conflated_with_persist_feed_growth(tmp_
     assert diag["total_before_dedup"] == 5
     assert diag["duplicates_removed"] == 2
     assert diag["total"] == 13
+
+
+def test_cli_warns_on_large_source_volume_drop(tmp_path, monkeypatch):
+    sources = tmp_path / "sources.yml"
+    _write_sources_yml(sources)
+    out_dir = tmp_path / "out"
+    (out_dir / "diagnostics").mkdir(parents=True)
+    (out_dir / "diagnostics" / "run.json").write_text(
+        json.dumps({"counts": {"src_a": 10, "src_b": 2}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(si, "http_get", _fake_http_get)
+    rc = _run_main(monkeypatch, [
+        "swiftioc", "--sources", str(sources), "--out-dir", str(out_dir), "--skip-rss",
+        "--warn-if-volume-drop", "src_a=50",
+    ])
+    assert rc == 0
+    diag = json.loads((out_dir / "diagnostics" / "run.json").read_text(encoding="utf-8"))
+    assert diag["volume_drops"] == [{"source": "src_a", "previous": 10, "current": 3, "drop_percent": 70.0}]

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -69,6 +69,20 @@ def test_http_get_returns_body_on_success(monkeypatch):
     assert hc.http_get("http://feed.example/x", name="src") == "hello world"
 
 
+def test_http_get_latency_includes_streamed_body(monkeypatch):
+    clock = [10.0]
+
+    class DelayedResponse(FakeResponse):
+        def iter_content(self, chunk_size=65536):
+            clock[0] += 0.125
+            yield from super().iter_content(chunk_size)
+
+    monkeypatch.setattr(hc.time, "perf_counter", lambda: clock[0])
+    _use_fake_session(monkeypatch, [DelayedResponse(body=b"body")])
+    hc.http_get("http://feed.example/x", name="src")
+    assert hc.get_fetch_metrics()["src"]["ms"] == 125
+
+
 def test_http_get_rejects_oversized_content_length(monkeypatch):
     huge = str(hc.MAX_RESPONSE_BYTES + 1)
     _use_fake_session(monkeypatch, [FakeResponse(headers={"Content-Length": huge}, body=b"x")])

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -130,6 +130,21 @@ def test_http_get_follows_redirect_to_public_host(monkeypatch):
     assert [url for url, _headers in fake.calls] == ["http://feed.example/x", "http://93.184.216.34/final"]
 
 
+def test_http_get_strips_credentials_on_cross_origin_redirect(monkeypatch):
+    fake = _use_fake_session(
+        monkeypatch,
+        [
+            FakeResponse(status_code=302, headers={"Location": "https://93.184.216.34/final"}, is_redirect=True),
+            FakeResponse(body=b"final content"),
+        ],
+    )
+    hc.http_get("https://feed.example/x", name="src", headers={"apiKey": "secret", "Authorization": "Bearer secret"})
+    redirected_headers = fake.calls[1][1]
+    assert "apiKey" not in redirected_headers
+    assert "Authorization" not in redirected_headers
+    assert "User-Agent" in redirected_headers
+
+
 def test_http_get_blocks_redirect_to_link_local_metadata_ip(monkeypatch):
     _use_fake_session(
         monkeypatch,

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -83,6 +83,13 @@ def test_http_get_latency_includes_streamed_body(monkeypatch):
     assert hc.get_fetch_metrics()["src"]["ms"] == 125
 
 
+def test_http_get_aggregates_paginated_source_metrics(monkeypatch):
+    _use_fake_session(monkeypatch, [FakeResponse(body=b"one"), FakeResponse(body=b"twos")])
+    hc.http_get("http://feed.example/one", name="src")
+    hc.http_get("http://feed.example/two", name="src")
+    assert hc.get_fetch_metrics()["src"] == {"ms": 0, "bytes": 7, "status": 200, "requests": 2}
+
+
 def test_http_get_rejects_oversized_content_length(monkeypatch):
     huge = str(hc.MAX_RESPONSE_BYTES + 1)
     _use_fake_session(monkeypatch, [FakeResponse(headers={"Content-Length": huge}, body=b"x")])

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -41,7 +41,7 @@ class FakeSession:
         self.calls = []
 
     def get(self, url, headers=None, timeout=None, stream=None, allow_redirects=None):
-        self.calls.append(url)
+        self.calls.append((url, headers))
         return self._responses.pop(0)
 
 
@@ -90,6 +90,12 @@ def test_http_get_aggregates_paginated_source_metrics(monkeypatch):
     assert hc.get_fetch_metrics()["src"] == {"ms": 0, "bytes": 7, "status": 200, "requests": 2}
 
 
+def test_http_get_allows_parser_specific_headers(monkeypatch):
+    fake = _use_fake_session(monkeypatch, [FakeResponse(body=b"ok")])
+    hc.http_get("http://feed.example/x", name="src", headers={"apiKey": "test-key"})
+    assert fake.calls[0][1]["apiKey"] == "test-key"
+
+
 def test_http_get_rejects_oversized_content_length(monkeypatch):
     huge = str(hc.MAX_RESPONSE_BYTES + 1)
     _use_fake_session(monkeypatch, [FakeResponse(headers={"Content-Length": huge}, body=b"x")])
@@ -121,7 +127,7 @@ def test_http_get_follows_redirect_to_public_host(monkeypatch):
         ],
     )
     assert hc.http_get("http://feed.example/x", name="src") == "final content"
-    assert fake.calls == ["http://feed.example/x", "http://93.184.216.34/final"]
+    assert [url for url, _headers in fake.calls] == ["http://feed.example/x", "http://93.184.216.34/final"]
 
 
 def test_http_get_blocks_redirect_to_link_local_metadata_ip(monkeypatch):

--- a/tests/test_ioc_timeline.py
+++ b/tests/test_ioc_timeline.py
@@ -32,6 +32,9 @@ def _make_index(tmp_path: Path, rows) -> Path:
             PRIMARY KEY (type, indicator))"""
     )
     con.executemany("INSERT INTO indicators VALUES (?,?,?,?,?,?,?,?,?,?)", rows)
+    con.execute("CREATE TABLE runs (run_ts INTEGER PRIMARY KEY, total INTEGER NOT NULL)")
+    run_timestamps = sorted({ts for row in rows for ts, _score in json.loads(row[-1])})
+    con.executemany("INSERT INTO runs VALUES (?, ?)", [(ts, 1) for ts in run_timestamps])
     con.commit()
     con.close()
     return db
@@ -72,6 +75,7 @@ def test_render_point_in_time(tmp_path):
         "run_count": 10, "max_score": 85, "last_score": 85,
         "last_sources": "feodo", "last_tags": "c2",
         "score_series": json.dumps(series),
+        "_run_timestamps": [_ts(2026, 2, 1), _ts(2026, 3, 1)],
     }
     # Before it was first reported.
     out_before = mod.render(row, datetime(2026, 1, 15))
@@ -97,10 +101,25 @@ def test_render_at_treats_first_seen_day_as_present(tmp_path):
         "run_count": 1, "max_score": 70, "last_score": 70,
         "last_sources": "feodo", "last_tags": "c2",
         "score_series": json.dumps(series),
+        "_run_timestamps": [first_seen_ts],
     }
     out = mod.render(row, datetime(2026, 3, 1))
     assert "present, score 70" in out
     assert "not yet reported" not in out
+
+
+def test_render_at_does_not_treat_an_absence_gap_as_presence(tmp_path):
+    mod = _load_timeline()
+    series = [[_ts(2026, 1, 1), 80], [_ts(2026, 3, 1), 70]]
+    row = {
+        "indicator": "1.2.3.4", "type": "ipv4",
+        "first_run_ts": _ts(2026, 1, 1), "last_run_ts": _ts(2026, 3, 1),
+        "run_count": 2, "max_score": 80, "last_score": 70,
+        "last_sources": "feodo", "last_tags": "c2",
+        "score_series": json.dumps(series),
+        "_run_timestamps": [_ts(2026, 1, 1), _ts(2026, 2, 1), _ts(2026, 3, 1)],
+    }
+    assert "not present" in mod.render(row, datetime(2026, 2, 15))
 
 
 def test_sparkline_bounds():

--- a/tests/test_malwarebazaar.py
+++ b/tests/test_malwarebazaar.py
@@ -2,6 +2,7 @@
 import csv
 import io
 import json
+import stat
 from dataclasses import asdict
 from datetime import datetime, timezone
 
@@ -121,6 +122,12 @@ def test_previous_feed_repairs_issue_82_and_preserves_history(tmp_path):
     assert len(patterns) == 1
     assert "SHA-1" in patterns[0] and SHA1 in patterns[0]
     assert "SHA-256" not in patterns[0]
+
+
+def test_atomic_exports_remain_world_readable(tmp_path):
+    path = tmp_path / "latest.jsonl"
+    si.write_jsonl(path, [])
+    assert stat.S_IMODE(path.stat().st_mode) & 0o004
 
 
 def test_previous_feed_drops_invalid_hashes_and_keeps_fingerprints(tmp_path):

--- a/tests/test_swiftioc.py
+++ b/tests/test_swiftioc.py
@@ -394,6 +394,7 @@ def test_rss_parser_extracts_iocs_from_entries(monkeypatch):
         entries = [FakeEntry()]
         feed = type("F", (), {"updated": None})()
 
+    monkeypatch.setattr(si, "http_get", lambda *a, **k: "<rss />")
     monkeypatch.setattr(si, "load_feedparser", lambda: type("M", (), {"parse": staticmethod(lambda *a, **k: FakeFeed())}))
     ws = si.now_utc().replace(year=2000)
     out = si.fetch_rss("http://blog.example.com/feed", "ref", "test_blog", ws)
@@ -407,6 +408,7 @@ def test_rss_parser_handles_parse_failure(monkeypatch):
     def boom(*a, **k):
         raise RuntimeError("network down")
 
+    monkeypatch.setattr(si, "http_get", lambda *a, **k: "<rss />")
     monkeypatch.setattr(si, "load_feedparser", lambda: type("M", (), {"parse": staticmethod(boom)}))
     ws = si.now_utc().replace(year=2000)
     out = si.fetch_rss("http://x", "ref", "test_blog", ws)

--- a/tests/test_swiftioc.py
+++ b/tests/test_swiftioc.py
@@ -1165,6 +1165,32 @@ def test_nvd_parser_keeps_old_cve_recently_modified(monkeypatch):
     assert out[0].first_seen.startswith("2023-03-01")  # true original publish date preserved
 
 
+def test_nvd_parser_fetches_all_result_pages(monkeypatch):
+    now = si.now_utc()
+    calls = []
+
+    def page(cve):
+        return {"cve": {
+            "id": cve, "published": si.iso(now), "lastModified": si.iso(now),
+            "descriptions": [], "metrics": {},
+        }}
+
+    def fake_get(url, *a, **k):
+        from urllib.parse import parse_qs, urlparse
+        calls.append(url)
+        start = int(parse_qs(urlparse(url).query).get("startIndex", ["0"])[0])
+        records = [page("CVE-2026-0001"), page("CVE-2026-0002")] if start == 0 else [page("CVE-2026-0003")]
+        return json.dumps({"totalResults": 3, "resultsPerPage": 2, "startIndex": start, "vulnerabilities": records})
+
+    monkeypatch.setattr(si, "http_get", fake_get)
+    out = si.fetch_nvd_recent(
+        "https://services.nvd.nist.gov/rest/json/cves/2.0/?resultsPerPage=2", "ref", "nvd", now - timedelta(minutes=1),
+    )
+    assert [row.indicator for row in out] == ["CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"]
+    assert len(calls) == 2
+    assert "startIndex=2" in calls[1]
+
+
 def test_threatfox_export_endpoint_shape(monkeypatch):
     # The real export endpoint returns {"<ioc_id>": [entry, ...]} with
     # ioc_value/first_seen_utc/ip:port/md5_hash spellings and comma-string

--- a/tests/test_swiftioc.py
+++ b/tests/test_swiftioc.py
@@ -12,6 +12,7 @@ import uuid
 from datetime import timedelta
 
 import pytest
+import requests
 
 import swiftioc as si
 
@@ -1191,6 +1192,26 @@ def test_nvd_parser_fetches_all_result_pages(monkeypatch):
     assert [row.indicator for row in out] == ["CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"]
     assert len(calls) == 2
     assert "startIndex=2" in calls[1]
+
+
+def test_nvd_parser_keeps_completed_pages_when_later_page_fails(monkeypatch):
+    now = si.now_utc()
+
+    def fake_get(url, *a, **k):
+        from urllib.parse import parse_qs, urlparse
+        start = int(parse_qs(urlparse(url).query).get("startIndex", ["0"])[0])
+        if start:
+            raise requests.exceptions.RequestException("rate limited")
+        return json.dumps({"totalResults": 2, "resultsPerPage": 1, "vulnerabilities": [{"cve": {
+            "id": "CVE-2026-0001", "published": si.iso(now), "lastModified": si.iso(now),
+            "descriptions": [], "metrics": {},
+        }}]})
+
+    monkeypatch.setattr(si, "http_get", fake_get)
+    rows = si.fetch_nvd_recent(
+        "https://services.nvd.nist.gov/rest/json/cves/2.0/?resultsPerPage=1", "ref", "nvd", now - timedelta(minutes=1),
+    )
+    assert [row.indicator for row in rows] == ["CVE-2026-0001"]
 
 
 def test_threatfox_export_endpoint_shape(monkeypatch):

--- a/tests/test_swiftioc.py
+++ b/tests/test_swiftioc.py
@@ -268,6 +268,17 @@ def test_dshield_block_parser_skips_malformed_rows(monkeypatch):
     assert out == []
 
 
+def test_feodo_parser_rejects_malformed_ip_rows(monkeypatch):
+    payload = (
+        "first_seen_utc,dst_ip,dst_port,c2_status,last_online,malware\n"
+        "2026-09-07 00:00:00,not-an-ip,443,online,2026-09-07,Dridex\n"
+        "2026-09-07 00:00:00,192.0.2.44,443,online,2026-09-07,Dridex\n"
+    )
+    monkeypatch.setattr(si, "http_get", lambda *a, **k: payload)
+    out = si.fetch_feodo_ipblocklist("http://x", "ref", "feodo", si.now_utc())
+    assert [(i.type, i.indicator) for i in out] == [("ipv4", "192[.]0[.]2[.]44")]
+
+
 def test_spamhaus_drop_parser_rejects_out_of_range_octets(monkeypatch):
     # Regression: a digit-only regex admitted 999.999.999.999/24 as a valid
     # CIDR; classify() correctly rejects it via ipaddress.
@@ -1194,6 +1205,16 @@ def test_threatfox_export_endpoint_shape(monkeypatch):
     assert si.refang(by_type["ipv4"].indicator) == "203.0.113.9"
     assert by_type["ipv4"].confidence == "medium"
     assert by_type["md5"].confidence == "low"
+
+
+def test_threatfox_ip_port_accepts_bracketed_ipv6(monkeypatch):
+    payload = json.dumps([{
+        "ioc": "[2001:db8::8]:443", "ioc_type": "ip:port",
+        "first_seen": "2026-09-07T00:00:00Z",
+    }])
+    monkeypatch.setattr(si, "http_get", lambda *a, **k: payload)
+    out = si.fetch_threatfox_export_json("http://x", "ref", "tf", si.now_utc().replace(year=2000))
+    assert [(i.type, si.refang(i.indicator)) for i in out] == [("ipv6", "2001:db8::8")]
 
 
 def test_blocklist_txt_plain_ip_feeds(monkeypatch):


### PR DESCRIPTION
Fixes the follow-up review findings from #84 and repairs a few visible site defects.

- Preserve NVD records already fetched when a later page fails or is rate-limited.
- Remove credentials and other sensitive request headers when a redirect changes origin.
- Publish atomic feed replacements with public read permissions.
- Remove stray “>” characters from dashboard export links and repair the landing page README link.

Validation: pytest, Ruff, Pyright, built-in self-test, and dashboard JavaScript tests pass.