### PR TITLE
Improve dashboard investigation exports

### DIFF
--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -199,10 +199,10 @@
       types: params.getAll('type').map(lower).filter(Boolean),
       sources: params.getAll('source').map(lower).filter(Boolean),
       tags: params.getAll('tag').map(lower).filter(Boolean),
-      scoreBands: params.getAll('score_band').filter((value) =>
+      scoreBands: params.getAll('score_band').map(lower).filter((value) =>
         ['high', 'elevated', 'moderate', 'aging'].includes(value)
       ),
-      ageBands: params.getAll('age_band').filter((value) =>
+      ageBands: params.getAll('age_band').map(lower).filter((value) =>
         ['day', 'week', 'month', 'older', 'unknown'].includes(value)
       ),
       type: lower(params.get('type')) || 'all',

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -48,6 +48,42 @@
     return one && one !== 'all' ? [one] : [];
   };
 
+  // CSV cells beginning with spreadsheet formula prefixes can execute when a
+  // downloaded investigation file is opened. Prefix them with an apostrophe so
+  // an IOC remains data in Excel, LibreOffice, and similar tools.
+  const csvCell = (value) => {
+    let text = stringValue(value);
+    if (/^[=+\-@]/.test(text)) text = "'" + text;
+    return '"' + text.replace(/"/g, '""') + '"';
+  };
+
+  const rowsToCsv = (rows) => {
+    const columns = [
+      ['indicator', 'Indicator'],
+      ['type', 'Type'],
+      ['score', 'Score'],
+      ['confidence', 'Confidence'],
+      ['source', 'Sources'],
+      ['firstSeen', 'First seen'],
+      ['lastSeen', 'Last seen'],
+      ['tags', 'Tags'],
+      ['reference', 'Reference'],
+      ['context', 'Context'],
+    ];
+    const values = Array.isArray(rows) ? rows : [];
+    return [
+      columns.map(([, label]) => csvCell(label)).join(','),
+      ...values.map((row) => columns.map(([key]) => {
+        const value = key === 'tags' && Array.isArray(row?.tags)
+          ? row.tags.join(', ')
+          : key === 'source' && Array.isArray(row?.sourceList)
+          ? row.sourceList.join(', ')
+          : row?.[key];
+        return csvCell(value);
+      }).join(',')),
+    ].join('\r\n') + '\r\n';
+  };
+
   const scoreBand = (row) => {
     const score = effectiveScore(row);
     if (score >= 80) return 'high';
@@ -156,22 +192,22 @@
 
   const readViewState = (search = '', hash = '') => {
     const params = new URLSearchParams(search);
-    const signal = params.get('signal');
+    const signal = lower(params.get('signal'));
     const score = Number(params.get('score')) || 0;
     const age = params.get('age') || 'all';
     const state = {
-      types: params.getAll('type').filter(Boolean),
-      sources: params.getAll('source').filter(Boolean),
-      tags: params.getAll('tag').filter(Boolean),
+      types: params.getAll('type').map(lower).filter(Boolean),
+      sources: params.getAll('source').map(lower).filter(Boolean),
+      tags: params.getAll('tag').map(lower).filter(Boolean),
       scoreBands: params.getAll('score_band').filter((value) =>
         ['high', 'elevated', 'moderate', 'aging'].includes(value)
       ),
       ageBands: params.getAll('age_band').filter((value) =>
         ['day', 'week', 'month', 'older', 'unknown'].includes(value)
       ),
-      type: params.get('type') || 'all',
-      source: params.get('source') || 'all',
-      tag: params.get('tag') || 'all',
+      type: lower(params.get('type')) || 'all',
+      source: lower(params.get('source')) || 'all',
+      tag: lower(params.get('tag')) || 'all',
       signal: ['all', 'high', 'corroborated', 'new'].includes(signal)
         ? signal
         : 'all',
@@ -236,6 +272,7 @@
     matchesRow,
     readViewState,
     refang,
+    rowsToCsv,
     writeViewUrl,
   };
 });

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -156,6 +156,12 @@ test('normalizes shared filter values and exports spreadsheet-safe CSV', () => {
   assert.match(csv, /"phishing, credential-theft"/);
 });
 
+test('exports an empty CSV with only its header when no rows are supplied', () => {
+  const csv = core.rowsToCsv([]);
+  assert.equal(csv.split('\r\n').filter(Boolean).length, 1);
+  assert.match(csv, /"Indicator"/);
+});
+
 test('dashboard markup keeps IDs and labelled controls consistent', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
   const ids = Array.from(html.matchAll(/\sid="([^"]+)"/g), (match) => match[1]);

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -142,6 +142,20 @@ test('sanitizes unsupported URL-controlled facets', () => {
   assert.equal(state.age, 'all');
 });
 
+test('normalizes shared filter values and exports spreadsheet-safe CSV', () => {
+  const state = core.readViewState('?type=DOMAIN&source=Feed-A&signal=HIGH');
+  assert.deepEqual(state.types, ['domain']);
+  assert.deepEqual(state.sources, ['feed-a']);
+  assert.equal(state.signal, 'high');
+  const csv = core.rowsToCsv([{
+    indicator: '=HYPERLINK("https://example.invalid")',
+    type: 'domain',
+    tags: ['phishing', 'credential-theft'],
+  }]);
+  assert.match(csv, /"'=HYPERLINK\(""https:\/\/example\.invalid""\)"/);
+  assert.match(csv, /"phishing, credential-theft"/);
+});
+
 test('dashboard markup keeps IDs and labelled controls consistent', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
   const ids = Array.from(html.matchAll(/\sid="([^"]+)"/g), (match) => match[1]);
@@ -161,4 +175,5 @@ test('dashboard markup keeps IDs and labelled controls consistent', () => {
     false,
     'Export links must not render stray greater-than characters'
   );
+  assert.match(html, /data-preview-download/);
 });

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -143,10 +143,12 @@ test('sanitizes unsupported URL-controlled facets', () => {
 });
 
 test('normalizes shared filter values and exports spreadsheet-safe CSV', () => {
-  const state = core.readViewState('?type=DOMAIN&source=Feed-A&signal=HIGH');
+  const state = core.readViewState('?type=DOMAIN&source=Feed-A&signal=HIGH&score_band=HIGH&age_band=WEEK');
   assert.deepEqual(state.types, ['domain']);
   assert.deepEqual(state.sources, ['feed-a']);
   assert.equal(state.signal, 'high');
+  assert.deepEqual(state.scoreBands, ['high']);
+  assert.deepEqual(state.ageBands, ['week']);
   const csv = core.rowsToCsv([{
     indicator: '=HYPERLINK("https://example.invalid")',
     type: 'domain',
@@ -182,4 +184,5 @@ test('dashboard markup keeps IDs and labelled controls consistent', () => {
     'Export links must not render stray greater-than characters'
   );
   assert.match(html, /data-preview-download/);
+  assert.match(html, /data-preview-download-note/);
 });

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -1851,6 +1851,7 @@
     const clearButton = qs('[data-preview-clear]', container);
     const shareButton = qs('[data-preview-share]', container);
     const downloadButton = qs('[data-preview-download]', container);
+    const downloadNote = qs('[data-preview-download-note]', container);
     const filterCount = qs('[data-preview-filter-count]', container);
     const refreshButton = qs('[data-preview-refresh]');
     const sortButtons = qsa('[data-preview-sort]', table);
@@ -2345,6 +2346,20 @@
       if (shareButton) shareButton.disabled = !state.rows.length;
       if (downloadButton) {
         downloadButton.disabled = !state.rows.length || !state.matches.length;
+        downloadButton.setAttribute(
+          'aria-label',
+          state.matches.length
+            ? 'Download ' + formatNumber(state.matches.length) + ' matching indicators as CSV'
+            : 'Download matching indicators as CSV'
+        );
+      }
+      if (downloadNote) {
+        downloadNote.hidden = !state.rows.length;
+        downloadNote.textContent = state.matches.length
+          ? formatNumber(state.matches.length) + ' matching indicator' +
+            (state.matches.length === 1 ? '' : 's') +
+            ' currently loaded in the preview.'
+          : 'No matching indicators currently loaded in the preview.';
       }
     };
 
@@ -2600,6 +2615,19 @@
         state.search = '';
         searchInput.value = '';
         apply();
+      }
+    });
+    document.addEventListener('keydown', (event) => {
+      const target = event.target;
+      const isTyping = target instanceof HTMLElement && (
+        target.matches('input, select, textarea, [contenteditable="true"]')
+      );
+      if (event.key === '/' && !isTyping && !event.metaKey && !event.ctrlKey && !event.altKey) {
+        event.preventDefault();
+        searchInput?.focus();
+      }
+      if (event.key === 'Escape' && !isTyping) {
+        facetMenus.forEach((menu) => { menu.open = false; });
       }
     });
     clearButton?.addEventListener('click', () => {

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -2343,7 +2343,9 @@
         filterCount.textContent = String(count);
       }
       if (shareButton) shareButton.disabled = !state.rows.length;
-      if (downloadButton) downloadButton.disabled = !state.matches.length;
+      if (downloadButton) {
+        downloadButton.disabled = !state.rows.length || !state.matches.length;
+      }
     };
 
     const apply = ({ sync = true } = {}) => {
@@ -2500,6 +2502,7 @@
       } catch (error) {
         console.error('Unable to load live preview', error);
         state.rows = [];
+        state.matches = [];
         render([]);
         updateSummary([], []);
         if (summary.meta) summary.meta.hidden = true;

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -204,6 +204,22 @@
     URL.revokeObjectURL(url);
   };
 
+  const downloadCsv = (rows) => {
+    if (!dashboardCore?.rowsToCsv || !rows.length) return false;
+    const blob = new Blob([dashboardCore.rowsToCsv(rows)], {
+      type: 'text/csv;charset=utf-8',
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'swiftioc-matching-indicators.csv';
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+    return true;
+  };
+
   // Compact label for a possibly multi-source row: "feodo +2".
   const primarySourceLabel = (row) => {
     if (!row) return 'unknown';
@@ -1834,6 +1850,7 @@
     const searchInput = qs('[data-preview-search]', container);
     const clearButton = qs('[data-preview-clear]', container);
     const shareButton = qs('[data-preview-share]', container);
+    const downloadButton = qs('[data-preview-download]', container);
     const filterCount = qs('[data-preview-filter-count]', container);
     const refreshButton = qs('[data-preview-refresh]');
     const sortButtons = qsa('[data-preview-sort]', table);
@@ -1877,6 +1894,7 @@
       stats: null,
       sourcePool: 0,
       loading: false,
+      matches: [],
     };
 
     const urlKeys = ['type', 'source', 'tag', 'signal', 'score', 'age', 'rows', 'sort', 'dir'];
@@ -2325,10 +2343,12 @@
         filterCount.textContent = String(count);
       }
       if (shareButton) shareButton.disabled = !state.rows.length;
+      if (downloadButton) downloadButton.disabled = !state.matches.length;
     };
 
     const apply = ({ sync = true } = {}) => {
       const matches = filteredRows().sort(compare);
+      state.matches = matches;
       const displayed = matches.slice(0, state.limit);
       render(displayed);
       updateSummary(matches, displayed);
@@ -2446,6 +2466,7 @@
         refreshButton,
         clearButton,
         shareButton,
+        downloadButton,
       ].forEach((control) => {
         if (control) control.disabled = disabled;
       });
@@ -2492,7 +2513,7 @@
         Object.values(facetRoots).forEach((root) => {
           root.disabled = !hasRows;
         });
-        [signalSelect, sortSelect, searchInput, shareButton]
+        [signalSelect, sortSelect, searchInput, shareButton, downloadButton]
           .forEach((control) => {
             if (control) control.disabled = !hasRows;
           });
@@ -2601,6 +2622,14 @@
     shareButton?.addEventListener('click', async () => {
       const url = writeUrl({ includeSearch: true });
       await copyOrPrompt(url.toString(), 'Shareable dashboard view copied.', 'Copy this shareable link:');
+    });
+    downloadButton?.addEventListener('click', () => {
+      if (downloadCsv(state.matches)) {
+        showToast(
+          'Downloaded ' + formatNumber(state.matches.length) +
+            ' matching indicator' + (state.matches.length === 1 ? '' : 's') + '.'
+        );
+      }
     });
     refreshButton?.addEventListener('click', () => load({ forceRefresh: true }));
     retryButton?.addEventListener('click', () => load({ forceRefresh: true }));

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -2352,6 +2352,13 @@ input.lookup-input {
   font-size: 0.68rem;
 }
 
+.toolbar-export-note {
+  align-self: center;
+  color: #94a3b8;
+  font-size: 0.68rem;
+  line-height: 1.35;
+}
+
 .preview-table-wrapper {
   position: relative;
   min-height: 18rem;

--- a/public/index.html
+++ b/public/index.html
@@ -412,6 +412,9 @@
                 >
                   Download matching CSV
                 </button>
+                <span class="toolbar-export-note" data-preview-download-note>
+                  Exports matching indicators currently loaded in the preview.
+                </span>
               </div>
             </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -403,6 +403,15 @@
                 >
                   Share view
                 </button>
+                <button
+                  type="button"
+                  class="button ghost"
+                  data-preview-download
+                  disabled
+                  title="Download every matching indicator currently loaded in the dashboard preview"
+                >
+                  Download matching CSV
+                </button>
               </div>
             </div>
 


### PR DESCRIPTION
Improve the dashboard workflow for triage and sharing.

- Add **Download matching CSV**, which exports every currently loaded indicator matching the active filters, not only the visible table page.
- Generate CSV safely for spreadsheet users: quote fields and neutralize formula-prefixed IOC values.
- Normalize shared URL filter values so links with mixed-case source/type/tag parameters work consistently.
- Add browser-level regression coverage for the export, URL normalization, and export control markup.

Validation: pytest, Ruff, Pyright, built-in self-test, dashboard JavaScript tests, and `git diff --check` all pass.