### PR TITLE
Turn threat intelligence into detections and campaign graphs

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -176,6 +176,7 @@ jobs:
             public/changelog/**
             public/index.md
             public/misp/**
+            public/detections/**
             public/feed.xml
             public/badge.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ public/iocs/latest.json
 public/iocs/latest.tsv
 public/iocs/stix2.json
 public/iocs/taxii2-envelope.json
+# Generated detection packs can be large; Pages and workflow artifacts publish
+# them directly after each collection run.
+public/detections/
 
 # Raw feed captures (only created with --save-raw-dir)
 public/diagnostics/raw/

--- a/docs/DETECTION_PACK.md
+++ b/docs/DETECTION_PACK.md
@@ -1,0 +1,31 @@
+# Detection Pack Compiler
+
+SwiftIOC turns its curated high-confidence feed into detection-as-code artifacts on every collection run. This gives analysts a reviewable path from intelligence to telemetry without copying thousands of indicators into hand-written rules.
+
+## Published artifacts
+
+| Artifact | Best for | Behavior |
+| --- | --- | --- |
+| `detections/sigma/network-iocs.yml` | SIEM and EDR network telemetry | Matches exact IP endpoints and uses Sigma's `cidr` modifier for network ranges. |
+| `detections/sigma/dns-iocs.yml` | Normalized DNS telemetry | Matches an exact domain or a label-boundary subdomain suffix. |
+| `detections/suricata/swiftioc.rules` | IDS/IPS alerting | Emits inbound, outbound, and DNS alerts with deterministic, collision-checked local SIDs. |
+| `detections/dns/swiftioc.rpz` | BIND-compatible DNS policy | Returns NXDOMAIN for exact malicious domains and their subdomains. |
+| `detections/manifest.json` | Automation and audit | Reports included types, skipped types, rule counts, generation time, and the review-required policy. |
+
+The compiler accepts IP addresses, IPv4/IPv6 networks, and domains. It records unsupported types such as CVEs, file hashes, email addresses, and URLs in the manifest instead of forcing them into telemetry where they cannot match correctly. Inputs are refanged, validated, normalized, and deduplicated before rule generation.
+
+## Analyst workspace
+
+The live dashboard can compile a smaller case-specific Sigma or Suricata bundle. Add indicators to the private investigation queue and choose **Build Sigma** or **Build Suricata**. Compilation happens entirely in the browser; the selection never leaves the workstation.
+
+Browser exports apply the same type allowlist and reject malformed values before constructing rule text. This prevents modified browser storage from injecting arbitrary Suricata options or YAML fields.
+
+## Operational workflow
+
+1. Download the artifact and its manifest from the live dashboard.
+2. Review skipped types and apply local allowlists, asset context, and severity policy.
+3. Compile Sigma for the target backend or load the Suricata/RPZ artifact into a staging policy.
+4. Run in alert-only mode and measure false positives.
+5. Promote through the organization's normal detection change process.
+
+Generated rules intentionally use an alert or experimental status. SwiftIOC supplies evidence and portable detection logic; each environment owns its field mappings, network variables, exceptions, and enforcement decision.

--- a/docs/DETECTION_PACK.md
+++ b/docs/DETECTION_PACK.md
@@ -9,6 +9,7 @@ SwiftIOC turns its curated high-confidence feed into detection-as-code artifacts
 | `detections/sigma/network-iocs.yml` | SIEM and EDR network telemetry | Matches exact IP endpoints and uses Sigma's `cidr` modifier for network ranges. |
 | `detections/sigma/dns-iocs.yml` | Normalized DNS telemetry | Matches an exact domain or a label-boundary subdomain suffix. |
 | `detections/suricata/swiftioc.rules` | IDS/IPS alerting | Emits inbound, outbound, and DNS alerts with deterministic, collision-checked local SIDs. |
+| `detections/suricata/sid-registry.json` | Stable rule identity | Preserves collision resolutions so unchanged rules keep their SIDs as feeds age in and out. |
 | `detections/dns/swiftioc.rpz` | BIND-compatible DNS policy | Returns NXDOMAIN for exact malicious domains and their subdomains. |
 | `detections/manifest.json` | Automation and audit | Reports included types, skipped types, rule counts, generation time, and the review-required policy. |
 
@@ -29,3 +30,5 @@ Browser exports apply the same type allowlist and reject malformed values before
 5. Promote through the organization's normal detection change process.
 
 Generated rules intentionally use an alert or experimental status. SwiftIOC supplies evidence and portable detection logic; each environment owns its field mappings, network variables, exceptions, and enforcement decision.
+
+The RPZ serial uses the generation timestamp and advances past the previous published serial when runs share a timestamp. This ensures DNS secondaries see every new policy revision.

--- a/docs/THREAT_CAMPAIGN_GRAPH.md
+++ b/docs/THREAT_CAMPAIGN_GRAPH.md
@@ -1,0 +1,28 @@
+# Threat Campaign Graph
+
+The Threat Campaign Graph turns the compact dashboard feed into a browser-local relationship map. It helps an analyst move from a flat IOC list to useful pivots without asserting attribution that the underlying evidence cannot support.
+
+## Relationship model
+
+The graph creates two kinds of pivot:
+
+- **Tag pivots** connect indicators that share a malware family, behavior, campaign, or other source-supplied tag.
+- **Source pivots** connect indicators reported by the same intelligence provider.
+
+Generic severity and feed-management tags are excluded, as are tags that duplicate a source name. Singleton pivots are omitted because they do not express a relationship. Remaining pivots are ranked by membership, IOC score, and corroboration, then bounded to six pivots and 24 indicators so rendering remains predictable on a phone or workstation.
+
+These links are investigative hints. A shared tag or source is not proof that two indicators belong to the same campaign or threat actor, and the dashboard states that limitation beside the graph.
+
+## Analyst interaction
+
+Analysts can switch between combined, tag-only, and source-only views; remix the deterministic radial layout; inspect nodes with a mouse or keyboard; and add an indicator directly to the private investigation queue. The graph rebuilds when the live-preview filters or feed data change, and it never uploads selections or graph state.
+
+Node selection highlights only direct neighbors and fades unrelated paths. This makes dense constellations readable without discarding the wider context. The layout uses an SVG view box and responsive inspector so it remains usable across desktop and mobile widths.
+
+## Safety and performance
+
+- Graph construction accepts only bounded arrays and clips pivot labels.
+- Duplicate indicator identities collapse through the same case-aware key used by the investigation workspace.
+- Rendering is capped at 30 total nodes by default.
+- Motion uses opacity and stroke animation and respects `prefers-reduced-motion`.
+- Keyboard users can focus each node and select it with Enter or Space.

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -136,6 +136,160 @@
     return rows;
   };
 
+  const validIpv4 = (value) => {
+    const parts = value.split('.');
+    return parts.length === 4 && parts.every((part) =>
+      /^\d{1,3}$/.test(part) && Number(part) <= 255
+    );
+  };
+
+  const validIpv6 = (value) => {
+    if (!value.includes(':') || !/^[0-9a-f:]+$/i.test(value)) return false;
+    try {
+      return new URL(`http://[${value}]/`).hostname.length > 2;
+    } catch (error) {
+      return false;
+    }
+  };
+
+  const validDomain = (value) => value.length <= 253 && value.includes('.') &&
+    value.split('.').every((label) =>
+      /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i.test(label)
+    );
+
+  const detectionRows = (value) => {
+    const rows = [];
+    const seen = new Set();
+    for (const row of normaliseInvestigationRows(value, 250)) {
+      const type = lower(row.type);
+      const indicator = refang(row.indicator).replace(/\.$/, '');
+      let valid = false;
+      if (type === 'ipv4') valid = validIpv4(indicator);
+      if (type === 'ipv4_cidr') {
+        const [address, prefix, ...rest] = indicator.split('/');
+        valid = !rest.length && validIpv4(address) && /^\d{1,2}$/.test(prefix) && Number(prefix) <= 32;
+      }
+      if (type === 'ipv6') valid = validIpv6(indicator);
+      if (type === 'ipv6_cidr') {
+        const [address, prefix, ...rest] = indicator.split('/');
+        valid = !rest.length && validIpv6(address) &&
+          /^\d{1,3}$/.test(prefix) && Number(prefix) <= 128;
+      }
+      if (type === 'domain') {
+        valid = validDomain(indicator);
+      }
+      const key = `${type}\u0000${indicator.toLowerCase()}`;
+      if (!valid || seen.has(key)) continue;
+      seen.add(key);
+      rows.push({ ...row, type, indicator });
+    }
+    return rows.sort((a, b) =>
+      a.type.localeCompare(b.type) || a.indicator.localeCompare(b.indicator)
+    );
+  };
+
+  const yamlList = (values, indent) => values
+    .map((value) => `${' '.repeat(indent)}- ${JSON.stringify(value)}`)
+    .join('\n');
+
+  const rowsToSigma = (value) => {
+    const rows = detectionRows(value);
+    const addresses = rows.filter((row) => /^ipv[46]$/.test(row.type)).map((row) => row.indicator);
+    const networks = rows.filter((row) => /^ipv[46]_cidr$/.test(row.type)).map((row) => row.indicator);
+    const domains = rows.filter((row) => row.type === 'domain').map((row) => row.indicator.toLowerCase());
+    const documents = [];
+    if (addresses.length || networks.length) {
+      const networkRule = [
+        'title: SwiftIOC investigation network indicators',
+        'status: experimental',
+        'description: Detects network traffic matching indicators selected in the SwiftIOC analyst workspace.',
+        'author: SwiftIOC analyst workspace',
+        'tags:',
+        '  - attack.command_and_control',
+        'logsource:',
+        '  category: network_connection',
+        'detection:',
+      ];
+      if (addresses.length) networkRule.push(
+        '  ip_source:', '    SourceIp:', yamlList(addresses, 6),
+        '  ip_destination:', '    DestinationIp:', yamlList(addresses, 6)
+      );
+      if (networks.length) networkRule.push(
+        '  ip_source_network:', '    SourceIp|cidr:', yamlList(networks, 6),
+        '  ip_destination_network:', '    DestinationIp|cidr:', yamlList(networks, 6)
+      );
+      networkRule.push(
+        '  condition: 1 of ip_*',
+        'falsepositives:',
+        '  - Legitimate shared infrastructure; validate with local context.',
+        'level: high',
+      );
+      documents.push(networkRule.join('\n'));
+    }
+    if (domains.length) {
+      documents.push([
+        'title: SwiftIOC investigation DNS indicators',
+        'status: experimental',
+        'description: Detects DNS queries matching domains selected in the SwiftIOC analyst workspace.',
+        'author: SwiftIOC analyst workspace',
+        'tags:',
+        '  - attack.command_and_control',
+        'logsource:',
+        '  category: dns',
+        'detection:',
+        '  domain_exact:',
+        '    query:',
+        yamlList(domains, 6),
+        '  domain_subdomain:',
+        '    query|endswith:',
+        yamlList(domains.map((domain) => `.${domain}`), 6),
+        '  condition: domain_exact or domain_subdomain',
+        'falsepositives:',
+        '  - Legitimate shared infrastructure; validate with local context.',
+        'level: high',
+      ].join('\n'));
+    }
+    return documents.join('\n---\n') + (documents.length ? '\n' : '');
+  };
+
+  const stableSid = (text, used) => {
+    let hash = 2166136261;
+    for (let index = 0; index < text.length; index += 1) {
+      hash ^= text.charCodeAt(index);
+      hash = Math.imul(hash, 16777619) >>> 0;
+    }
+    let sid = 4000000 + (hash % 900000);
+    while (used.has(sid)) sid = 4000000 + ((sid - 3999999) % 900000);
+    used.add(sid);
+    return sid;
+  };
+
+  const rowsToSuricata = (value) => {
+    const rules = [
+      '# SwiftIOC analyst-workspace detection pack',
+      '# Review and tune against local allowlists before enabling enforcement.',
+    ];
+    const used = new Set();
+    for (const row of detectionRows(value)) {
+      if (row.type.startsWith('ipv')) {
+        const target = row.indicator.includes(':') ? `[${row.indicator}]` : row.indicator;
+        for (const [direction, header] of [
+          ['inbound', `alert ip ${target} any -> $HOME_NET any`],
+          ['outbound', `alert ip $HOME_NET any -> ${target} any`],
+        ]) {
+          rules.push(`${header} (msg:"SwiftIOC ${direction} investigation match"; ` +
+            `classtype:trojan-activity; sid:${stableSid(`ip:${row.indicator}:${direction}`, used)}; rev:1;)`);
+        }
+      }
+      if (row.type === 'domain') {
+        rules.push('alert dns $HOME_NET any -> any 53 ' +
+          `(msg:"SwiftIOC investigation DNS match"; dns.query; dotprefix; content:".${row.indicator}"; ` +
+          `nocase; endswith; classtype:trojan-activity; sid:${stableSid(`dns:${row.indicator}`, used)}; rev:1;)`);
+      }
+    }
+    return rules.join('\n') + '\n';
+  };
+
   const scoreBand = (row) => {
     const score = effectiveScore(row);
     if (score >= 80) return 'high';
@@ -322,11 +476,14 @@
     compareRows,
     effectiveScore,
     investigationKey,
+    detectionRows,
     matchesRow,
     normaliseInvestigationRows,
     readViewState,
     refang,
     rowsToCsv,
+    rowsToSigma,
+    rowsToSuricata,
     writeViewUrl,
   };
 });

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -144,7 +144,7 @@
   };
 
   const validIpv6 = (value) => {
-    if (!value.includes(':') || !/^[0-9a-f:]+$/i.test(value)) return false;
+    if (!value.includes(':') || !/^[0-9a-f:.]+$/i.test(value)) return false;
     try {
       return new URL(`http://[${value}]/`).hostname.length > 2;
     } catch (error) {

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -290,6 +290,117 @@
     return rules.join('\n') + '\n';
   };
 
+  const buildCampaignGraph = (value, options = {}) => {
+    const rows = Array.isArray(value) ? value.filter((row) => row?.indicator) : [];
+    const mode = ['all', 'tags', 'sources'].includes(options.mode) ? options.mode : 'all';
+    const maxPivots = Math.max(1, Math.min(Number(options.maxPivots) || 6, 10));
+    const maxIndicators = Math.max(2, Math.min(Number(options.maxIndicators) || 24, 50));
+    const ignoredTags = new Set([
+      'aggregated', 'blocklist', 'critical', 'high', 'info', 'ioc', 'low',
+      'malicious', 'malware', 'medium', 'threat-intel', 'threat intelligence',
+    ]);
+    const sourceNames = new Set(rows.flatMap((row) => rowSources(row).map(lower)));
+    const pivots = new Map();
+
+    const addPivot = (kind, label, row) => {
+      const clean = stringValue(label).slice(0, 80);
+      if (!clean) return;
+      const key = `${kind}:${clean.toLowerCase()}`;
+      const pivot = pivots.get(key) || { key, kind, label: clean, rows: new Map(), score: 0 };
+      const rowKey = investigationKey(row);
+      if (!rowKey || pivot.rows.has(rowKey)) return;
+      pivot.rows.set(rowKey, row);
+      pivot.score += effectiveScore(row) + Math.min(Number(row.sourceCount) || rowSources(row).length, 5) * 5;
+      pivots.set(key, pivot);
+    };
+
+    rows.forEach((row) => {
+      if (mode !== 'sources') {
+        const tags = Array.isArray(row.tags) ? row.tags : [];
+        tags.slice(0, 25).forEach((tag) => {
+          if (!ignoredTags.has(lower(tag)) && !sourceNames.has(lower(tag))) {
+            addPivot('tag', tag, row);
+          }
+        });
+      }
+      if (mode !== 'tags') {
+        rowSources(row).slice(0, 25).forEach((source) => addPivot('source', source, row));
+      }
+    });
+
+    const selectedPivots = Array.from(pivots.values())
+      .filter((pivot) => pivot.rows.size >= 2)
+      .sort((a, b) =>
+        (b.rows.size * 100 + b.score / b.rows.size) -
+          (a.rows.size * 100 + a.score / a.rows.size) ||
+        a.key.localeCompare(b.key)
+      )
+      .slice(0, maxPivots);
+
+    const candidateRows = new Map();
+    selectedPivots.forEach((pivot) => {
+      Array.from(pivot.rows.values())
+        .sort((a, b) =>
+          effectiveScore(b) - effectiveScore(a) ||
+          (Number(b.sourceCount) || rowSources(b).length) -
+            (Number(a.sourceCount) || rowSources(a).length) ||
+          stringValue(a.indicator).localeCompare(stringValue(b.indicator))
+        )
+        .slice(0, 12)
+        .forEach((row) => candidateRows.set(investigationKey(row), row));
+    });
+    const selectedRows = Array.from(candidateRows.values())
+      .sort((a, b) =>
+        effectiveScore(b) - effectiveScore(a) ||
+        stringValue(a.indicator).localeCompare(stringValue(b.indicator))
+      )
+      .slice(0, maxIndicators);
+    const selectedKeys = new Set(selectedRows.map(investigationKey));
+
+    const nodes = [
+      ...selectedPivots.map((pivot) => ({
+        id: `pivot:${pivot.key}`,
+        kind: 'pivot',
+        pivotKind: pivot.kind,
+        label: pivot.label,
+        count: Array.from(pivot.rows.keys()).filter((key) => selectedKeys.has(key)).length,
+        totalCount: pivot.rows.size,
+      })),
+      ...selectedRows.map((row) => ({
+        id: `ioc:${investigationKey(row)}`,
+        kind: 'indicator',
+        label: stringValue(row.indicator),
+        score: effectiveScore(row),
+        row,
+      })),
+    ];
+    const edges = [];
+    selectedPivots.forEach((pivot) => {
+      pivot.rows.forEach((_row, key) => {
+        if (selectedKeys.has(key)) {
+          edges.push({
+            source: `pivot:${pivot.key}`,
+            target: `ioc:${key}`,
+            kind: pivot.kind,
+          });
+        }
+      });
+    });
+    edges.sort((a, b) =>
+      a.source.localeCompare(b.source) || a.target.localeCompare(b.target)
+    );
+    return {
+      mode,
+      nodes,
+      edges,
+      stats: {
+        pivots: selectedPivots.length,
+        indicators: selectedRows.length,
+        relationships: edges.length,
+      },
+    };
+  };
+
   const scoreBand = (row) => {
     const score = effectiveScore(row);
     if (score >= 80) return 'high';
@@ -474,6 +585,7 @@
 
   return {
     compareRows,
+    buildCampaignGraph,
     effectiveScore,
     investigationKey,
     detectionRows,

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -192,6 +192,34 @@ test('preserves case-sensitive URL paths in investigation identity', () => {
   );
 });
 
+test('builds type-aware Sigma detections from the investigation queue', () => {
+  const sigma = core.rowsToSigma([
+    { indicator: '1[.]2[.]3[.]4', type: 'ipv4' },
+    { indicator: 'evil[.]example', type: 'domain' },
+    { indicator: 'hxxps://evil[.]example/dropper', type: 'url' },
+  ]);
+  assert.match(sigma, /category: network_connection/);
+  assert.match(sigma, /"1\.2\.3\.4"/);
+  assert.match(sigma, /category: dns/);
+  assert.match(sigma, /"\.evil\.example"/);
+  assert.doesNotMatch(sigma, /dropper/);
+});
+
+test('builds deterministic Suricata rules and rejects injected values', () => {
+  const rows = [
+    { indicator: '1[.]2[.]3[.]4', type: 'ipv4' },
+    { indicator: 'evil[.]example', type: 'domain' },
+    { indicator: 'evil.com"; sid:1;', type: 'domain' },
+  ];
+  const first = core.rowsToSuricata(rows);
+  const second = core.rowsToSuricata(rows.slice().reverse());
+  assert.equal(first, second);
+  assert.equal((first.match(/\bsid:\d+;/g) || []).length, 3);
+  assert.match(first, /1\.2\.3\.4/);
+  assert.match(first, /dotprefix; content:"\.evil\.example"/);
+  assert.doesNotMatch(first, /sid:1;/);
+});
+
 test('dashboard markup keeps IDs and labelled controls consistent', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
   const css = fs.readFileSync(path.join(__dirname, 'styles.css'), 'utf8');
@@ -216,6 +244,8 @@ test('dashboard markup keeps IDs and labelled controls consistent', () => {
   assert.match(html, /data-preview-download-note/);
   assert.match(html, /data-investigation-root/);
   assert.match(html, /data-investigation-list/);
+  assert.match(html, /data-investigation-sigma/);
+  assert.match(html, /data-investigation-suricata/);
   assert.match(html, /class="signal-radar"/);
   assert.match(html, /data-delta-root/);
   assert.match(html, /iocs\/delta\.jsonl/);

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -220,6 +220,41 @@ test('builds deterministic Suricata rules and rejects injected values', () => {
   assert.doesNotMatch(first, /sid:1;/);
 });
 
+test('builds deterministic campaign pivots and omits singleton relationships', () => {
+  const rows = [
+    { ...row, indicator: 'one.example', tags: ['ransomware', 'feed-a', 'critical'], sourceList: ['feed-a'] },
+    { ...row, indicator: 'two.example', tags: ['ransomware', 'feed-a', 'critical'], sourceList: ['feed-a', 'feed-b'], score: 90 },
+    { ...row, indicator: 'three.example', tags: ['singleton'], sourceList: ['feed-b'], score: 70 },
+  ];
+  const graph = core.buildCampaignGraph(rows, { mode: 'tags' });
+  assert.deepEqual(graph.stats, { pivots: 1, indicators: 2, relationships: 2 });
+  assert.equal(graph.nodes.find((node) => node.kind === 'pivot').label, 'ransomware');
+  assert.equal(graph.nodes.some((node) => node.label === 'singleton'), false);
+  assert.equal(graph.edges.every((edge) => edge.kind === 'tag'), true);
+  assert.deepEqual(
+    core.buildCampaignGraph(rows.slice().reverse(), { mode: 'tags' }),
+    graph
+  );
+});
+
+test('campaign graph respects source mode and graph-size caps', () => {
+  const rows = Array.from({ length: 20 }, (_, index) => ({
+    ...row,
+    indicator: `${index}.example.test`,
+    tags: ['shared-tag'],
+    sourceList: ['shared-source'],
+    score: 100 - index,
+  }));
+  const graph = core.buildCampaignGraph(rows, {
+    mode: 'sources',
+    maxPivots: 1,
+    maxIndicators: 5,
+  });
+  assert.equal(graph.stats.pivots, 1);
+  assert.equal(graph.stats.indicators, 5);
+  assert.equal(graph.nodes.find((node) => node.kind === 'pivot').pivotKind, 'source');
+});
+
 test('dashboard markup keeps IDs and labelled controls consistent', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
   const css = fs.readFileSync(path.join(__dirname, 'styles.css'), 'utf8');
@@ -246,6 +281,7 @@ test('dashboard markup keeps IDs and labelled controls consistent', () => {
   assert.match(html, /data-investigation-list/);
   assert.match(html, /data-investigation-sigma/);
   assert.match(html, /data-investigation-suricata/);
+  assert.match(html, /data-campaign-graph/);
   assert.match(html, /class="signal-radar"/);
   assert.match(html, /data-delta-root/);
   assert.match(html, /iocs\/delta\.jsonl/);

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -220,6 +220,17 @@ test('builds deterministic Suricata rules and rejects injected values', () => {
   assert.doesNotMatch(first, /sid:1;/);
 });
 
+test('accepts IPv4-embedded IPv6 observables in browser detection exports', () => {
+  const rows = core.detectionRows([
+    { indicator: '::ffff:192.0.2.1', type: 'ipv6' },
+    { indicator: '::ffff:192.0.2.0/120', type: 'ipv6_cidr' },
+  ]);
+  assert.deepEqual(rows.map((row) => row.indicator), [
+    '::ffff:192.0.2.1',
+    '::ffff:192.0.2.0/120',
+  ]);
+});
+
 test('builds deterministic campaign pivots and omits singleton relationships', () => {
   const rows = [
     { ...row, indicator: 'one.example', tags: ['ransomware', 'feed-a', 'critical'], sourceList: ['feed-a'] },
@@ -278,6 +289,8 @@ test('dashboard markup keeps IDs and labelled controls consistent', () => {
   assert.match(html, /data-preview-download/);
   assert.match(html, /data-preview-download-note/);
   assert.match(html, /data-investigation-root/);
+  assert.match(html, /data-detection-artifact="sigma\/network-iocs\.yml"[^>]*hidden/);
+  assert.match(html, /data-detection-artifact="sigma\/dns-iocs\.yml"[^>]*hidden/);
   assert.match(html, /data-investigation-list/);
   assert.match(html, /data-investigation-sigma/);
   assert.match(html, /data-investigation-suricata/);

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -33,6 +33,7 @@
   // Per-indicator historical summary (first-publicly-seen, peak score, run
   // count) built from git history by scripts/build_history_index.py. Optional.
   const HISTORY_SUMMARY_URL = resolveIocUrl('history_summary.json');
+  const DETECTION_MANIFEST_URL = resolveIocUrl('detections/manifest.json');
 
   const DATASET_STORAGE_KEY = 'swiftioc-dashboard-cache-v2';
   const DATASET_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
@@ -3732,6 +3733,32 @@
     });
   };
 
+  const initialiseDetectionDownloads = () => {
+    const optionalLinks = qsa('[data-detection-artifact]');
+    if (!optionalLinks.length) return;
+    fetch(DETECTION_MANIFEST_URL, {
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+    })
+      .then((response) => (response.ok ? response.json() : null))
+      .then((manifest) => {
+        const included = manifest?.included;
+        if (!included || typeof included !== 'object') return;
+        const hasNetwork = ['ipv4', 'ipv6', 'ipv4_cidr', 'ipv6_cidr']
+          .some((kind) => Number(included[kind]) > 0);
+        const availability = {
+          'sigma/network-iocs.yml': hasNetwork,
+          'sigma/dns-iocs.yml': Number(included.domain) > 0,
+        };
+        optionalLinks.forEach((link) => {
+          link.hidden = !availability[link.dataset.detectionArtifact];
+        });
+      })
+      .catch((error) => {
+        console.warn('Detection manifest unavailable', error);
+      });
+  };
+
   const initialiseVisualEffects = () => {
     const targets = qsa([
       '.page-header',
@@ -3808,6 +3835,7 @@
   initialiseIocLookup();
   initialiseTrendSparkline();
   initialiseDownloadFallbacks();
+  initialiseDetectionDownloads();
   loadStats();
   initialisePreview();
 })();

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -2667,6 +2667,9 @@
     const apply = ({ sync = true } = {}) => {
       const matches = filteredRows().sort(compare);
       state.matches = matches;
+      window.dispatchEvent(new CustomEvent('swiftioc:preview-filtered', {
+        detail: { rows: matches },
+      }));
       const displayed = matches.slice(0, state.limit);
       render(displayed);
       updateSummary(matches, displayed);
@@ -2819,6 +2822,9 @@
         console.error('Unable to load live preview', error);
         state.rows = [];
         state.matches = [];
+        window.dispatchEvent(new CustomEvent('swiftioc:preview-filtered', {
+          detail: { rows: [] },
+        }));
         render([]);
         updateSummary([], []);
         if (summary.meta) summary.meta.hidden = true;
@@ -3001,6 +3007,216 @@
     span.className = `threat-pill ${cls}`;
     span.textContent = text;
     return span;
+  };
+
+  const initialiseCampaignGraph = () => {
+    const root = qs('[data-campaign-root]');
+    const svg = qs('[data-campaign-graph]', root);
+    if (!root || !svg || !dashboardCore?.buildCampaignGraph) return;
+    const mode = qs('[data-campaign-mode]', root);
+    const remix = qs('[data-campaign-layout]', root);
+    const empty = qs('[data-campaign-empty]', root);
+    const title = qs('[data-campaign-title]', root);
+    const description = qs('[data-campaign-description]', root);
+    const meta = qs('[data-campaign-meta]', root);
+    const kind = qs('[data-campaign-kind]', root);
+    const connections = qs('[data-campaign-connections]', root);
+    const score = qs('[data-campaign-score]', root);
+    const queue = qs('[data-campaign-queue]', root);
+    const summary = qs('[data-campaign-summary]', root);
+    const svgNamespace = 'http://www.w3.org/2000/svg';
+    let entries = [];
+    let graph = null;
+    let selected = null;
+    let rotation = 0;
+
+    const createSvg = (name, attributes = {}) => {
+      const element = document.createElementNS(svgNamespace, name);
+      Object.entries(attributes).forEach(([key, value]) => element.setAttribute(key, String(value)));
+      return element;
+    };
+
+    const positionsFor = (nodes) => {
+      const pivots = nodes.filter((node) => node.kind === 'pivot');
+      const indicators = nodes.filter((node) => node.kind === 'indicator');
+      const positions = new Map();
+      pivots.forEach((node, index) => {
+        const angle = rotation - Math.PI / 2 + (index * Math.PI * 2) / Math.max(pivots.length, 1);
+        positions.set(node.id, {
+          x: 500 + Math.cos(angle) * 185,
+          y: 260 + Math.sin(angle) * 105,
+        });
+      });
+      indicators.forEach((node, index) => {
+        const angle = rotation * 0.6 - Math.PI / 2 + (index * Math.PI * 2) / Math.max(indicators.length, 1);
+        const ring = index % 2 ? 1 : 0.88;
+        positions.set(node.id, {
+          x: 500 + Math.cos(angle) * 405 * ring,
+          y: 260 + Math.sin(angle) * 210 * ring,
+        });
+      });
+      return positions;
+    };
+
+    const selectNode = (node) => {
+      selected = node;
+      const connected = new Set();
+      graph.edges.forEach((edge) => {
+        if (edge.source === node.id) connected.add(edge.target);
+        if (edge.target === node.id) connected.add(edge.source);
+      });
+      qsa('[data-graph-node]', svg).forEach((element) => {
+        const active = element.dataset.graphNode === node.id;
+        const related = connected.has(element.dataset.graphNode);
+        element.classList.toggle('is-selected', active);
+        element.classList.toggle('is-connected', related);
+        element.classList.toggle('is-dimmed', !active && !related);
+      });
+      qsa('[data-graph-edge]', svg).forEach((element) => {
+        const related = element.dataset.source === node.id || element.dataset.target === node.id;
+        element.classList.toggle('is-connected', related);
+        element.classList.toggle('is-dimmed', !related);
+      });
+
+      const degree = graph.edges.filter((edge) => edge.source === node.id || edge.target === node.id).length;
+      setText(title, node.label);
+      setText(kind, node.kind === 'pivot' ? `${node.pivotKind} pivot` : node.row?.type || 'indicator');
+      setText(connections, formatNumber(degree));
+      setText(score, node.kind === 'indicator' ? String(node.score) : '—');
+      if (meta) meta.hidden = false;
+      if (description) {
+        description.textContent = node.kind === 'pivot'
+          ? `${formatNumber(node.totalCount)} indicators in the preview share this ${node.pivotKind}. Select a connected indicator to inspect it.`
+          : `Reported by ${primarySourceLabel(node.row)}${node.row?.tags?.length ? ` · ${node.row.tags.slice(0, 3).join(', ')}` : ''}.`;
+      }
+      if (queue) {
+        queue.disabled = node.kind !== 'indicator';
+        queue.textContent = node.kind === 'indicator' && investigationWorkspace.has(node.row)
+          ? 'Remove from queue'
+          : 'Add indicator to queue';
+      }
+    };
+
+    const render = () => {
+      graph = dashboardCore.buildCampaignGraph(entries, {
+        mode: mode?.value || 'all',
+        maxPivots: 6,
+        maxIndicators: 24,
+      });
+      svg.innerHTML = '';
+      selected = null;
+      const hasGraph = graph.nodes.length > 0 && graph.edges.length > 0;
+      if (empty) empty.hidden = hasGraph;
+      svg.hidden = !hasGraph;
+      root.hidden = !entries.length;
+      if (summary) {
+        summary.textContent = hasGraph
+          ? `${formatNumber(graph.stats.indicators)} indicators · ${formatNumber(graph.stats.pivots)} pivots · ${formatNumber(graph.stats.relationships)} relationships`
+          : 'No repeated tags or sources were found in the current preview.';
+      }
+      if (title) title.textContent = 'Select a node';
+      if (description) description.textContent = 'Choose a pivot to understand its reach, or choose an indicator to add it to your investigation queue.';
+      if (meta) meta.hidden = true;
+      if (queue) {
+        queue.disabled = true;
+        queue.textContent = 'Add indicator to queue';
+      }
+      if (!hasGraph) return;
+
+      const positions = positionsFor(graph.nodes);
+      const edgeLayer = createSvg('g', { class: 'campaign-edges' });
+      graph.edges.forEach((edge, index) => {
+        const start = positions.get(edge.source);
+        const end = positions.get(edge.target);
+        if (!start || !end) return;
+        const line = createSvg('line', {
+          x1: start.x, y1: start.y, x2: end.x, y2: end.y,
+          class: `campaign-edge ${edge.kind}`,
+          'data-graph-edge': '',
+          'data-source': edge.source,
+          'data-target': edge.target,
+        });
+        line.style.setProperty('--edge-delay', `${Math.min(index * 24, 420)}ms`);
+        edgeLayer.appendChild(line);
+      });
+      svg.appendChild(edgeLayer);
+
+      const nodeLayer = createSvg('g', { class: 'campaign-nodes' });
+      graph.nodes.forEach((node, index) => {
+        const position = positions.get(node.id);
+        const group = createSvg('g', {
+          class: `campaign-node ${node.kind} ${node.pivotKind || ''}`,
+          transform: `translate(${position.x} ${position.y})`,
+          role: 'button',
+          tabindex: '0',
+          'aria-label': node.kind === 'pivot'
+            ? `${node.pivotKind} pivot ${node.label}, ${node.totalCount} indicators`
+            : `${node.row?.type || 'indicator'} ${node.label}, score ${node.score}`,
+          'data-graph-node': node.id,
+        });
+        group.style.setProperty('--node-delay', `${Math.min(index * 30, 480)}ms`);
+        const circle = createSvg('circle', {
+          r: node.kind === 'pivot' ? Math.min(31, 20 + Math.sqrt(node.totalCount || 1) * 1.6) : 11,
+        });
+        const label = createSvg('text', {
+          y: node.kind === 'pivot' ? 4 : 3,
+          'text-anchor': 'middle',
+        });
+        label.textContent = node.kind === 'pivot'
+          ? (node.label.length > 15 ? node.label.slice(0, 14) + '…' : node.label)
+          : String(node.score);
+        const tooltip = createSvg('title');
+        tooltip.textContent = node.label;
+        group.append(circle, label, tooltip);
+        group.addEventListener('click', () => selectNode(node));
+        group.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            selectNode(node);
+          }
+        });
+        nodeLayer.appendChild(group);
+      });
+      svg.appendChild(nodeLayer);
+    };
+
+    mode?.addEventListener('change', render);
+    remix?.addEventListener('click', () => {
+      rotation = (rotation + Math.PI / 7) % (Math.PI * 2);
+      render();
+    });
+    queue?.addEventListener('click', () => {
+      if (!selected?.row) return;
+      const wasSelected = investigationWorkspace.has(selected.row);
+      if (investigationWorkspace.toggle(selected.row)) {
+        showToast(wasSelected ? 'Removed from the investigation queue.' : 'Added graph finding to the investigation queue.');
+      }
+      selectNode(selected);
+      syncInvestigationButtons();
+    });
+    investigationWorkspace.subscribe(() => {
+      if (selected?.row) selectNode(selected);
+    });
+    window.addEventListener('swiftioc:preview-filtered', (event) => {
+      if (!Array.isArray(event.detail?.rows)) return;
+      entries = event.detail.rows;
+      render();
+    });
+    subscribeToDataset((dataset) => {
+      if (dataset && !isCacheOrigin(dataset.origin)) {
+        entries = dataset.entries || [];
+        render();
+      }
+    });
+    loadDataset({})
+      .then(({ dataset }) => {
+        entries = dataset.entries || [];
+        render();
+      })
+      .catch((error) => {
+        root.hidden = true;
+        console.warn('Campaign graph failed to load', error);
+      });
   };
 
   const makeThreatCard = (row) => {
@@ -3525,6 +3741,7 @@
       '.metrics-strip',
       '.score-distribution',
       '.delta-strip',
+      '.campaign-graph-section',
       '.dashboard-main > .panel',
       '.top-threats',
       '#exports',
@@ -3586,6 +3803,7 @@
   initialiseTableToggles();
   initialiseInvestigationWorkspace();
   initialiseStatusBanner();
+  initialiseCampaignGraph();
   initialiseTopThreats();
   initialiseIocLookup();
   initialiseTrendSparkline();

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -271,6 +271,20 @@
     return true;
   };
 
+  const downloadDetection = (content, filename, mediaType) => {
+    if (!content) return false;
+    const blob = new Blob([content], { type: `${mediaType};charset=utf-8` });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+    return true;
+  };
+
   const INVESTIGATION_STORAGE_KEY = 'swiftioc-investigation-workspace-v1';
   const INVESTIGATION_LIMIT = 50;
   const investigationListeners = new Set();
@@ -396,6 +410,8 @@
     const copy = qs('[data-investigation-copy]', root);
     const csv = qs('[data-investigation-csv]', root);
     const json = qs('[data-investigation-json]', root);
+    const sigma = qs('[data-investigation-sigma]', root);
+    const suricata = qs('[data-investigation-suricata]', root);
     const clear = qs('[data-investigation-clear]', root);
 
     const render = (rows) => {
@@ -447,6 +463,25 @@
     json?.addEventListener('click', () => {
       const rows = investigationWorkspace.getRows();
       if (downloadJsonCollection(rows)) showToast(`Exported ${formatNumber(rows.length)} queued indicators.`);
+    });
+    sigma?.addEventListener('click', () => {
+      const rows = investigationWorkspace.getRows();
+      const content = dashboardCore?.rowsToSigma?.(rows) || '';
+      if (downloadDetection(content, 'swiftioc-investigation.yml', 'application/yaml')) {
+        showToast('Built Sigma detections from deployable IP and domain indicators.');
+      } else {
+        showToast('Sigma export needs at least one valid IP, CIDR, or domain.');
+      }
+    });
+    suricata?.addEventListener('click', () => {
+      const rows = investigationWorkspace.getRows();
+      const deployable = dashboardCore?.detectionRows?.(rows) || [];
+      const content = deployable.length ? dashboardCore?.rowsToSuricata?.(deployable) : '';
+      if (downloadDetection(content, 'swiftioc-investigation.rules', 'text/plain')) {
+        showToast('Built Suricata rules with stable local SIDs.');
+      } else {
+        showToast('Suricata export needs at least one valid IP, CIDR, or domain.');
+      }
     });
     clear?.addEventListener('click', () => {
       investigationWorkspace.clear();

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -1572,6 +1572,12 @@ input.lookup-input:focus-visible {
   background: rgba(239, 68, 68, 0.22);
 }
 
+.exports-grid a.button-link.detection-download {
+  border-color: rgba(34, 211, 238, 0.58);
+  background: linear-gradient(135deg, rgba(8, 145, 178, 0.16), rgba(109, 40, 217, 0.1));
+  color: #cffafe;
+}
+
 @media (max-width: 1100px) {
   .dashboard-main {
     grid-template-columns: minmax(0, 1.5fr) minmax(0, 1.1fr);
@@ -2870,6 +2876,17 @@ input.lookup-input {
 .button.danger {
   border-color: rgba(248, 113, 113, 0.62);
   color: #fecaca;
+}
+
+.button.detection-export {
+  border-color: rgba(34, 211, 238, 0.58);
+  background: linear-gradient(135deg, rgba(8, 145, 178, 0.16), rgba(109, 40, 217, 0.12));
+  color: #cffafe;
+}
+
+.button.detection-export:hover {
+  border-color: rgba(103, 232, 249, 0.9);
+  box-shadow: 0 0 20px rgba(34, 211, 238, 0.14);
 }
 
 .investigation-list {

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -1261,7 +1261,7 @@ input.lookup-input:focus-visible {
 
 /* Page-specific dashboard layout (kept here so presentation is cacheable and
  * the HTML remains focused on structure and accessibility). */
-+/* Page-specific layout refinements for the main dashboard */
+/* Page-specific layout refinements for the main dashboard */
 
 .page-wrapper {
   min-height: 100vh;
@@ -2889,6 +2889,261 @@ input.lookup-input {
   box-shadow: 0 0 20px rgba(34, 211, 238, 0.14);
 }
 
+/* Relationship map for campaign-oriented analyst pivots. */
+.campaign-graph-section {
+  margin-bottom: 1rem;
+  overflow: hidden;
+  border-color: rgba(34, 211, 238, 0.48);
+  background:
+    radial-gradient(circle at 34% 45%, rgba(8, 145, 178, 0.11), transparent 38%),
+    radial-gradient(circle at 82% 20%, rgba(109, 40, 217, 0.13), transparent 32%),
+    rgba(8, 15, 28, 0.96);
+}
+
+.campaign-graph-header {
+  align-items: flex-start;
+  gap: 1.25rem;
+  padding: 1rem 1.1rem;
+}
+
+.campaign-graph-header > div:first-child {
+  max-width: 48rem;
+}
+
+.campaign-graph-header .panel-title {
+  margin-top: 0.12rem;
+  font-size: clamp(1.2rem, 2vw, 1.55rem);
+}
+
+.campaign-graph-header .panel-subtitle {
+  margin-top: 0.3rem;
+  line-height: 1.5;
+}
+
+.campaign-controls {
+  display: grid;
+  grid-template-columns: minmax(9.5rem, 1fr) auto;
+  align-items: end;
+  gap: 0.35rem 0.5rem;
+  min-width: min(100%, 19rem);
+}
+
+.campaign-controls label {
+  grid-column: 1 / -1;
+  color: #94a3b8;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.campaign-controls select {
+  min-height: 2.35rem;
+  border-color: rgba(103, 232, 249, 0.45);
+  background: #0b1323;
+}
+
+.campaign-graph-body {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(15rem, 1fr);
+  min-height: 31rem;
+  padding: 0;
+}
+
+.campaign-stage {
+  position: relative;
+  min-width: 0;
+  min-height: 31rem;
+  overflow: hidden;
+  background-image:
+    linear-gradient(rgba(56, 189, 248, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(56, 189, 248, 0.035) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+.campaign-stage::after {
+  content: '';
+  position: absolute;
+  inset: 10% 18%;
+  pointer-events: none;
+  border: 1px solid rgba(34, 211, 238, 0.08);
+  border-radius: 50%;
+  box-shadow: 0 0 80px rgba(34, 211, 238, 0.06);
+}
+
+[data-campaign-graph] {
+  position: relative;
+  z-index: 1;
+  display: block;
+  width: 100%;
+  height: 31rem;
+}
+
+.campaign-edge {
+  stroke-width: 1.15;
+  stroke-dasharray: 3 5;
+  opacity: 0.48;
+  animation: campaign-edge-in 620ms ease both;
+  animation-delay: var(--edge-delay, 0ms);
+  transition: opacity 180ms ease, stroke-width 180ms ease;
+}
+
+.campaign-edge.tag { stroke: #a78bfa; }
+.campaign-edge.source { stroke: #22d3ee; }
+.campaign-edge.is-connected { stroke-width: 2.6; opacity: 1; }
+.campaign-edge.is-dimmed { opacity: 0.06; }
+
+.campaign-node {
+  cursor: pointer;
+  opacity: 0;
+  animation: campaign-node-in 520ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation-delay: var(--node-delay, 0ms);
+  transition: opacity 180ms ease;
+}
+
+.campaign-node circle {
+  stroke-width: 2;
+  transition: r 180ms ease, filter 180ms ease, stroke-width 180ms ease;
+}
+
+.campaign-node text {
+  pointer-events: none;
+  fill: #f8fafc;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  font-weight: 750;
+}
+
+.campaign-node.pivot text { font-size: 10.5px; }
+.campaign-node.pivot.tag circle { fill: #5b21b6; stroke: #c4b5fd; }
+.campaign-node.pivot.source circle { fill: #0e7490; stroke: #a5f3fc; }
+.campaign-node.indicator circle { fill: #0f172a; stroke: #f97316; }
+.campaign-node:hover circle,
+.campaign-node:focus-visible circle,
+.campaign-node.is-selected circle {
+  stroke-width: 4;
+  filter: drop-shadow(0 0 9px rgba(103, 232, 249, 0.8));
+}
+.campaign-node:focus-visible { outline: none; }
+.campaign-node.is-connected { opacity: 1; }
+.campaign-node.is-dimmed { opacity: 0.18; }
+
+.campaign-inspector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-width: 0;
+  padding: 1.1rem;
+  border-left: 1px solid rgba(71, 85, 105, 0.66);
+  background: rgba(2, 6, 23, 0.42);
+}
+
+.campaign-inspector h3 {
+  margin: 0;
+  color: #f8fafc;
+  font-size: 1.05rem;
+  overflow-wrap: anywhere;
+}
+
+.campaign-inspector > p:not(.eyebrow) {
+  color: #aebed3;
+  font-size: 0.78rem;
+  line-height: 1.55;
+}
+
+.campaign-node-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.4rem;
+  margin: 0.15rem 0;
+}
+
+.campaign-node-meta div {
+  min-width: 0;
+  padding: 0.55rem;
+  border: 1px solid rgba(71, 85, 105, 0.56);
+  border-radius: 0.55rem;
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.campaign-node-meta dt {
+  color: #94a3b8;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+}
+
+.campaign-node-meta dd {
+  margin: 0.15rem 0 0;
+  overflow: hidden;
+  color: #e2e8f0;
+  font-size: 0.75rem;
+  text-overflow: ellipsis;
+}
+
+.campaign-summary {
+  margin-top: auto;
+  padding-top: 0.7rem;
+  border-top: 1px solid rgba(71, 85, 105, 0.5);
+}
+
+.campaign-legend {
+  position: absolute;
+  bottom: 0.65rem;
+  left: 0.75rem;
+  z-index: 2;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 0.8rem;
+  padding: 0.38rem 0.5rem;
+  border: 1px solid rgba(71, 85, 105, 0.48);
+  border-radius: 999px;
+  background: rgba(2, 6, 23, 0.78);
+  color: #aebed3;
+  font-size: 0.65rem;
+}
+
+.campaign-legend span { display: inline-flex; align-items: center; gap: 0.3rem; }
+.legend-node { width: 0.55rem; height: 0.55rem; border-radius: 50%; }
+.legend-node.tag { background: #a78bfa; }
+.legend-node.source { background: #22d3ee; }
+.legend-node.indicator { background: #f97316; }
+
+.campaign-empty {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: grid;
+  place-content: center;
+  gap: 0.3rem;
+  padding: 2rem;
+  color: #e2e8f0;
+  text-align: center;
+}
+
+.campaign-empty span { color: #94a3b8; font-size: 0.78rem; }
+
+@media (max-width: 900px) {
+  .campaign-graph-header { flex-direction: column; }
+  .campaign-controls { width: 100%; }
+  .campaign-graph-body { grid-template-columns: 1fr; }
+  .campaign-inspector {
+    border-top: 1px solid rgba(71, 85, 105, 0.66);
+    border-left: 0;
+  }
+  .campaign-stage,
+  [data-campaign-graph] { min-height: 25rem; height: 25rem; }
+}
+
+@media (max-width: 540px) {
+  .campaign-graph-header { padding: 0.85rem; }
+  .campaign-controls { grid-template-columns: 1fr; }
+  .campaign-controls label { grid-column: auto; }
+  .campaign-controls .button { width: 100%; }
+  .campaign-stage,
+  [data-campaign-graph] { min-height: 22rem; height: 22rem; }
+  .campaign-node-meta { grid-template-columns: 1fr; }
+  .campaign-legend { right: 0.75rem; border-radius: 0.65rem; }
+}
+
 .investigation-list {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -3253,6 +3508,16 @@ body::before {
   to { opacity: 1; transform: none; }
 }
 
+@keyframes campaign-edge-in {
+  from { opacity: 0; stroke-dashoffset: 24; }
+  to { stroke-dashoffset: 0; }
+}
+
+@keyframes campaign-node-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 @media (max-width: 820px) {
   .page-header {
     min-height: 24rem;
@@ -3285,6 +3550,8 @@ body::before {
   .score-seg,
   .preview-row-enter,
   .top-threats.is-visible .threat-card,
+  .campaign-edge,
+  .campaign-node,
   .toast:not([hidden]) {
     animation: none !important;
   }

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=11" />
+    <link rel="stylesheet" href="assets/styles.css?v=12" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -91,6 +91,7 @@
         </a>
         <div class="nav-links">
           <a href="#ioc-lookup">Check an IOC</a>
+          <a href="#campaign-graph">Campaign graph</a>
           <a href="#live-preview">Browse feed</a>
           <a href="#sources">Sources</a>
           <a href="#indicator-types">Types</a>
@@ -315,6 +316,71 @@
         <div class="delta-actions">
           <a class="button-link primary" href="iocs/delta.json" download>Delta JSON</a>
           <a class="button-link" href="iocs/delta.jsonl" download>Event stream</a>
+        </div>
+      </section>
+
+      <section
+        id="campaign-graph"
+        class="panel campaign-graph-section"
+        data-campaign-root
+        aria-labelledby="campaign-graph-heading"
+        hidden
+      >
+        <div class="panel-header campaign-graph-header">
+          <div>
+            <p class="eyebrow">Campaign lens · inferred relationships</p>
+            <h2 id="campaign-graph-heading" class="panel-title">Threat Campaign Graph</h2>
+            <p class="panel-subtitle">
+              Explore shared tags and reporting sources. These are investigation pivots,
+              not claims of common threat-actor ownership.
+            </p>
+          </div>
+          <div class="campaign-controls" aria-label="Campaign graph controls">
+            <label for="campaign-mode">Connect through</label>
+            <select id="campaign-mode" data-campaign-mode>
+              <option value="all">Tags + sources</option>
+              <option value="tags">Tags only</option>
+              <option value="sources">Sources only</option>
+            </select>
+            <button type="button" class="button ghost" data-campaign-layout>
+              Remix layout
+            </button>
+          </div>
+        </div>
+        <div class="panel-body campaign-graph-body">
+          <div class="campaign-stage" data-campaign-stage>
+            <svg
+              data-campaign-graph
+              viewBox="0 0 1000 520"
+              role="img"
+              aria-label="Interactive relationship graph of indicators, tags, and reporting sources"
+            ></svg>
+            <div class="campaign-empty" data-campaign-empty hidden>
+              <strong>No shared pivots in this preview</strong>
+              <span>Try tags and sources together, or wait for the next feed refresh.</span>
+            </div>
+            <div class="campaign-legend" aria-label="Graph legend">
+              <span><i class="legend-node tag"></i>Tag pivot</span>
+              <span><i class="legend-node source"></i>Source pivot</span>
+              <span><i class="legend-node indicator"></i>Indicator</span>
+            </div>
+          </div>
+          <aside class="campaign-inspector" data-campaign-inspector aria-live="polite">
+            <p class="eyebrow">Selected node</p>
+            <h3 data-campaign-title>Select a node</h3>
+            <p data-campaign-description>
+              Choose a pivot to understand its reach, or choose an indicator to add it to your investigation queue.
+            </p>
+            <dl class="campaign-node-meta" data-campaign-meta hidden>
+              <div><dt>Kind</dt><dd data-campaign-kind>—</dd></div>
+              <div><dt>Connections</dt><dd data-campaign-connections>—</dd></div>
+              <div><dt>Score</dt><dd data-campaign-score>—</dd></div>
+            </dl>
+            <button type="button" class="button detection-export" data-campaign-queue disabled>
+              Add indicator to queue
+            </button>
+            <p class="campaign-summary" data-campaign-summary>Building graph…</p>
+          </aside>
         </div>
       </section>
 
@@ -816,7 +882,7 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=11"></script>
-    <script defer src="assets/dashboard.js?v=11"></script>
+    <script defer src="assets/dashboard-core.js?v=12"></script>
+    <script defer src="assets/dashboard.js?v=12"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=10" />
+    <link rel="stylesheet" href="assets/styles.css?v=11" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -194,6 +194,12 @@
             </button>
             <button type="button" class="button ghost" data-investigation-json>
               Export JSON
+            </button>
+            <button type="button" class="button ghost detection-export" data-investigation-sigma>
+              Build Sigma
+            </button>
+            <button type="button" class="button ghost detection-export" data-investigation-suricata>
+              Build Suricata
             </button>
             <button type="button" class="button ghost danger" data-investigation-clear>
               Clear queue
@@ -785,6 +791,18 @@
               rel="nofollow"
               download
               >TAXII 2.1 envelope</a>
+            <a class="button-link detection-download" href="detections/sigma/network-iocs.yml" download>
+              Sigma network rules
+            </a>
+            <a class="button-link detection-download" href="detections/suricata/swiftioc.rules" download>
+              Suricata rules
+            </a>
+            <a class="button-link detection-download" href="detections/dns/swiftioc.rpz" download>
+              DNS RPZ
+            </a>
+            <a class="button-link" href="detections/manifest.json">
+              Detection manifest
+            </a>
           </div>
           <p class="panel-footnote">
             The ★ high-confidence feeds contain only indicators scoring ≥80 or
@@ -798,7 +816,7 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=10"></script>
-    <script defer src="assets/dashboard.js?v=10"></script>
+    <script defer src="assets/dashboard-core.js?v=11"></script>
+    <script defer src="assets/dashboard.js?v=11"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -857,8 +857,13 @@
               rel="nofollow"
               download
               >TAXII 2.1 envelope</a>
-            <a class="button-link detection-download" href="detections/sigma/network-iocs.yml" download>
+            <a class="button-link detection-download" href="detections/sigma/network-iocs.yml"
+              data-detection-artifact="sigma/network-iocs.yml" download hidden>
               Sigma network rules
+            </a>
+            <a class="button-link detection-download" href="detections/sigma/dns-iocs.yml"
+              data-detection-artifact="sigma/dns-iocs.yml" download hidden>
+              Sigma DNS rules
             </a>
             <a class="button-link detection-download" href="detections/suricata/swiftioc.rules" download>
               Suricata rules

--- a/swiftioc/__init__.py
+++ b/swiftioc/__init__.py
@@ -106,6 +106,11 @@ from .collect import (
     type_breakdown,
     type_counts,
 )
+from .detections import (
+    DEPLOYABLE_TYPES,
+    DETECTION_NAMESPACE,
+    write_detection_pack,
+)
 from .writers import (
     CSV_HEADER,
     build_stix_bundle,
@@ -173,6 +178,8 @@ __all__ = [
     "write_changelog", "write_dashboard_feed", "build_delta", "write_delta", "build_stix_bundle", "CSV_HEADER",
     "STIX_NAMESPACE", "STIX_IDENTITY_ID", "STIX_TLP_ID", "STIX_HASH_NAMES",
     "MISP_ATTRIBUTE_TYPES", "MISP_CATEGORY_BY_TYPE",
+    # detection pack
+    "DEPLOYABLE_TYPES", "DETECTION_NAMESPACE", "write_detection_pack",
     # logging
     "JsonLineFormatter", "configure_logging",
     "gh_summary_path", "append_gh_summary",

--- a/swiftioc/cli.py
+++ b/swiftioc/cli.py
@@ -13,6 +13,7 @@ import yaml
 
 from . import http_client
 from .collect import collect_from_yaml, parse_name_int_pairs, top_tags, type_breakdown
+from .detections import write_detection_pack
 from .http_client import UA_POOL, get_fetch_metrics, logger
 from .logging_utils import configure_logging
 from .models import classify, defang_min, iso, now_utc, parse_dt
@@ -307,12 +308,22 @@ def main() -> int:
         len(high_conf), len(rows), args.high_confidence_score,
     )
 
+    run_ts = iso(now_utc())
+    detection_manifest = write_detection_pack(
+        out_dir / "detections", high_conf, generated_at=run_ts
+    )
+    logger.info(
+        "Detection pack: %d Sigma rules, %d Suricata rules, %d RPZ domains",
+        detection_manifest["artifacts"]["sigma_rules"],
+        detection_manifest["artifacts"]["suricata_rules"],
+        detection_manifest["artifacts"]["rpz_domains"],
+    )
+
     dashboard_written = write_dashboard_feed(
         out_dir / "iocs" / "dashboard.jsonl", rows, limit=args.dashboard_rows
     )
     logger.info("Dashboard feed: top %d rows written", dashboard_written)
 
-    run_ts = iso(now_utc())
     delta = build_delta(
         previous_rows,
         rows,
@@ -413,6 +424,7 @@ def main() -> int:
         "corroborated_total": corroborated_total,
         "high_confidence_total": len(high_conf),
         "high_confidence_score": args.high_confidence_score,
+        "detection_pack": detection_manifest["artifacts"],
         "delta_counts": delta["counts"],
         "delta_baseline_available": delta["baseline_available"],
         "counts": counts,

--- a/swiftioc/detections.py
+++ b/swiftioc/detections.py
@@ -1,0 +1,219 @@
+"""Compile curated SwiftIOC intelligence into reviewable detection artifacts."""
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import uuid
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
+
+import yaml
+
+from .models import Indicator, classify, parse_dt, refang
+from .writers import STIX_NAMESPACE, _atomic_text_writer
+
+
+DETECTION_NAMESPACE = uuid.uuid5(STIX_NAMESPACE, "detection-pack")
+DEPLOYABLE_TYPES = {"ipv4", "ipv6", "ipv4_cidr", "ipv6_cidr", "domain"}
+
+
+def _unique_observables(rows: Iterable[Indicator]) -> Tuple[Dict[str, List[str]], Counter[str]]:
+    """Return validated, raw observables grouped by type and skipped counts."""
+    grouped: Dict[str, set[str]] = {name: set() for name in sorted(DEPLOYABLE_TYPES)}
+    skipped: Counter[str] = Counter()
+    for row in rows:
+        kind = str(row.type).lower()
+        value = refang(row.indicator).strip()
+        if kind not in DEPLOYABLE_TYPES:
+            skipped[kind or "unknown"] += 1
+            continue
+        try:
+            if kind in {"ipv4", "ipv6"}:
+                parsed = ipaddress.ip_address(value)
+                expected = 4 if kind == "ipv4" else 6
+                if parsed.version != expected:
+                    raise ValueError("address family mismatch")
+                value = str(parsed)
+            elif kind in {"ipv4_cidr", "ipv6_cidr"}:
+                parsed_network = ipaddress.ip_network(value, strict=False)
+                expected = 4 if kind == "ipv4_cidr" else 6
+                if parsed_network.version != expected:
+                    raise ValueError("network family mismatch")
+                value = str(parsed_network)
+            else:
+                value = value.lower().rstrip(".")
+                if classify(value) != "domain":
+                    raise ValueError("invalid domain")
+        except ValueError:
+            skipped[f"invalid_{kind}"] += 1
+            continue
+        grouped[kind].add(value)
+    return {kind: sorted(values) for kind, values in grouped.items()}, skipped
+
+
+def _sigma_rule(*, name: str, title: str, description: str, logsource: Dict[str, str],
+                detection: Dict[str, Any], generated_at: str) -> str:
+    observed = parse_dt(generated_at)
+    document: Dict[str, Any] = {
+        "title": title,
+        "id": str(uuid.uuid5(DETECTION_NAMESPACE, name)),
+        "status": "experimental",
+        "description": description,
+        "references": ["https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/"],
+        "author": "SwiftIOC",
+        "date": observed.strftime("%Y-%m-%d") if observed else generated_at[:10],
+        "tags": ["attack.command_and_control"],
+        "logsource": logsource,
+        "detection": detection,
+        "falsepositives": ["Legitimate infrastructure sharing an address or domain; validate with local context."],
+        "level": "high",
+    }
+    return yaml.safe_dump(document, sort_keys=False, allow_unicode=True, width=120)
+
+
+def _sigma_documents(grouped: Dict[str, List[str]], generated_at: str) -> Dict[str, str]:
+    addresses = grouped["ipv4"] + grouped["ipv6"]
+    networks = grouped["ipv4_cidr"] + grouped["ipv6_cidr"]
+    documents: Dict[str, str] = {}
+    if addresses or networks:
+        detection: Dict[str, Any] = {}
+        if addresses:
+            detection.update({
+                "ip_source": {"SourceIp": addresses},
+                "ip_destination": {"DestinationIp": addresses},
+            })
+        if networks:
+            detection.update({
+                "ip_source_network": {"SourceIp|cidr": networks},
+                "ip_destination_network": {"DestinationIp|cidr": networks},
+            })
+        detection["condition"] = "1 of ip_*"
+        documents["sigma/network-iocs.yml"] = _sigma_rule(
+            name="network-iocs",
+            title="SwiftIOC high-confidence network indicators",
+            description="Detects network traffic where either endpoint matches SwiftIOC's curated high-confidence feed.",
+            logsource={"category": "network_connection"},
+            detection=detection,
+            generated_at=generated_at,
+        )
+    if grouped["domain"]:
+        documents["sigma/dns-iocs.yml"] = _sigma_rule(
+            name="dns-iocs",
+            title="SwiftIOC high-confidence DNS indicators",
+            description="Detects DNS queries ending in a domain from SwiftIOC's curated high-confidence feed.",
+            logsource={"category": "dns"},
+            detection={
+                "domain_exact": {"query": grouped["domain"]},
+                "domain_subdomain": {"query|endswith": [f".{value}" for value in grouped["domain"]]},
+                "condition": "domain_exact or domain_subdomain",
+            },
+            generated_at=generated_at,
+        )
+    return documents
+
+
+def _sid(value: str, used: set[int]) -> int:
+    candidate = 4_000_000 + int(hashlib.sha256(value.encode("utf-8")).hexdigest()[:8], 16) % 900_000
+    while candidate in used:
+        candidate = 4_000_000 + ((candidate - 4_000_000 + 1) % 900_000)
+    used.add(candidate)
+    return candidate
+
+
+def _suricata_rules(grouped: Dict[str, List[str]]) -> Tuple[str, int]:
+    rules: List[str] = []
+    used: set[int] = set()
+    addresses = grouped["ipv4"] + grouped["ipv6"] + grouped["ipv4_cidr"] + grouped["ipv6_cidr"]
+    for address in addresses:
+        target = f"[{address}]" if ":" in address else address
+        for direction, header in (
+            ("inbound", f"alert ip {target} any -> $HOME_NET any"),
+            ("outbound", f"alert ip $HOME_NET any -> {target} any"),
+        ):
+            sid = _sid(f"ip:{address}:{direction}", used)
+            rules.append(
+                f'{header} (msg:"SwiftIOC {direction} high-confidence IP match"; '
+                f'classtype:trojan-activity; sid:{sid}; rev:1;)'
+            )
+    for domain in grouped["domain"]:
+        sid = _sid(f"dns:{domain}", used)
+        rules.append(
+            'alert dns $HOME_NET any -> any 53 '
+            f'(msg:"SwiftIOC high-confidence DNS match"; dns.query; dotprefix; content:".{domain}"; '
+            f'nocase; endswith; classtype:trojan-activity; sid:{sid}; rev:1;)'
+        )
+    header = (
+        "# SwiftIOC high-confidence detection pack\n"
+        "# Review and tune against local allowlists before enabling enforcement.\n"
+    )
+    return header + "\n".join(rules) + ("\n" if rules else ""), len(rules)
+
+
+def _rpz_zone(domains: Sequence[str], generated_at: str) -> str:
+    observed = parse_dt(generated_at)
+    serial = observed.strftime("%Y%m%d%H") if observed else "1"
+    lines = [
+        "$TTL 300",
+        f"@ IN SOA localhost. root.localhost. ({serial} 300 60 86400 60)",
+        "@ IN NS localhost.",
+    ]
+    for domain in domains:
+        lines.extend((f"{domain}. CNAME .", f"*.{domain}. CNAME ."))
+    return "\n".join(lines) + "\n"
+
+
+def _pack_readme() -> str:
+    return """# SwiftIOC Detection Pack
+
+Generated from the curated high-confidence feed. Treat these artifacts as detection-as-code inputs: review them, apply local allowlists, test in alert-only mode, and then promote them through your normal change process.
+
+- `sigma/network-iocs.yml` matches source or destination IPs in normalized network-connection events.
+- `sigma/dns-iocs.yml` matches malicious domain suffixes in normalized DNS events.
+- `suricata/swiftioc.rules` contains stable-SID inbound, outbound, and DNS alert rules.
+- `dns/swiftioc.rpz` is a response-policy zone for exact domains and their subdomains.
+- `manifest.json` records coverage and every unsupported or invalid indicator type that was skipped.
+
+Compile Sigma for your backend with Sigma CLI, load the Suricata file through your managed rules directory, or configure the RPZ as a secondary policy zone. Field mappings and network variables vary by environment, so validate generated detections before production use.
+"""
+
+
+def write_detection_pack(out_dir: Path, rows: Sequence[Indicator], *, generated_at: str) -> Dict[str, Any]:
+    """Write Sigma, Suricata, and DNS RPZ artifacts plus an auditable manifest."""
+    grouped, skipped = _unique_observables(rows)
+    sigma = _sigma_documents(grouped, generated_at)
+    suricata, suricata_count = _suricata_rules(grouped)
+    artifacts: Dict[str, str] = {
+        **sigma,
+        "suricata/swiftioc.rules": suricata,
+        "dns/swiftioc.rpz": _rpz_zone(grouped["domain"], generated_at),
+        "README.md": _pack_readme(),
+    }
+    # Optional Sigma families can disappear as the curated feed changes. Never
+    # leave an older rule on disk where a publisher would mistake it for part
+    # of the current pack.
+    managed_optional = {"sigma/network-iocs.yml", "sigma/dns-iocs.yml"}
+    for relative in managed_optional - artifacts.keys():
+        (out_dir / relative).unlink(missing_ok=True)
+    included = {kind: len(values) for kind, values in grouped.items() if values}
+    manifest: Dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": generated_at,
+        "source": "SwiftIOC high-confidence feed",
+        "policy": "review-required",
+        "included": included,
+        "skipped": dict(sorted(skipped.items())),
+        "artifacts": {
+            "sigma_rules": len(sigma),
+            "suricata_rules": suricata_count,
+            "rpz_domains": len(grouped["domain"]),
+        },
+    }
+    for relative, content in artifacts.items():
+        with _atomic_text_writer(out_dir / relative) as handle:
+            handle.write(content)
+    with _atomic_text_writer(out_dir / "manifest.json") as handle:
+        json.dump(manifest, handle, ensure_ascii=False, indent=2, sort_keys=True)
+        handle.write("\n")
+    return manifest

--- a/swiftioc/detections.py
+++ b/swiftioc/detections.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 import ipaddress
 import json
+import re
 import uuid
 from collections import Counter
 from pathlib import Path
@@ -114,15 +115,20 @@ def _sigma_documents(grouped: Dict[str, List[str]], generated_at: str) -> Dict[s
     return documents
 
 
-def _sid(value: str, used: set[int]) -> int:
+def _sid(value: str, used: set[int], registry: Dict[str, int]) -> int:
+    registered = registry.get(value)
+    if registered is not None and registered not in used:
+        used.add(registered)
+        return registered
     candidate = 4_000_000 + int(hashlib.sha256(value.encode("utf-8")).hexdigest()[:8], 16) % 900_000
     while candidate in used:
         candidate = 4_000_000 + ((candidate - 4_000_000 + 1) % 900_000)
     used.add(candidate)
+    registry[value] = candidate
     return candidate
 
 
-def _suricata_rules(grouped: Dict[str, List[str]]) -> Tuple[str, int]:
+def _suricata_rules(grouped: Dict[str, List[str]], registry: Dict[str, int]) -> Tuple[str, int]:
     rules: List[str] = []
     used: set[int] = set()
     addresses = grouped["ipv4"] + grouped["ipv6"] + grouped["ipv4_cidr"] + grouped["ipv6_cidr"]
@@ -132,13 +138,13 @@ def _suricata_rules(grouped: Dict[str, List[str]]) -> Tuple[str, int]:
             ("inbound", f"alert ip {target} any -> $HOME_NET any"),
             ("outbound", f"alert ip $HOME_NET any -> {target} any"),
         ):
-            sid = _sid(f"ip:{address}:{direction}", used)
+            sid = _sid(f"ip:{address}:{direction}", used, registry)
             rules.append(
                 f'{header} (msg:"SwiftIOC {direction} high-confidence IP match"; '
                 f'classtype:trojan-activity; sid:{sid}; rev:1;)'
             )
     for domain in grouped["domain"]:
-        sid = _sid(f"dns:{domain}", used)
+        sid = _sid(f"dns:{domain}", used, registry)
         rules.append(
             'alert dns $HOME_NET any -> any 53 '
             f'(msg:"SwiftIOC high-confidence DNS match"; dns.query; dotprefix; content:".{domain}"; '
@@ -151,9 +157,42 @@ def _suricata_rules(grouped: Dict[str, List[str]]) -> Tuple[str, int]:
     return header + "\n".join(rules) + ("\n" if rules else ""), len(rules)
 
 
-def _rpz_zone(domains: Sequence[str], generated_at: str) -> str:
+def _load_detection_state(out_dir: Path) -> Tuple[Dict[str, int], int | None]:
+    registry: Dict[str, int] = {}
+    try:
+        previous = json.loads(
+            (out_dir / "suricata" / "sid-registry.json").read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError, TypeError):
+        previous = {}
+    if isinstance(previous, dict):
+        for key, value in previous.items():
+            if isinstance(key, str) and isinstance(value, int) and 1 <= value <= 0xFFFFFFFF:
+                registry[key] = value
+
+    previous_serial: int | None = None
+    try:
+        zone = (out_dir / "dns" / "swiftioc.rpz").read_text(encoding="utf-8")
+        match = re.search(r"root\.localhost\.\s*\((\d+)", zone)
+        if match:
+            value = int(match.group(1))
+            if 0 <= value <= 0xFFFFFFFF:
+                previous_serial = value
+    except OSError:
+        pass
+    return registry, previous_serial
+
+
+def _rpz_serial(generated_at: str, previous: int | None) -> int:
     observed = parse_dt(generated_at)
-    serial = observed.strftime("%Y%m%d%H") if observed else "1"
+    candidate = int(observed.timestamp()) if observed else 1
+    candidate = max(1, min(candidate, 0xFFFFFFFF))
+    if previous is None or candidate > previous:
+        return candidate
+    return 0 if previous == 0xFFFFFFFF else previous + 1
+
+
+def _rpz_zone(domains: Sequence[str], serial: int) -> str:
     lines = [
         "$TTL 300",
         f"@ IN SOA localhost. root.localhost. ({serial} 300 60 86400 60)",
@@ -172,6 +211,7 @@ Generated from the curated high-confidence feed. Treat these artifacts as detect
 - `sigma/network-iocs.yml` matches source or destination IPs in normalized network-connection events.
 - `sigma/dns-iocs.yml` matches malicious domain suffixes in normalized DNS events.
 - `suricata/swiftioc.rules` contains stable-SID inbound, outbound, and DNS alert rules.
+- `suricata/sid-registry.json` preserves collision-resolved SIDs across feed revisions.
 - `dns/swiftioc.rpz` is a response-policy zone for exact domains and their subdomains.
 - `manifest.json` records coverage and every unsupported or invalid indicator type that was skipped.
 
@@ -182,12 +222,17 @@ Compile Sigma for your backend with Sigma CLI, load the Suricata file through yo
 def write_detection_pack(out_dir: Path, rows: Sequence[Indicator], *, generated_at: str) -> Dict[str, Any]:
     """Write Sigma, Suricata, and DNS RPZ artifacts plus an auditable manifest."""
     grouped, skipped = _unique_observables(rows)
+    sid_registry, previous_rpz_serial = _load_detection_state(out_dir)
     sigma = _sigma_documents(grouped, generated_at)
-    suricata, suricata_count = _suricata_rules(grouped)
+    suricata, suricata_count = _suricata_rules(grouped, sid_registry)
+    rpz_serial = _rpz_serial(generated_at, previous_rpz_serial)
     artifacts: Dict[str, str] = {
         **sigma,
         "suricata/swiftioc.rules": suricata,
-        "dns/swiftioc.rpz": _rpz_zone(grouped["domain"], generated_at),
+        "suricata/sid-registry.json": json.dumps(
+            dict(sorted(sid_registry.items())), ensure_ascii=False, indent=2
+        ) + "\n",
+        "dns/swiftioc.rpz": _rpz_zone(grouped["domain"], rpz_serial),
         "README.md": _pack_readme(),
     }
     # Optional Sigma families can disappear as the curated feed changes. Never
@@ -202,6 +247,7 @@ def write_detection_pack(out_dir: Path, rows: Sequence[Indicator], *, generated_
         "generated_at": generated_at,
         "source": "SwiftIOC high-confidence feed",
         "policy": "review-required",
+        "rpz_serial": rpz_serial,
         "included": included,
         "skipped": dict(sorted(skipped.items())),
         "artifacts": {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,6 +73,9 @@ def test_cli_main_end_to_end_writes_expected_outputs(tmp_path, monkeypatch):
         "iocs/delta.json", "iocs/delta.jsonl",
         "iocs/taxii2-envelope.json",
         "changelog/CHANGELOG.md",
+        "detections/manifest.json", "detections/README.md",
+        "detections/sigma/network-iocs.yml",
+        "detections/suricata/swiftioc.rules", "detections/dns/swiftioc.rpz",
     ]:
         assert (out_dir / rel).exists(), f"missing output: {rel}"
 
@@ -85,6 +88,7 @@ def test_cli_main_end_to_end_writes_expected_outputs(tmp_path, monkeypatch):
     assert "score_bands" in diag and "fetch_metrics" in diag
     assert diag["delta_baseline_available"] is False
     assert diag["delta_counts"] == {"added": 0, "updated": 0, "removed": 0}
+    assert diag["detection_pack"]["suricata_rules"] == 4
 
     rows = [json.loads(line) for line in (out_dir / "iocs" / "latest.jsonl").read_text(encoding="utf-8").splitlines()]
     assert {r["indicator"] for r in rows} == {"1[.]1[.]1[.]1", "2[.]2[.]2[.]2", "3[.]3[.]3[.]3"}

--- a/tests/test_detections.py
+++ b/tests/test_detections.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import uuid
@@ -109,3 +110,36 @@ def test_detection_pack_records_invalid_observables(tmp_path):
     }
     assert not (tmp_path / "sigma" / "network-iocs.yml").exists()
     assert not (tmp_path / "sigma" / "dns-iocs.yml").exists()
+
+
+def test_suricata_collision_registry_keeps_unchanged_rule_sid(tmp_path):
+    colliding_ip = _indicator("154.91.59.103", "ipv4")
+    colliding_domain = _indicator("fakelouisvuitton.org", "domain")
+    si.write_detection_pack(
+        tmp_path, [colliding_ip, colliding_domain], generated_at="2026-09-08T02:00:00Z"
+    )
+    domain_key = "dns:fakelouisvuitton.org"
+    base_sid = 4_000_000 + int(hashlib.sha256(domain_key.encode()).hexdigest()[:8], 16) % 900_000
+    registry = json.loads((tmp_path / "suricata" / "sid-registry.json").read_text())
+    domain_sid = registry[domain_key]
+    assert domain_sid != base_sid
+
+    si.write_detection_pack(
+        tmp_path, [colliding_domain], generated_at="2026-09-08T03:00:00Z"
+    )
+
+    registry = json.loads((tmp_path / "suricata" / "sid-registry.json").read_text())
+    assert registry[domain_key] == domain_sid
+    assert f"sid:{domain_sid};" in (tmp_path / "suricata" / "swiftioc.rules").read_text()
+
+
+def test_rpz_serial_advances_when_two_revisions_share_a_timestamp(tmp_path):
+    first = si.write_detection_pack(
+        tmp_path, [_indicator("first.example", "domain")], generated_at="2026-09-08T02:00:00Z"
+    )
+    second = si.write_detection_pack(
+        tmp_path, [_indicator("second.example", "domain")], generated_at="2026-09-08T02:00:00Z"
+    )
+
+    assert second["rpz_serial"] == first["rpz_serial"] + 1
+    assert f"({second['rpz_serial']} " in (tmp_path / "dns" / "swiftioc.rpz").read_text()

--- a/tests/test_detections.py
+++ b/tests/test_detections.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import re
+import uuid
+
+import yaml
+
+import swiftioc as si
+
+
+def _indicator(value: str, kind: str, score: int = 90) -> si.Indicator:
+    return si.Indicator(
+        indicator=value,
+        type=kind,
+        source="feed-a,feed-b",
+        first_seen="2026-09-08T00:00:00Z",
+        last_seen="2026-09-08T01:00:00Z",
+        confidence="high",
+        tlp="CLEAR",
+        tags="c2",
+        reference="https://example.invalid/report",
+        context="test fixture",
+        score=score,
+    )
+
+
+def test_detection_pack_writes_valid_type_aware_artifacts(tmp_path):
+    rows = [
+        _indicator("1[.]2[.]3[.]4", "ipv4"),
+        _indicator("2001:db8::1", "ipv6"),
+        _indicator("evil[.]example", "domain"),
+        _indicator("hxxps://evil[.]example/dropper", "url"),
+        _indicator("a" * 64, "sha256"),
+    ]
+
+    manifest = si.write_detection_pack(
+        tmp_path, rows, generated_at="2026-09-08T02:00:00Z"
+    )
+
+    assert manifest["policy"] == "review-required"
+    assert manifest["included"] == {"domain": 1, "ipv4": 1, "ipv6": 1}
+    assert manifest["skipped"] == {"sha256": 1, "url": 1}
+    assert manifest["artifacts"] == {
+        "sigma_rules": 2,
+        "suricata_rules": 5,
+        "rpz_domains": 1,
+    }
+
+    network = yaml.safe_load((tmp_path / "sigma" / "network-iocs.yml").read_text())
+    assert network["logsource"] == {"category": "network_connection"}
+    assert network["detection"]["ip_source"]["SourceIp"] == ["1.2.3.4", "2001:db8::1"]
+    assert network["id"] == str(uuid.uuid5(si.DETECTION_NAMESPACE, "network-iocs"))
+
+    dns = yaml.safe_load((tmp_path / "sigma" / "dns-iocs.yml").read_text())
+    assert dns["detection"]["domain_exact"]["query"] == ["evil.example"]
+    assert dns["detection"]["domain_subdomain"]["query|endswith"] == [".evil.example"]
+
+    rules = (tmp_path / "suricata" / "swiftioc.rules").read_text()
+    assert "1.2.3.4" in rules
+    assert "[2001:db8::1]" in rules
+    assert 'dotprefix; content:".evil.example"' in rules
+    assert "hxxps" not in rules
+    assert len(re.findall(r"\bsid:\d+;", rules)) == 5
+
+    rpz = (tmp_path / "dns" / "swiftioc.rpz").read_text()
+    assert "evil.example. CNAME ." in rpz
+    assert "*.evil.example. CNAME ." in rpz
+    assert json.loads((tmp_path / "manifest.json").read_text()) == manifest
+
+
+def test_detection_pack_is_deterministic_and_deduplicates(tmp_path):
+    row = _indicator("Example[.]COM.", "domain")
+    duplicate = _indicator("example.com", "domain")
+
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    si.write_detection_pack(first, [row, duplicate], generated_at="2026-09-08T02:00:00Z")
+    si.write_detection_pack(second, [duplicate, row], generated_at="2026-09-08T02:00:00Z")
+
+    assert (first / "sigma" / "dns-iocs.yml").read_text() == (
+        second / "sigma" / "dns-iocs.yml"
+    ).read_text()
+    assert (first / "suricata" / "swiftioc.rules").read_text() == (
+        second / "suricata" / "swiftioc.rules"
+    ).read_text()
+    assert (first / "manifest.json").read_text() == (second / "manifest.json").read_text()
+
+
+def test_detection_pack_records_invalid_observables(tmp_path):
+    # Seed optional rules, then prove an empty deployable set cannot leave a
+    # stale detection behind for the publisher to serve as current.
+    si.write_detection_pack(
+        tmp_path,
+        [_indicator("1.2.3.4", "ipv4"), _indicator("evil.example", "domain")],
+        generated_at="2026-09-08T01:00:00Z",
+    )
+    manifest = si.write_detection_pack(
+        tmp_path,
+        [_indicator("999.2.3.4", "ipv4"), _indicator("bad domain", "domain")],
+        generated_at="2026-09-08T02:00:00Z",
+    )
+    assert manifest["included"] == {}
+    assert manifest["skipped"] == {"invalid_domain": 1, "invalid_ipv4": 1}
+    assert manifest["artifacts"] == {
+        "sigma_rules": 0,
+        "suricata_rules": 0,
+        "rpz_domains": 0,
+    }
+    assert not (tmp_path / "sigma" / "network-iocs.yml").exists()
+    assert not (tmp_path / "sigma" / "dns-iocs.yml").exists()


### PR DESCRIPTION
SwiftIOC currently publishes strong intelligence, but analysts still have to translate a flat feed into investigation pivots and deployable detection logic. This PR closes both gaps with an automated Detection Pack Compiler and an interactive Threat Campaign Graph.

The collector now converts each curated run into Sigma network/DNS rules, Suricata IP/DNS alerts, a BIND-compatible DNS RPZ, and an audit manifest. Inputs are refanged, validated, normalized, and deduplicated; CIDRs use Sigma's dedicated modifier; DNS matching respects label boundaries; Suricata SIDs are deterministic and collision-checked; unsupported types are recorded; and stale optional rules are removed when an observable family disappears.

The dashboard adds a campaign lens that connects indicators through shared tags and reporting sources. It removes generic severity and feed-management tags, suppresses singleton pivots, ranks useful relationships, and caps the visualization at six pivots and 24 indicators for stable performance. Analysts can switch between combined, tag-only, and source-only views, remix the layout, navigate nodes with a keyboard, inspect direct neighbors, and add findings to the private investigation queue. The graph rebuilds when preview filters or feed data change and clearly states that relationships are investigation pivots rather than attribution claims.

The browser-local workspace also gains **Build Sigma** and **Build Suricata** actions. These reject malformed browser-storage values and create case-specific rules without sending investigation data to a server. The exports panel reads the detection manifest and only exposes optional Sigma artifacts that exist in the current snapshot.

Review follow-ups preserve collision-resolved Suricata SIDs across feed changes, advance the RPZ serial for every published revision, accept IPv4-embedded IPv6 observables in browser exports, and prevent optional Sigma links from producing 404 downloads.

Frontend refinements include responsive graph/inspector layouts, consistent section spacing, unclipped mobile controls, cache-busting asset revisions, reduced-motion support, improved graph focus states, and removal of a stray patch character that invalidated a CSS comment.

Validation:
- 154 Python tests pass
- 19 dashboard unit tests pass
- Ruff passes
- Pyright reports 0 errors
- GitHub CI and CodeQL pass on the final amended revision
- Headless Brave verified Sigma and Suricata downloads, graph rendering, keyboard selection, layout remixing, source/tag modes, and preview-filter synchronization
- Desktop and 390px mobile QA found no horizontal overflow, clipped graph controls, or console errors
- Generated Sigma YAML parses successfully and follows Sigma 2.1 structure/modifiers
- Generated Suricata rules follow documented DNS sticky-buffer, dotprefix, endswith, SID, and classtype forms
- HTML structural checks, dashboard JavaScript syntax checks, and `git diff --check` pass