### PR TITLE
Add an analyst investigation workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - "swiftioc/**"
       - "scripts/**"
       - "tests/**"
+      - "public/index.html"
+      - "public/assets/**"
       - "sources*.yml"
       - "requirements*.txt"
       - "pyproject.toml"
@@ -36,6 +38,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      - name: Test dashboard JavaScript
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          node --test public/assets/dashboard-core.test.js
+          node --check public/assets/dashboard-core.js
+          node --check public/assets/dashboard.js
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -84,6 +84,53 @@
     ].join('\r\n') + '\r\n';
   };
 
+  const investigationKey = (row) => {
+    const indicator = lower(row?.indicator);
+    if (!indicator) return '';
+    return `${lower(row?.type) || 'unknown'}\u0000${indicator}`;
+  };
+
+  // Treat browser storage as untrusted input. Keep only the fields needed by
+  // the analyst workspace, cap collection size, and discard duplicate or
+  // malformed records before anything is rendered or exported.
+  const normaliseInvestigationRows = (value, limit = 50) => {
+    if (!Array.isArray(value)) return [];
+    const rows = [];
+    const seen = new Set();
+    const cap = Math.max(1, Math.min(Number(limit) || 50, 250));
+    for (const candidate of value) {
+      if (!candidate || typeof candidate !== 'object') continue;
+      const indicator = stringValue(candidate.indicator);
+      if (!indicator || indicator.length > 2048) continue;
+      const row = {
+        indicator,
+        type: stringValue(candidate.type) || 'unknown',
+        confidence: stringValue(candidate.confidence),
+        source: stringValue(candidate.source),
+        sourceList: Array.isArray(candidate.sourceList)
+          ? candidate.sourceList.map(stringValue).filter(Boolean).slice(0, 25)
+          : [],
+        firstSeen: stringValue(candidate.firstSeen),
+        lastSeen: stringValue(candidate.lastSeen),
+        tags: Array.isArray(candidate.tags)
+          ? candidate.tags.map(stringValue).filter(Boolean).slice(0, 50)
+          : [],
+        reference: stringValue(candidate.reference),
+        context: stringValue(candidate.context),
+        tlp: stringValue(candidate.tlp),
+      };
+      if (typeof candidate.score === 'number' && Number.isFinite(candidate.score)) {
+        row.score = Math.max(0, Math.min(100, candidate.score));
+      }
+      const key = investigationKey(row);
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      rows.push(row);
+      if (rows.length >= cap) break;
+    }
+    return rows;
+  };
+
   const scoreBand = (row) => {
     const score = effectiveScore(row);
     if (score >= 80) return 'high';
@@ -269,7 +316,9 @@
   return {
     compareRows,
     effectiveScore,
+    investigationKey,
     matchesRow,
+    normaliseInvestigationRows,
     readViewState,
     refang,
     rowsToCsv,

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -85,9 +85,14 @@
   };
 
   const investigationKey = (row) => {
-    const indicator = lower(row?.indicator);
-    if (!indicator) return '';
-    return `${lower(row?.type) || 'unknown'}\u0000${indicator}`;
+    const type = lower(row?.type) || 'unknown';
+    const rawIndicator = stringValue(row?.indicator);
+    if (!rawIndicator) return '';
+    // URL paths and query components can be case-sensitive. Preserve the full
+    // value for URLs while continuing to collapse harmless case differences
+    // for domains, IPs, hashes, and the other indicator families.
+    const indicator = type === 'url' ? rawIndicator : rawIndicator.toLowerCase();
+    return `${type}\u0000${indicator}`;
   };
 
   // Treat browser storage as untrusted input. Keep only the fields needed by

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -164,6 +164,22 @@ test('exports an empty CSV with only its header when no rows are supplied', () =
   assert.match(csv, /"Indicator"/);
 });
 
+test('sanitizes and deduplicates browser-local investigation rows', () => {
+  const rows = core.normaliseInvestigationRows([
+    { ...row, score: 120, sourceList: ['feed-a', '', 'feed-b'] },
+    { ...row, score: 50 },
+    null,
+    { type: 'domain' },
+    { indicator: 'second.example', type: 'domain', score: Number.NaN },
+  ]);
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].score, 100);
+  assert.deepEqual(rows[0].sourceList, ['feed-a', 'feed-b']);
+  assert.equal(core.investigationKey(rows[0]), 'domain\u0000example[.]evil');
+  assert.equal(Object.hasOwn(rows[1], 'score'), false);
+  assert.deepEqual(core.normaliseInvestigationRows({ rows: [] }), []);
+});
+
 test('dashboard markup keeps IDs and labelled controls consistent', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
   const ids = Array.from(html.matchAll(/\sid="([^"]+)"/g), (match) => match[1]);
@@ -185,7 +201,14 @@ test('dashboard markup keeps IDs and labelled controls consistent', () => {
   );
   assert.match(html, /data-preview-download/);
   assert.match(html, /data-preview-download-note/);
+  assert.match(html, /data-investigation-root/);
+  assert.match(html, /data-investigation-list/);
   assert.match(html, /data-delta-root/);
   assert.match(html, /iocs\/delta\.jsonl/);
   assert.match(html, /iocs\/taxii2-envelope\.json/);
+  assert.equal(
+    (html.match(/<a\b/g) || []).length,
+    (html.match(/<\/a>/g) || []).length,
+    'Every link must have a complete closing tag'
+  );
 });

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -180,6 +180,18 @@ test('sanitizes and deduplicates browser-local investigation rows', () => {
   assert.deepEqual(core.normaliseInvestigationRows({ rows: [] }), []);
 });
 
+test('preserves case-sensitive URL paths in investigation identity', () => {
+  const upper = { indicator: 'https://host/Payload?id=ABC', type: 'url' };
+  const lowerPath = { indicator: 'https://host/payload?id=ABC', type: 'url' };
+  assert.notEqual(core.investigationKey(upper), core.investigationKey(lowerPath));
+  assert.equal(core.normaliseInvestigationRows([upper, lowerPath]).length, 2);
+
+  assert.equal(
+    core.investigationKey({ indicator: 'Example[.]COM', type: 'domain' }),
+    core.investigationKey({ indicator: 'example[.]com', type: 'domain' })
+  );
+});
+
 test('dashboard markup keeps IDs and labelled controls consistent', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
   const ids = Array.from(html.matchAll(/\sid="([^"]+)"/g), (match) => match[1]);

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -220,6 +220,203 @@
     return true;
   };
 
+  const downloadJsonCollection = (rows) => {
+    if (!rows.length) return false;
+    const blob = new Blob([JSON.stringify(rows, null, 2) + '\n'], {
+      type: 'application/json;charset=utf-8',
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'swiftioc-investigation-workspace.json';
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+    return true;
+  };
+
+  const INVESTIGATION_STORAGE_KEY = 'swiftioc-investigation-workspace-v1';
+  const INVESTIGATION_LIMIT = 50;
+  const investigationListeners = new Set();
+  const investigationKey = (row) => dashboardCore?.investigationKey(row) ||
+    `${normaliseLower(row?.type) || 'unknown'}\u0000${normaliseLower(row?.indicator)}`;
+  const cleanInvestigationRows = (value) => dashboardCore?.normaliseInvestigationRows(
+    value,
+    INVESTIGATION_LIMIT
+  ) || (Array.isArray(value) ? value.filter((row) => row?.indicator).slice(0, INVESTIGATION_LIMIT) : []);
+
+  let investigationRows = [];
+  try {
+    investigationRows = cleanInvestigationRows(
+      JSON.parse(window.localStorage.getItem(INVESTIGATION_STORAGE_KEY) || '[]')
+    );
+  } catch (error) {
+    investigationRows = [];
+  }
+
+  const notifyInvestigationListeners = () => {
+    const snapshot = investigationRows.slice();
+    investigationListeners.forEach((listener) => listener(snapshot));
+  };
+
+  const saveInvestigationRows = () => {
+    try {
+      window.localStorage.setItem(
+        INVESTIGATION_STORAGE_KEY,
+        JSON.stringify(investigationRows)
+      );
+    } catch (error) {
+      console.warn('Investigation workspace could not be saved', error);
+    }
+    notifyInvestigationListeners();
+  };
+
+  const investigationWorkspace = {
+    getRows: () => investigationRows.slice(),
+    has: (row) => investigationRows.some(
+      (candidate) => investigationKey(candidate) === investigationKey(row)
+    ),
+    add: (row) => {
+      if (!row?.indicator || investigationWorkspace.has(row)) return false;
+      if (investigationRows.length >= INVESTIGATION_LIMIT) {
+        showToast(`The workspace holds up to ${INVESTIGATION_LIMIT} indicators.`);
+        return false;
+      }
+      investigationRows = cleanInvestigationRows([...investigationRows, row]);
+      saveInvestigationRows();
+      return true;
+    },
+    remove: (row) => {
+      const key = investigationKey(row);
+      const next = investigationRows.filter(
+        (candidate) => investigationKey(candidate) !== key
+      );
+      if (next.length === investigationRows.length) return false;
+      investigationRows = next;
+      saveInvestigationRows();
+      return true;
+    },
+    toggle: (row) => investigationWorkspace.has(row)
+      ? investigationWorkspace.remove(row)
+      : investigationWorkspace.add(row),
+    clear: () => {
+      if (!investigationRows.length) return;
+      investigationRows = [];
+      saveInvestigationRows();
+    },
+    subscribe: (listener) => {
+      investigationListeners.add(listener);
+      return () => investigationListeners.delete(listener);
+    },
+  };
+
+  const syncInvestigationButtons = () => {
+    qsa('[data-investigation-toggle]').forEach((button) => {
+      const row = button._investigationRow;
+      if (!row) return;
+      const selected = investigationWorkspace.has(row);
+      button.setAttribute('aria-pressed', String(selected));
+      button.textContent = selected ? 'Queued' : 'Add to queue';
+      button.title = selected
+        ? 'Remove this indicator from the investigation queue'
+        : 'Keep this indicator in the browser-local investigation queue';
+    });
+  };
+
+  const makeInvestigationButton = (row) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'button ghost row-action queue-action';
+    button.dataset.investigationToggle = '';
+    button._investigationRow = row;
+    button.addEventListener('click', () => {
+      const wasSelected = investigationWorkspace.has(row);
+      if (investigationWorkspace.toggle(row)) {
+        showToast(wasSelected
+          ? 'Removed from the investigation queue.'
+          : 'Added to the investigation queue.');
+      }
+      syncInvestigationButtons();
+    });
+    const selected = investigationWorkspace.has(row);
+    button.setAttribute('aria-pressed', String(selected));
+    button.textContent = selected ? 'Queued' : 'Add to queue';
+    button.title = selected
+      ? 'Remove this indicator from the investigation queue'
+      : 'Keep this indicator in the browser-local investigation queue';
+    return button;
+  };
+
+  const initialiseInvestigationWorkspace = () => {
+    const root = qs('[data-investigation-root]');
+    if (!root) return;
+    const list = qs('[data-investigation-list]', root);
+    const count = qs('[data-investigation-count]', root);
+    const copy = qs('[data-investigation-copy]', root);
+    const csv = qs('[data-investigation-csv]', root);
+    const json = qs('[data-investigation-json]', root);
+    const clear = qs('[data-investigation-clear]', root);
+
+    const render = (rows) => {
+      root.hidden = !rows.length;
+      setText(count, formatNumber(rows.length));
+      if (!list) return;
+      list.innerHTML = '';
+      rows.forEach((row) => {
+        const item = document.createElement('li');
+        const identity = document.createElement('div');
+        identity.className = 'investigation-identity';
+        const indicator = document.createElement('code');
+        indicator.textContent = row.indicator;
+        const meta = document.createElement('span');
+        meta.textContent = [
+          row.type || 'unknown',
+          typeof row.score === 'number' ? `score ${row.score}` : row.confidence,
+          primarySourceLabel(row),
+        ].filter(Boolean).join(' · ');
+        identity.append(indicator, meta);
+
+        const remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'button ghost row-action';
+        remove.textContent = 'Remove';
+        remove.setAttribute('aria-label', `Remove ${row.indicator} from investigation queue`);
+        remove.addEventListener('click', () => {
+          investigationWorkspace.remove(row);
+          showToast('Removed from the investigation queue.');
+        });
+        item.append(identity, remove);
+        list.appendChild(item);
+      });
+      syncInvestigationButtons();
+    };
+
+    copy?.addEventListener('click', async () => {
+      const rows = investigationWorkspace.getRows();
+      await copyOrPrompt(
+        rows.map((row) => row.indicator).join('\n'),
+        `Copied ${formatNumber(rows.length)} queued indicators.`,
+        'Copy these queued indicators:'
+      );
+    });
+    csv?.addEventListener('click', () => {
+      const rows = investigationWorkspace.getRows();
+      if (downloadCsv(rows)) showToast(`Exported ${formatNumber(rows.length)} queued indicators.`);
+    });
+    json?.addEventListener('click', () => {
+      const rows = investigationWorkspace.getRows();
+      if (downloadJsonCollection(rows)) showToast(`Exported ${formatNumber(rows.length)} queued indicators.`);
+    });
+    clear?.addEventListener('click', () => {
+      investigationWorkspace.clear();
+      showToast('Investigation queue cleared.');
+    });
+
+    investigationWorkspace.subscribe(render);
+    render(investigationWorkspace.getRows());
+  };
+
   // Compact label for a possibly multi-source row: "feodo +2".
   const primarySourceLabel = (row) => {
     if (!row) return 'unknown';
@@ -2181,7 +2378,9 @@
         downloadJson(row);
         showToast('Indicator JSON downloaded.');
       });
-      actions.append(copy, toggle, download);
+      const queue = makeInvestigationButton(row);
+      actions.append(queue, copy, toggle, download);
+      syncInvestigationButtons();
       actionsCell.appendChild(actions);
       tr.appendChild(actionsCell);
 
@@ -2691,6 +2890,9 @@
     subscribeToDataset((dataset) => {
       if (!state.loading && dataset?.entries?.length) useDataset(dataset);
     });
+    investigationWorkspace.subscribe(() => {
+      if (state.rows.length) syncInvestigationButtons();
+    });
     window.addEventListener('popstate', () => {
       readUrl();
       populateFacets();
@@ -2952,6 +3154,8 @@
             await copyOrPrompt(row.indicator, 'Indicator copied to clipboard.', 'Copy this indicator:');
           })
         );
+        actions.appendChild(makeInvestigationButton(row));
+        syncInvestigationButtons();
         actions.appendChild(
           makeAction('Download JSON', () => downloadJson(row))
         );
@@ -3237,6 +3441,7 @@
    * ========================================================================= */
 
   initialiseTableToggles();
+  initialiseInvestigationWorkspace();
   initialiseStatusBanner();
   initialiseTopThreats();
   initialiseIocLookup();

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -239,8 +239,13 @@
   const INVESTIGATION_STORAGE_KEY = 'swiftioc-investigation-workspace-v1';
   const INVESTIGATION_LIMIT = 50;
   const investigationListeners = new Set();
-  const investigationKey = (row) => dashboardCore?.investigationKey(row) ||
-    `${normaliseLower(row?.type) || 'unknown'}\u0000${normaliseLower(row?.indicator)}`;
+  const investigationKey = (row) => {
+    if (dashboardCore) return dashboardCore.investigationKey(row);
+    const type = normaliseLower(row?.type) || 'unknown';
+    const rawIndicator = normaliseString(row?.indicator);
+    const indicator = type === 'url' ? rawIndicator : rawIndicator.toLowerCase();
+    return rawIndicator ? `${type}\u0000${indicator}` : '';
+  };
   const cleanInvestigationRows = (value) => dashboardCore?.normaliseInvestigationRows(
     value,
     INVESTIGATION_LIMIT

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -2810,3 +2810,138 @@ input.lookup-input {
     grid-template-columns: 1fr;
   }
 }
+
+/* Browser-local case building for repeated analyst triage. */
+.investigation-workspace {
+  margin-bottom: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(167, 139, 250, 0.62);
+  border-radius: 1rem;
+  background:
+    linear-gradient(120deg, rgba(109, 40, 217, 0.15), transparent 54%),
+    rgba(8, 15, 28, 0.96);
+  box-shadow: 0 16px 40px rgba(2, 6, 23, 0.3);
+}
+
+.investigation-workspace[hidden] {
+  display: none;
+}
+
+.investigation-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.investigation-heading h2 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  font-size: clamp(1.15rem, 2vw, 1.45rem);
+}
+
+.investigation-heading p:last-child {
+  color: #b8c5d8;
+  font-size: 0.8rem;
+}
+
+.investigation-count {
+  display: inline-grid;
+  min-width: 1.6rem;
+  min-height: 1.6rem;
+  padding-inline: 0.35rem;
+  place-items: center;
+  border: 1px solid rgba(196, 181, 253, 0.48);
+  border-radius: 999px;
+  background: rgba(109, 40, 217, 0.25);
+  color: #ede9fe;
+  font-size: 0.75rem;
+}
+
+.investigation-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+
+.button.danger {
+  border-color: rgba(248, 113, 113, 0.62);
+  color: #fecaca;
+}
+
+.investigation-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin: 0.85rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.investigation-list li {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+  padding: 0.6rem 0.7rem;
+  border: 1px solid rgba(100, 116, 139, 0.56);
+  border-radius: 0.65rem;
+  background: rgba(2, 6, 23, 0.48);
+}
+
+.investigation-identity {
+  display: grid;
+  min-width: 0;
+}
+
+.investigation-identity code {
+  overflow: hidden;
+  color: #f8fafc;
+  font-size: 0.78rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.investigation-identity span {
+  overflow: hidden;
+  color: #94a3b8;
+  font-size: 0.68rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.queue-action[aria-pressed='true'] {
+  border-color: rgba(167, 139, 250, 0.75);
+  background: rgba(109, 40, 217, 0.2);
+  color: #ede9fe;
+}
+
+@media (max-width: 820px) {
+  .investigation-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .investigation-actions {
+    justify-content: flex-start;
+  }
+
+  .investigation-list {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .investigation-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .investigation-actions .button {
+    width: 100%;
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=8" />
+    <link rel="stylesheet" href="assets/styles.css?v=9" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -157,6 +157,40 @@
           aria-atomic="true"
           hidden
         ></div>
+      </section>
+
+      <section
+        id="investigation-workspace"
+        class="investigation-workspace"
+        data-investigation-root
+        aria-labelledby="investigation-heading"
+        hidden
+      >
+        <div class="investigation-heading">
+          <div>
+            <p class="eyebrow">Private analyst workspace</p>
+            <h2 id="investigation-heading">
+              Investigation queue
+              <span class="investigation-count" data-investigation-count>0</span>
+            </h2>
+            <p>Shortlist indicators while you triage. This queue stays in this browser.</p>
+          </div>
+          <div class="investigation-actions">
+            <button type="button" class="button ghost" data-investigation-copy>
+              Copy indicators
+            </button>
+            <button type="button" class="button ghost" data-investigation-csv>
+              Export CSV
+            </button>
+            <button type="button" class="button ghost" data-investigation-json>
+              Export JSON
+            </button>
+            <button type="button" class="button ghost danger" data-investigation-clear>
+              Clear queue
+            </button>
+          </div>
+        </div>
+        <ul class="investigation-list" data-investigation-list aria-label="Queued indicators"></ul>
       </section>
 
       <section
@@ -695,7 +729,7 @@
               rel="nofollow"
               download
               title="Only score ≥80 or indicators confirmed by 2+ sources — block-ready"
-              >★ High-confidence CSV</a
+              >★ High-confidence CSV</a>
             <a
               class="button-link exports-highlight"
               href="iocs/high_confidence.jsonl"
@@ -704,43 +738,43 @@
               rel="nofollow"
               download
               title="Only score ≥80 or indicators confirmed by 2+ sources — block-ready"
-              >★ High-confidence JSONL</a
+              >★ High-confidence JSONL</a>
             <a
               class="button-link"
               href="iocs/latest.csv"
               rel="nofollow"
               download
-              >CSV</a
+              >CSV</a>
             <a
               class="button-link"
               href="iocs/latest.tsv"
               rel="nofollow"
               download
-              >TSV</a
+              >TSV</a>
             <a
               class="button-link"
               href="iocs/latest.json"
               rel="nofollow"
               download
-              >JSON</a
+              >JSON</a>
             <a
               class="button-link"
               href="iocs/latest.jsonl"
               rel="nofollow"
               download
-              >JSONL</a
+              >JSONL</a>
             <a
               class="button-link"
               href="iocs/stix2.json"
               rel="nofollow"
               download
-              >STIX 2.1 bundle</a
+              >STIX 2.1 bundle</a>
             <a
               class="button-link"
               href="iocs/taxii2-envelope.json"
               rel="nofollow"
               download
-              >TAXII 2.1 envelope</a
+              >TAXII 2.1 envelope</a>
           </div>
           <p class="panel-footnote">
             The ★ high-confidence feeds contain only indicators scoring ≥80 or
@@ -754,7 +788,7 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=8"></script>
-    <script defer src="assets/dashboard.js?v=8"></script>
+    <script defer src="assets/dashboard-core.js?v=9"></script>
+    <script defer src="assets/dashboard.js?v=9"></script>
   </body>
 </html>


### PR DESCRIPTION
Security analysts can already search and filter SwiftIOC, but they have no way to keep a working set while moving between lookup results and the live feed. This PR adds a browser-local investigation queue so analysts can collect indicators during triage and export only that case set.

### Analyst workflow
- Add or remove indicators from either lookup results or live-preview rows.
- Keep up to 50 indicators across page refreshes using browser-local storage.
- Show type, score, and primary-source context in a responsive queue.
- Copy all queued indicator values or export the complete queue as CSV or JSON.
- Keep selection buttons synchronized and expose their state with `aria-pressed`.
- Validate, normalize, cap, and deduplicate persisted records before rendering or export.
- Preserve case-sensitive URL paths and query values when identifying queued records.
- Keep the queue private to the browser; it does not send selected indicators to a server.

### Frontend reliability
- Repair eight incomplete `</a>` tags in the export grid that could merge adjacent download links in browser parsing.
- Update dashboard asset cache versions.
- Make dashboard and asset changes trigger the main CI workflow.
- Run dashboard unit tests and JavaScript syntax checks in CI.
- Add regression checks for persisted-row sanitization, duplicate handling, queue markup, unique IDs, labels, and balanced anchor tags.

Validation: 151 pytest tests, Ruff, Pyright, built-in self-test, 14 dashboard JavaScript tests, JavaScript syntax checks, workflow YAML parsing, HTML parsing, `git diff --check`, and a manual responsive browser pass with persistence verification and no console errors.