### PR TITLE
Fix review findings and dashboard export links

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,8 +302,7 @@
               class="button-link secondary"
               href="https://github.com/PKHarsimran/SwiftIOC-Automated-Threat-Intelligence-Collector"
               >View repo</a
-            >
-            <a class="button-link ghost" href="README.md">README</a>
+            <a class="button-link ghost" href="https://github.com/PKHarsimran/SwiftIOC-Automated-Threat-Intelligence-Collector#readme">README</a>
           </div>
         </article>
         <article class="cardlet">

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -156,4 +156,9 @@ test('dashboard markup keeps IDs and labelled controls consistent', () => {
       html.indexOf('src="assets/dashboard.js'),
     'Pure helpers must load before the dashboard controller'
   );
+  assert.equal(
+    /<\/a>\s*>\s*<a\b/.test(html),
+    false,
+    'Export links must not render stray greater-than characters'
+  );
 });

--- a/public/index.html
+++ b/public/index.html
@@ -667,7 +667,6 @@
               download
               title="Only score ≥80 or indicators confirmed by 2+ sources — block-ready"
               >★ High-confidence CSV</a
-            >
             <a
               class="button-link exports-highlight"
               href="iocs/high_confidence.jsonl"
@@ -677,42 +676,36 @@
               download
               title="Only score ≥80 or indicators confirmed by 2+ sources — block-ready"
               >★ High-confidence JSONL</a
-            >
             <a
               class="button-link"
               href="iocs/latest.csv"
               rel="nofollow"
               download
               >CSV</a
-            >
             <a
               class="button-link"
               href="iocs/latest.tsv"
               rel="nofollow"
               download
               >TSV</a
-            >
             <a
               class="button-link"
               href="iocs/latest.json"
               rel="nofollow"
               download
               >JSON</a
-            >
             <a
               class="button-link"
               href="iocs/latest.jsonl"
               rel="nofollow"
               download
               >JSONL</a
-            >
             <a
               class="button-link"
               href="iocs/stix2.json"
               rel="nofollow"
               download
               >STIX 2.1 bundle</a
-            >
           </div>
           <p class="panel-footnote">
             The ★ high-confidence feeds contain only indicators scoring ≥80 or

--- a/swiftioc/http_client.py
+++ b/swiftioc/http_client.py
@@ -141,6 +141,13 @@ def _validate_redirect_target(url: str) -> None:
         raise requests.exceptions.RequestException(f"Refusing redirect to a non-public host: {url!r}")
 
 
+def _origin(url: str) -> tuple[str, str, int]:
+    """Return a normalized HTTP origin for redirect credential handling."""
+    parsed = urlparse(url)
+    default_port = 443 if parsed.scheme.lower() == "https" else 80
+    return (parsed.scheme.lower(), (parsed.hostname or "").lower(), parsed.port or default_port)
+
+
 def _read_capped(r: requests.Response, max_bytes: int) -> bytes:
     """Read a streamed response body, aborting before it exceeds max_bytes.
 
@@ -188,7 +195,15 @@ def http_get(
         hops += 1
         if not location or hops > MAX_REDIRECTS:
             raise requests.exceptions.TooManyRedirects(f"Exceeded {MAX_REDIRECTS} redirects fetching {url!r}")
-        current_url = urljoin(current_url, location)
+        next_url = urljoin(current_url, location)
+        if _origin(next_url) != _origin(current_url):
+            # A redirect is untrusted until its target is validated. Never
+            # forward credentials (for example an NVD API key) to another
+            # origin, even when that host resolves to a public address.
+            for key in list(request_headers):
+                if key.lower() in {"apikey", "authorization", "cookie", "proxy-authorization"}:
+                    del request_headers[key]
+        current_url = next_url
         _validate_redirect_target(current_url)
         r = s.get(current_url, headers=request_headers, timeout=timeout, stream=True, allow_redirects=False)
 

--- a/swiftioc/parsers.py
+++ b/swiftioc/parsers.py
@@ -167,8 +167,8 @@ def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime, *, api_k
                 next_url = page_url._replace(query=urlencode(page_query, doseq=True)).geturl()
                 try:
                     next_data = json.loads(ensure_text(_pkg.http_get(next_url, name=source, headers=request_headers)))
-                except json.JSONDecodeError:
-                    logger.warning("%s returned invalid JSON at startIndex %d", source, next_index)
+                except (json.JSONDecodeError, requests.exceptions.RequestException) as exc:
+                    logger.warning("%s pagination stopped at startIndex %d: %s", source, next_index, exc)
                     break
                 next_records = next_data.get("vulnerabilities") if isinstance(next_data, dict) else None
                 if not isinstance(next_records, list):

--- a/swiftioc/writers.py
+++ b/swiftioc/writers.py
@@ -43,6 +43,9 @@ def _atomic_text_writer(path: Path, *, newline: Optional[str] = None):
     path.parent.mkdir(parents=True, exist_ok=True)
     handle = tempfile.NamedTemporaryFile("w", encoding="utf-8", newline=newline, dir=path.parent, delete=False)
     temp_path = Path(handle.name)
+    # NamedTemporaryFile defaults to 0600; preserve public read access after
+    # os.replace for deployments where the static server runs as another user.
+    os.chmod(temp_path, 0o644)
     try:
         with handle:
             yield handle
@@ -471,4 +474,3 @@ def write_changelog(path: Path, counts: Dict[str, int], total: int, *, max_entri
     entries = entries[-max_entries:]
     body = "# Changelog\n\n" + "\n\n".join(entries) + "\n"
     path.write_text(body, encoding="utf-8")
-


### PR DESCRIPTION
Addresses the review feedback on #84 and repairs visible dashboard/landing-page defects.

- Keep already collected NVD CVEs if a later page fails or is rate-limited.
- Strip API credentials and other sensitive headers on cross-origin redirects.
- Keep atomic public exports world-readable.
- Remove stray “>” characters from dashboard export links and repair the README link.

Validation: pytest, Ruff, Pyright, built-in self-test, and dashboard JavaScript tests pass.