### PR TITLE
Make the threat campaign graph analyst-grade

### DIFF
--- a/docs/THREAT_CAMPAIGN_GRAPH.md
+++ b/docs/THREAT_CAMPAIGN_GRAPH.md
@@ -17,12 +17,15 @@ These links are investigative hints. A shared tag or source is not proof that tw
 
 Analysts can switch between combined, tag-only, and source-only views; choose a focused, expanded, or maximum detail level; remix the deterministic cluster layout; inspect nodes with a mouse or keyboard; and add an indicator directly to the private investigation queue. The graph rebuilds when the live-preview filters or feed data change, and it never uploads selections or graph state.
 
+Arrow keys move between graph nodes, Home and End jump to the first or last node, and Enter or Space selects the focused node. A selected finding remains selected when the analyst remixes the layout or changes graph density. Phones start in the focused 24-IOC view for legible targets while retaining the larger options.
+
 Node color communicates risk, node size and the outer ring communicate corroboration, and source/tag pivots anchor their related indicators into readable clusters. Live graph counters show high-risk, corroborated, visible, and average-score totals. Node selection highlights only direct neighbors and fades unrelated paths; the inspector then exposes sources, timestamps, TLP, tags, context, related nodes, and the original report link. The layout uses an SVG view box and responsive inspector so it remains usable across desktop and mobile widths.
 
 ## Safety and performance
 
 - Graph construction accepts only bounded arrays and clips pivot labels.
 - Duplicate indicator identities collapse through the same case-aware key used by the investigation workspace.
+- Missing or placeholder source names never create synthetic relationships.
 - Rendering is bounded by the selected detail level and capped at 48 indicators plus eight pivots.
 - Motion uses opacity and stroke animation and respects `prefers-reduced-motion`.
 - Keyboard users can focus each node and select it with Enter or Space.

--- a/docs/THREAT_CAMPAIGN_GRAPH.md
+++ b/docs/THREAT_CAMPAIGN_GRAPH.md
@@ -15,14 +15,14 @@ These links are investigative hints. A shared tag or source is not proof that tw
 
 ## Analyst interaction
 
-Analysts can switch between combined, tag-only, and source-only views; remix the deterministic radial layout; inspect nodes with a mouse or keyboard; and add an indicator directly to the private investigation queue. The graph rebuilds when the live-preview filters or feed data change, and it never uploads selections or graph state.
+Analysts can switch between combined, tag-only, and source-only views; choose a focused, expanded, or maximum detail level; remix the deterministic cluster layout; inspect nodes with a mouse or keyboard; and add an indicator directly to the private investigation queue. The graph rebuilds when the live-preview filters or feed data change, and it never uploads selections or graph state.
 
-Node selection highlights only direct neighbors and fades unrelated paths. This makes dense constellations readable without discarding the wider context. The layout uses an SVG view box and responsive inspector so it remains usable across desktop and mobile widths.
+Node color communicates risk, node size and the outer ring communicate corroboration, and source/tag pivots anchor their related indicators into readable clusters. Live graph counters show high-risk, corroborated, visible, and average-score totals. Node selection highlights only direct neighbors and fades unrelated paths; the inspector then exposes sources, timestamps, TLP, tags, context, related nodes, and the original report link. The layout uses an SVG view box and responsive inspector so it remains usable across desktop and mobile widths.
 
 ## Safety and performance
 
 - Graph construction accepts only bounded arrays and clips pivot labels.
 - Duplicate indicator identities collapse through the same case-aware key used by the investigation workspace.
-- Rendering is capped at 30 total nodes by default.
+- Rendering is bounded by the selected detail level and capped at 48 indicators plus eight pivots.
 - Motion uses opacity and stroke animation and respects `prefers-reduced-motion`.
 - Keyboard users can focus each node and select it with Enter or Space.

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -359,9 +359,12 @@
       )
       .slice(0, maxIndicators);
     const selectedKeys = new Set(selectedRows.map(investigationKey));
+    const renderedPivots = selectedPivots.filter((pivot) =>
+      Array.from(pivot.rows.keys()).some((key) => selectedKeys.has(key))
+    );
 
     const nodes = [
-      ...selectedPivots.map((pivot) => ({
+      ...renderedPivots.map((pivot) => ({
         id: `pivot:${pivot.key}`,
         kind: 'pivot',
         pivotKind: pivot.kind,
@@ -384,7 +387,7 @@
       })),
     ];
     const edges = [];
-    selectedPivots.forEach((pivot) => {
+    renderedPivots.forEach((pivot) => {
       pivot.rows.forEach((_row, key) => {
         if (selectedKeys.has(key)) {
           edges.push({
@@ -404,7 +407,7 @@
       nodes,
       edges,
       stats: {
-        pivots: selectedPivots.length,
+        pivots: renderedPivots.length,
         indicators: selectedRows.length,
         relationships: edges.length,
         highScore: selectedScores.filter((value) => value >= 80).length,
@@ -414,8 +417,8 @@
         averageScore: selectedScores.length
           ? Math.round(selectedScores.reduce((total, value) => total + value, 0) / selectedScores.length)
           : 0,
-        tagPivots: selectedPivots.filter((pivot) => pivot.kind === 'tag').length,
-        sourcePivots: selectedPivots.filter((pivot) => pivot.kind === 'source').length,
+        tagPivots: renderedPivots.filter((pivot) => pivot.kind === 'tag').length,
+        sourcePivots: renderedPivots.filter((pivot) => pivot.kind === 'source').length,
       },
     };
   };

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -365,12 +365,18 @@
         label: pivot.label,
         count: Array.from(pivot.rows.keys()).filter((key) => selectedKeys.has(key)).length,
         totalCount: pivot.rows.size,
+        averageScore: Math.round(
+          Array.from(pivot.rows.values()).reduce((total, row) => total + effectiveScore(row), 0) /
+            Math.max(pivot.rows.size, 1)
+        ),
       })),
       ...selectedRows.map((row) => ({
         id: `ioc:${investigationKey(row)}`,
         kind: 'indicator',
         label: stringValue(row.indicator),
         score: effectiveScore(row),
+        sourceCount: Number(row.sourceCount) || rowSources(row).length,
+        tagCount: Array.isArray(row.tags) ? row.tags.length : 0,
         row,
       })),
     ];
@@ -389,6 +395,7 @@
     edges.sort((a, b) =>
       a.source.localeCompare(b.source) || a.target.localeCompare(b.target)
     );
+    const selectedScores = selectedRows.map(effectiveScore);
     return {
       mode,
       nodes,
@@ -397,6 +404,15 @@
         pivots: selectedPivots.length,
         indicators: selectedRows.length,
         relationships: edges.length,
+        highScore: selectedScores.filter((value) => value >= 80).length,
+        corroborated: selectedRows.filter((row) =>
+          (Number(row.sourceCount) || rowSources(row).length) >= 2
+        ).length,
+        averageScore: selectedScores.length
+          ? Math.round(selectedScores.reduce((total, value) => total + value, 0) / selectedScores.length)
+          : 0,
+        tagPivots: selectedPivots.filter((pivot) => pivot.kind === 'tag').length,
+        sourcePivots: selectedPivots.filter((pivot) => pivot.kind === 'source').length,
       },
     };
   };

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -299,6 +299,7 @@
       'aggregated', 'blocklist', 'critical', 'high', 'info', 'ioc', 'low',
       'malicious', 'malware', 'medium', 'threat-intel', 'threat intelligence',
     ]);
+    const ignoredSources = new Set(['', 'n/a', 'none', 'unknown', 'unspecified']);
     const sourceNames = new Set(rows.flatMap((row) => rowSources(row).map(lower)));
     const pivots = new Map();
 
@@ -324,7 +325,9 @@
         });
       }
       if (mode !== 'tags') {
-        rowSources(row).slice(0, 25).forEach((source) => addPivot('source', source, row));
+        rowSources(row).slice(0, 25).forEach((source) => {
+          if (!ignoredSources.has(lower(source))) addPivot('source', source, row);
+        });
       }
     });
 

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -238,7 +238,16 @@ test('builds deterministic campaign pivots and omits singleton relationships', (
     { ...row, indicator: 'three.example', tags: ['singleton'], sourceList: ['feed-b'], score: 70 },
   ];
   const graph = core.buildCampaignGraph(rows, { mode: 'tags' });
-  assert.deepEqual(graph.stats, { pivots: 1, indicators: 2, relationships: 2 });
+  assert.deepEqual(graph.stats, {
+    pivots: 1,
+    indicators: 2,
+    relationships: 2,
+    highScore: 2,
+    corroborated: 2,
+    averageScore: 85,
+    tagPivots: 1,
+    sourcePivots: 0,
+  });
   assert.equal(graph.nodes.find((node) => node.kind === 'pivot').label, 'ransomware');
   assert.equal(graph.nodes.some((node) => node.label === 'singleton'), false);
   assert.equal(graph.edges.every((edge) => edge.kind === 'tag'), true);
@@ -295,6 +304,9 @@ test('dashboard markup keeps IDs and labelled controls consistent', () => {
   assert.match(html, /data-investigation-sigma/);
   assert.match(html, /data-investigation-suricata/);
   assert.match(html, /data-campaign-graph/);
+  assert.match(html, /data-campaign-density/);
+  assert.match(html, /data-campaign-related-list/);
+  assert.match(html, /data-campaign-reference/);
   assert.match(html, /class="signal-radar"/);
   assert.match(html, /data-delta-root/);
   assert.match(html, /iocs\/delta\.jsonl/);

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -275,6 +275,16 @@ test('campaign graph respects source mode and graph-size caps', () => {
   assert.equal(graph.nodes.find((node) => node.kind === 'pivot').pivotKind, 'source');
 });
 
+test('campaign graph does not invent relationships for missing sources', () => {
+  const rows = [
+    { ...row, indicator: 'one.example', source: 'unknown', sourceList: [], sourceCount: 0, tags: [] },
+    { ...row, indicator: 'two.example', source: 'unknown', sourceList: [], sourceCount: 0, tags: [] },
+  ];
+  const graph = core.buildCampaignGraph(rows, { mode: 'sources' });
+  assert.equal(graph.nodes.length, 0);
+  assert.equal(graph.edges.length, 0);
+});
+
 test('dashboard markup keeps IDs and labelled controls consistent', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
   const css = fs.readFileSync(path.join(__dirname, 'styles.css'), 'utf8');
@@ -304,6 +314,7 @@ test('dashboard markup keeps IDs and labelled controls consistent', () => {
   assert.match(html, /data-investigation-sigma/);
   assert.match(html, /data-investigation-suricata/);
   assert.match(html, /data-campaign-graph/);
+  assert.match(html, /data-campaign-graph[\s\S]*?role="group"/);
   assert.match(html, /data-campaign-density/);
   assert.match(html, /data-campaign-related-list/);
   assert.match(html, /data-campaign-reference/);

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -285,6 +285,26 @@ test('campaign graph does not invent relationships for missing sources', () => {
   assert.equal(graph.edges.length, 0);
 });
 
+test('campaign graph prunes pivots disconnected by the indicator cap', () => {
+  const rows = ['alpha', 'beta', 'gamma'].flatMap((tag, tagIndex) =>
+    [0, 1].map((index) => ({
+      ...row,
+      indicator: `${tag}-${index}.example`,
+      tags: [tag],
+      score: 100 - tagIndex * 20,
+    }))
+  );
+  const graph = core.buildCampaignGraph(rows, {
+    mode: 'tags',
+    maxPivots: 3,
+    maxIndicators: 2,
+  });
+  assert.equal(graph.stats.pivots, 1);
+  assert.equal(graph.stats.tagPivots, 1);
+  assert.equal(graph.nodes.filter((node) => node.kind === 'pivot').length, 1);
+  assert.equal(graph.edges.length, 2);
+});
+
 test('dashboard markup keeps IDs and labelled controls consistent', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
   const css = fs.readFileSync(path.join(__dirname, 'styles.css'), 'utf8');

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -2285,8 +2285,12 @@
       return [0, 40, 60, 80][confidenceRankForRow(row)] || 0;
     };
 
-    const rowKey = (row) =>
-      normaliseLower(row.type) + '\u0000' + normaliseLower(row.indicator);
+    const rowKey = (row) => {
+      if (dashboardCore?.investigationKey) return dashboardCore.investigationKey(row);
+      const type = normaliseLower(row.type) || 'unknown';
+      const indicator = normaliseString(row.indicator);
+      return type + '\u0000' + (type === 'url' ? indicator : indicator.toLowerCase());
+    };
 
     const sourceCount = (rows) => {
       const sources = new Set();
@@ -3045,6 +3049,14 @@
     let graph = null;
     let selected = null;
     let rotation = 0;
+    if (density && window.matchMedia?.('(max-width: 540px)').matches) {
+      density.value = '24';
+    }
+
+    const compactText = (value, limit = 220) => {
+      const text = normaliseString(value);
+      return text.length > limit ? text.slice(0, limit - 1).trimEnd() + '…' : text;
+    };
 
     const createSvg = (name, attributes = {}) => {
       const element = document.createElementNS(svgNamespace, name);
@@ -3139,7 +3151,7 @@
       if (description) {
         description.textContent = node.kind === 'pivot'
           ? `${formatNumber(node.totalCount)} indicators share this ${node.pivotKind}; ${formatNumber(node.count)} are visible in this graph. Their average risk score is ${node.averageScore}.`
-          : `${node.row?.confidence ? `${node.row.confidence} confidence · ` : ''}Reported by ${primarySourceLabel(node.row)}${node.row?.context ? ` · ${node.row.context}` : ''}.`;
+          : `${node.row?.confidence ? `${node.row.confidence} confidence · ` : ''}Reported by ${primarySourceLabel(node.row)}${node.row?.context ? ` · ${compactText(node.row.context)}` : ''}.`;
       }
       const tags = node.kind === 'indicator' && Array.isArray(node.row?.tags)
         ? node.row.tags.slice(0, 8)
@@ -3180,6 +3192,7 @@
     };
 
     const render = () => {
+      const selectedId = selected?.id;
       graph = dashboardCore.buildCampaignGraph(entries, {
         mode: mode?.value || 'all',
         maxPivots: 8,
@@ -3187,6 +3200,7 @@
       });
       svg.innerHTML = '';
       selected = null;
+      const nextSelected = graph.nodes.find((node) => node.id === selectedId) || null;
       const hasGraph = graph.nodes.length > 0 && graph.edges.length > 0;
       if (empty) empty.hidden = hasGraph;
       svg.hidden = !hasGraph;
@@ -3288,11 +3302,30 @@
           if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
             selectNode(node);
+            return;
+          }
+          const navigation = {
+            ArrowRight: 1,
+            ArrowDown: 1,
+            ArrowLeft: -1,
+            ArrowUp: -1,
+          };
+          if (event.key in navigation || event.key === 'Home' || event.key === 'End') {
+            event.preventDefault();
+            const elements = qsa('[data-graph-node]', svg);
+            const current = elements.indexOf(group);
+            const target = event.key === 'Home'
+              ? 0
+              : event.key === 'End'
+              ? elements.length - 1
+              : (current + navigation[event.key] + elements.length) % elements.length;
+            elements[target]?.focus();
           }
         });
         nodeLayer.appendChild(group);
       });
       svg.appendChild(nodeLayer);
+      if (nextSelected) selectNode(nextSelected);
     };
 
     mode?.addEventListener('change', render);

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -3015,6 +3015,7 @@
     const svg = qs('[data-campaign-graph]', root);
     if (!root || !svg || !dashboardCore?.buildCampaignGraph) return;
     const mode = qs('[data-campaign-mode]', root);
+    const density = qs('[data-campaign-density]', root);
     const remix = qs('[data-campaign-layout]', root);
     const empty = qs('[data-campaign-empty]', root);
     const title = qs('[data-campaign-title]', root);
@@ -3023,6 +3024,20 @@
     const kind = qs('[data-campaign-kind]', root);
     const connections = qs('[data-campaign-connections]', root);
     const score = qs('[data-campaign-score]', root);
+    const sources = qs('[data-campaign-sources]', root);
+    const lastSeen = qs('[data-campaign-last-seen]', root);
+    const tlp = qs('[data-campaign-tlp]', root);
+    const stats = qs('[data-campaign-stats]', root);
+    const high = qs('[data-campaign-high]', root);
+    const corroborated = qs('[data-campaign-corroborated]', root);
+    const average = qs('[data-campaign-average]', root);
+    const visible = qs('[data-campaign-visible]', root);
+    const tagBlock = qs('[data-campaign-tags]', root);
+    const tagList = qs('[data-campaign-tag-list]', root);
+    const relatedBlock = qs('[data-campaign-related]', root);
+    const relatedHeading = qs('[data-campaign-related-heading]', root);
+    const relatedList = qs('[data-campaign-related-list]', root);
+    const reference = qs('[data-campaign-reference]', root);
     const queue = qs('[data-campaign-queue]', root);
     const summary = qs('[data-campaign-summary]', root);
     const svgNamespace = 'http://www.w3.org/2000/svg';
@@ -3041,19 +3056,42 @@
       const pivots = nodes.filter((node) => node.kind === 'pivot');
       const indicators = nodes.filter((node) => node.kind === 'indicator');
       const positions = new Map();
+      const pivotAngles = new Map();
       pivots.forEach((node, index) => {
         const angle = rotation - Math.PI / 2 + (index * Math.PI * 2) / Math.max(pivots.length, 1);
+        pivotAngles.set(node.id, angle);
         positions.set(node.id, {
           x: 500 + Math.cos(angle) * 185,
           y: 260 + Math.sin(angle) * 105,
         });
       });
-      indicators.forEach((node, index) => {
-        const angle = rotation * 0.6 - Math.PI / 2 + (index * Math.PI * 2) / Math.max(indicators.length, 1);
-        const ring = index % 2 ? 1 : 0.88;
+
+      const grouped = new Map(pivots.map((pivot) => [pivot.id, []]));
+      indicators.forEach((node) => {
+        const primaryEdge = graph.edges.find((edge) => edge.target === node.id);
+        const pivotId = primaryEdge?.source || pivots[0]?.id;
+        if (pivotId) grouped.get(pivotId)?.push(node);
+      });
+      grouped.forEach((members, pivotId) => {
+        const center = pivotAngles.get(pivotId) ?? -Math.PI / 2;
+        members.forEach((node, index) => {
+          const spread = Math.min(0.72, 0.13 * Math.max(members.length - 1, 1));
+          const offset = members.length > 1
+            ? -spread / 2 + (index * spread) / (members.length - 1)
+            : 0;
+          const angle = center + offset + rotation * 0.12;
+          const radius = index % 2 ? 405 : 355;
+          positions.set(node.id, {
+            x: 500 + Math.cos(angle) * radius,
+            y: 260 + Math.sin(angle) * radius * 0.51,
+          });
+        });
+      });
+      indicators.filter((node) => !positions.has(node.id)).forEach((node, index) => {
+        const angle = rotation - Math.PI / 2 + (index * Math.PI * 2) / Math.max(indicators.length, 1);
         positions.set(node.id, {
-          x: 500 + Math.cos(angle) * 405 * ring,
-          y: 260 + Math.sin(angle) * 210 * ring,
+          x: 500 + Math.cos(angle) * 390,
+          y: 260 + Math.sin(angle) * 200,
         });
       });
       return positions;
@@ -3080,15 +3118,58 @@
       });
 
       const degree = graph.edges.filter((edge) => edge.source === node.id || edge.target === node.id).length;
+      const relatedNodes = graph.nodes.filter((candidate) => connected.has(candidate.id));
       setText(title, node.label);
       setText(kind, node.kind === 'pivot' ? `${node.pivotKind} pivot` : node.row?.type || 'indicator');
       setText(connections, formatNumber(degree));
-      setText(score, node.kind === 'indicator' ? String(node.score) : '—');
+      setText(score, node.kind === 'indicator' ? String(node.score) : String(node.averageScore));
+      setText(
+        sources,
+        node.kind === 'indicator'
+          ? formatNumber(node.sourceCount)
+          : formatNumber(new Set(relatedNodes.flatMap((candidate) =>
+            candidate.row?.sourceList?.length
+              ? candidate.row.sourceList
+              : [candidate.row?.source].filter(Boolean)
+          )).size)
+      );
+      setText(lastSeen, node.kind === 'indicator' ? node.row?.lastSeenDisplay || 'Unknown' : 'Multiple');
+      setText(tlp, node.kind === 'indicator' ? node.row?.tlp || 'Unmarked' : 'Multiple');
       if (meta) meta.hidden = false;
       if (description) {
         description.textContent = node.kind === 'pivot'
-          ? `${formatNumber(node.totalCount)} indicators in the preview share this ${node.pivotKind}. Select a connected indicator to inspect it.`
-          : `Reported by ${primarySourceLabel(node.row)}${node.row?.tags?.length ? ` · ${node.row.tags.slice(0, 3).join(', ')}` : ''}.`;
+          ? `${formatNumber(node.totalCount)} indicators share this ${node.pivotKind}; ${formatNumber(node.count)} are visible in this graph. Their average risk score is ${node.averageScore}.`
+          : `${node.row?.confidence ? `${node.row.confidence} confidence · ` : ''}Reported by ${primarySourceLabel(node.row)}${node.row?.context ? ` · ${node.row.context}` : ''}.`;
+      }
+      const tags = node.kind === 'indicator' && Array.isArray(node.row?.tags)
+        ? node.row.tags.slice(0, 8)
+        : [];
+      if (tagList) {
+        tagList.replaceChildren(...tags.map((value) => {
+          const chip = document.createElement('span');
+          chip.textContent = value;
+          return chip;
+        }));
+      }
+      if (tagBlock) tagBlock.hidden = !tags.length;
+      if (relatedList) {
+        relatedList.replaceChildren(...relatedNodes.slice(0, 10).map((candidate) => {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = 'campaign-related-node';
+          button.textContent = candidate.label;
+          button.title = candidate.label;
+          button.addEventListener('click', () => selectNode(candidate));
+          return button;
+        }));
+      }
+      if (relatedHeading) relatedHeading.textContent = node.kind === 'pivot' ? 'Connected indicators' : 'Relationship pivots';
+      if (relatedBlock) relatedBlock.hidden = !relatedNodes.length;
+      const reportUrl = node.kind === 'indicator' ? safeHttpUrl(node.row?.reference) : null;
+      if (reference) {
+        reference.hidden = !reportUrl;
+        if (reportUrl) reference.href = reportUrl;
+        else reference.removeAttribute('href');
       }
       if (queue) {
         queue.disabled = node.kind !== 'indicator';
@@ -3101,8 +3182,8 @@
     const render = () => {
       graph = dashboardCore.buildCampaignGraph(entries, {
         mode: mode?.value || 'all',
-        maxPivots: 6,
-        maxIndicators: 24,
+        maxPivots: 8,
+        maxIndicators: Number(density?.value) || 36,
       });
       svg.innerHTML = '';
       selected = null;
@@ -3110,14 +3191,25 @@
       if (empty) empty.hidden = hasGraph;
       svg.hidden = !hasGraph;
       root.hidden = !entries.length;
+      if (stats) stats.hidden = !hasGraph;
+      setText(high, formatNumber(graph.stats.highScore));
+      setText(corroborated, formatNumber(graph.stats.corroborated));
+      setText(average, formatNumber(graph.stats.averageScore));
+      setText(visible, formatNumber(graph.stats.indicators));
       if (summary) {
         summary.textContent = hasGraph
-          ? `${formatNumber(graph.stats.indicators)} indicators · ${formatNumber(graph.stats.pivots)} pivots · ${formatNumber(graph.stats.relationships)} relationships`
+          ? `${formatNumber(graph.stats.relationships)} relationships across ${formatNumber(graph.stats.tagPivots)} tag and ${formatNumber(graph.stats.sourcePivots)} source pivots. Node size reflects corroboration; color reflects risk score.`
           : 'No repeated tags or sources were found in the current preview.';
       }
       if (title) title.textContent = 'Select a node';
       if (description) description.textContent = 'Choose a pivot to understand its reach, or choose an indicator to add it to your investigation queue.';
       if (meta) meta.hidden = true;
+      if (tagBlock) tagBlock.hidden = true;
+      if (relatedBlock) relatedBlock.hidden = true;
+      if (reference) {
+        reference.hidden = true;
+        reference.removeAttribute('href');
+      }
       if (queue) {
         queue.disabled = true;
         queue.textContent = 'Add indicator to queue';
@@ -3145,8 +3237,11 @@
       const nodeLayer = createSvg('g', { class: 'campaign-nodes' });
       graph.nodes.forEach((node, index) => {
         const position = positions.get(node.id);
+        const riskBand = node.kind === 'indicator'
+          ? node.score >= 80 ? 'critical' : node.score >= 60 ? 'elevated' : node.score >= 40 ? 'moderate' : 'aging'
+          : '';
         const group = createSvg('g', {
-          class: `campaign-node ${node.kind} ${node.pivotKind || ''}`,
+          class: `campaign-node ${node.kind} ${node.pivotKind || ''} ${riskBand}`,
           transform: `translate(${position.x} ${position.y})`,
           role: 'button',
           tabindex: '0',
@@ -3156,8 +3251,17 @@
           'data-graph-node': node.id,
         });
         group.style.setProperty('--node-delay', `${Math.min(index * 30, 480)}ms`);
+        if (node.kind === 'indicator' && node.sourceCount >= 2) {
+          group.appendChild(createSvg('circle', {
+            r: 16 + Math.min(node.sourceCount, 5),
+            class: 'campaign-corroboration-ring',
+          }));
+        }
         const circle = createSvg('circle', {
-          r: node.kind === 'pivot' ? Math.min(31, 20 + Math.sqrt(node.totalCount || 1) * 1.6) : 11,
+          r: node.kind === 'pivot'
+            ? Math.min(33, 20 + Math.sqrt(node.totalCount || 1) * 1.7)
+            : 11 + Math.min(Math.max(node.sourceCount - 1, 0), 4) * 0.8,
+          class: 'campaign-node-core',
         });
         const label = createSvg('text', {
           y: node.kind === 'pivot' ? 4 : 3,
@@ -3166,9 +3270,19 @@
         label.textContent = node.kind === 'pivot'
           ? (node.label.length > 15 ? node.label.slice(0, 14) + '…' : node.label)
           : String(node.score);
+        const subtitle = createSvg('text', {
+          y: node.kind === 'pivot' ? 44 : 28,
+          'text-anchor': 'middle',
+          class: 'campaign-node-subtitle',
+        });
+        subtitle.textContent = node.kind === 'pivot'
+          ? `${node.count}/${node.totalCount} IOCs`
+          : String(node.row?.type || 'IOC').toUpperCase().slice(0, 12);
         const tooltip = createSvg('title');
-        tooltip.textContent = node.label;
-        group.append(circle, label, tooltip);
+        tooltip.textContent = node.kind === 'pivot'
+          ? `${node.label} · ${node.totalCount} indicators · average score ${node.averageScore}`
+          : `${node.label} · ${node.row?.type || 'indicator'} · score ${node.score} · ${node.sourceCount} source${node.sourceCount === 1 ? '' : 's'}${node.row?.lastSeenDisplay ? ` · last seen ${node.row.lastSeenDisplay}` : ''}`;
+        group.append(circle, label, subtitle, tooltip);
         group.addEventListener('click', () => selectNode(node));
         group.addEventListener('keydown', (event) => {
           if (event.key === 'Enter' || event.key === ' ') {
@@ -3182,6 +3296,7 @@
     };
 
     mode?.addEventListener('change', render);
+    density?.addEventListener('change', render);
     remix?.addEventListener('click', () => {
       rotation = (rotation + Math.PI / 7) % (Math.PI * 2);
       render();

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -2922,21 +2922,27 @@ input.lookup-input {
 
 .campaign-controls {
   display: grid;
-  grid-template-columns: minmax(9.5rem, 1fr) auto;
+  grid-template-columns: repeat(2, minmax(9rem, 1fr)) auto;
   align-items: end;
   gap: 0.35rem 0.5rem;
-  min-width: min(100%, 19rem);
+  min-width: min(100%, 32rem);
 }
 
-.campaign-controls label {
-  grid-column: 1 / -1;
+.campaign-control-field {
+  display: grid;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.campaign-control-field label {
   color: #94a3b8;
   font-size: 0.68rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
-.campaign-controls select {
+.campaign-control-field select {
+  width: 100%;
   min-height: 2.35rem;
   border-color: rgba(103, 232, 249, 0.45);
   background: #0b1323;
@@ -2978,6 +2984,41 @@ input.lookup-input {
   height: 31rem;
 }
 
+.campaign-stage-stats {
+  position: absolute;
+  top: 0.7rem;
+  left: 0.75rem;
+  z-index: 3;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(4.2rem, auto));
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0.38rem;
+  border: 1px solid rgba(71, 85, 105, 0.56);
+  border-radius: 0.75rem;
+  background: rgba(2, 6, 23, 0.82);
+  box-shadow: 0 12px 28px rgba(2, 6, 23, 0.28);
+  backdrop-filter: blur(12px);
+}
+
+.campaign-stage-stats div {
+  padding: 0.25rem 0.42rem;
+  text-align: center;
+}
+
+.campaign-stage-stats dt {
+  color: #7f91aa;
+  font-size: 0.56rem;
+  letter-spacing: 0.045em;
+  text-transform: uppercase;
+}
+
+.campaign-stage-stats dd {
+  margin: 0.1rem 0 0;
+  color: #e0f2fe;
+  font: 750 0.78rem/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
 .campaign-edge {
   stroke-width: 1.15;
   stroke-dasharray: 3 5;
@@ -3000,7 +3041,7 @@ input.lookup-input {
   transition: opacity 180ms ease;
 }
 
-.campaign-node circle {
+.campaign-node .campaign-node-core {
   stroke-width: 2;
   transition: r 180ms ease, filter 180ms ease, stroke-width 180ms ease;
 }
@@ -3014,12 +3055,28 @@ input.lookup-input {
 }
 
 .campaign-node.pivot text { font-size: 10.5px; }
-.campaign-node.pivot.tag circle { fill: #5b21b6; stroke: #c4b5fd; }
-.campaign-node.pivot.source circle { fill: #0e7490; stroke: #a5f3fc; }
-.campaign-node.indicator circle { fill: #0f172a; stroke: #f97316; }
-.campaign-node:hover circle,
-.campaign-node:focus-visible circle,
-.campaign-node.is-selected circle {
+.campaign-node .campaign-node-subtitle {
+  fill: #91a4bd;
+  font-size: 7.5px;
+  font-weight: 650;
+  letter-spacing: 0.025em;
+}
+.campaign-node.pivot.tag .campaign-node-core { fill: #5b21b6; stroke: #c4b5fd; }
+.campaign-node.pivot.source .campaign-node-core { fill: #0e7490; stroke: #a5f3fc; }
+.campaign-node.indicator .campaign-node-core { fill: #0f172a; }
+.campaign-node.indicator.critical .campaign-node-core { stroke: #fb7185; fill: #4c1024; }
+.campaign-node.indicator.elevated .campaign-node-core { stroke: #fbbf24; fill: #3f2a0b; }
+.campaign-node.indicator.moderate .campaign-node-core { stroke: #38bdf8; fill: #0c3045; }
+.campaign-node.indicator.aging .campaign-node-core { stroke: #64748b; fill: #172033; }
+.campaign-corroboration-ring {
+  fill: none;
+  stroke: rgba(103, 232, 249, 0.42);
+  stroke-width: 1;
+  stroke-dasharray: 2.4 2.4;
+}
+.campaign-node:hover .campaign-node-core,
+.campaign-node:focus-visible .campaign-node-core,
+.campaign-node.is-selected .campaign-node-core {
   stroke-width: 4;
   filter: drop-shadow(0 0 9px rgba(103, 232, 249, 0.8));
 }
@@ -3052,9 +3109,63 @@ input.lookup-input {
 
 .campaign-node-meta {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.4rem;
   margin: 0.15rem 0;
+}
+
+.campaign-detail-block {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.campaign-detail-block h4 {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.64rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.campaign-tag-list,
+.campaign-related-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.campaign-tag-list span,
+.campaign-related-node {
+  max-width: 100%;
+  padding: 0.28rem 0.45rem;
+  overflow: hidden;
+  border: 1px solid rgba(129, 140, 248, 0.38);
+  border-radius: 999px;
+  background: rgba(76, 29, 149, 0.18);
+  color: #ddd6fe;
+  font-size: 0.66rem;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.campaign-related-node {
+  cursor: pointer;
+  border-color: rgba(34, 211, 238, 0.32);
+  background: rgba(14, 116, 144, 0.13);
+  color: #bae6fd;
+}
+
+.campaign-related-node:hover,
+.campaign-related-node:focus-visible {
+  border-color: #67e8f9;
+  outline: none;
+  background: rgba(14, 116, 144, 0.28);
+}
+
+.campaign-reference {
+  align-self: flex-start;
+  text-decoration: none;
 }
 
 .campaign-node-meta div {
@@ -3136,11 +3247,17 @@ input.lookup-input {
 @media (max-width: 540px) {
   .campaign-graph-header { padding: 0.85rem; }
   .campaign-controls { grid-template-columns: 1fr; }
-  .campaign-controls label { grid-column: auto; }
   .campaign-controls .button { width: 100%; }
   .campaign-stage,
   [data-campaign-graph] { min-height: 22rem; height: 22rem; }
-  .campaign-node-meta { grid-template-columns: 1fr; }
+  .campaign-stage-stats {
+    right: 0.65rem;
+    left: 0.65rem;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .campaign-stage-stats div { padding-inline: 0.15rem; }
+  .campaign-stage-stats dt { font-size: 0.5rem; }
+  .campaign-node-meta { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .campaign-legend { right: 0.75rem; border-radius: 0.65rem; }
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=12" />
+    <link rel="stylesheet" href="assets/styles.css?v=13" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -336,12 +336,22 @@
             </p>
           </div>
           <div class="campaign-controls" aria-label="Campaign graph controls">
-            <label for="campaign-mode">Connect through</label>
-            <select id="campaign-mode" data-campaign-mode>
-              <option value="all">Tags + sources</option>
-              <option value="tags">Tags only</option>
-              <option value="sources">Sources only</option>
-            </select>
+            <div class="campaign-control-field">
+              <label for="campaign-mode">Connect through</label>
+              <select id="campaign-mode" data-campaign-mode>
+                <option value="all">Tags + sources</option>
+                <option value="tags">Tags only</option>
+                <option value="sources">Sources only</option>
+              </select>
+            </div>
+            <div class="campaign-control-field">
+              <label for="campaign-density">Detail level</label>
+              <select id="campaign-density" data-campaign-density>
+                <option value="24">Focused · 24 IOCs</option>
+                <option value="36" selected>Expanded · 36 IOCs</option>
+                <option value="48">Maximum · 48 IOCs</option>
+              </select>
+            </div>
             <button type="button" class="button ghost" data-campaign-layout>
               Remix layout
             </button>
@@ -349,6 +359,12 @@
         </div>
         <div class="panel-body campaign-graph-body">
           <div class="campaign-stage" data-campaign-stage>
+            <dl class="campaign-stage-stats" data-campaign-stats hidden>
+              <div><dt>High risk</dt><dd data-campaign-high>0</dd></div>
+              <div><dt>Corroborated</dt><dd data-campaign-corroborated>0</dd></div>
+              <div><dt>Avg score</dt><dd data-campaign-average>0</dd></div>
+              <div><dt>Visible IOCs</dt><dd data-campaign-visible>0</dd></div>
+            </dl>
             <svg
               data-campaign-graph
               viewBox="0 0 1000 520"
@@ -375,7 +391,20 @@
               <div><dt>Kind</dt><dd data-campaign-kind>—</dd></div>
               <div><dt>Connections</dt><dd data-campaign-connections>—</dd></div>
               <div><dt>Score</dt><dd data-campaign-score>—</dd></div>
+              <div><dt>Sources</dt><dd data-campaign-sources>—</dd></div>
+              <div><dt>Last seen</dt><dd data-campaign-last-seen>—</dd></div>
+              <div><dt>TLP</dt><dd data-campaign-tlp>—</dd></div>
             </dl>
+            <div class="campaign-detail-block" data-campaign-tags hidden>
+              <h4>Intelligence tags</h4>
+              <div class="campaign-tag-list" data-campaign-tag-list></div>
+            </div>
+            <div class="campaign-detail-block" data-campaign-related hidden>
+              <h4 data-campaign-related-heading>Connected nodes</h4>
+              <div class="campaign-related-list" data-campaign-related-list></div>
+            </div>
+            <a class="button ghost campaign-reference" data-campaign-reference
+              target="_blank" rel="noopener noreferrer" hidden>Open source report</a>
             <button type="button" class="button detection-export" data-campaign-queue disabled>
               Add indicator to queue
             </button>
@@ -887,7 +916,7 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=12"></script>
-    <script defer src="assets/dashboard.js?v=12"></script>
+    <script defer src="assets/dashboard-core.js?v=13"></script>
+    <script defer src="assets/dashboard.js?v=13"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=13" />
+    <link rel="stylesheet" href="assets/styles.css?v=14" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -368,7 +368,7 @@
             <svg
               data-campaign-graph
               viewBox="0 0 1000 520"
-              role="img"
+              role="group"
               aria-label="Interactive relationship graph of indicators, tags, and reporting sources"
             ></svg>
             <div class="campaign-empty" data-campaign-empty hidden>
@@ -916,7 +916,7 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=13"></script>
-    <script defer src="assets/dashboard.js?v=13"></script>
+    <script defer src="assets/dashboard-core.js?v=14"></script>
+    <script defer src="assets/dashboard.js?v=14"></script>
   </body>
 </html>


### PR DESCRIPTION
PR #92 established the Threat Campaign Graph. This follow-up makes it more useful during real analyst triage, improves its visual clarity at higher data density, and fixes frontend edge cases found during a second audit.

The graph now:
- displays 36 indicators by default and offers focused (24), expanded (36), and maximum (48) detail levels
- starts phones in the focused view for readable targets
- organizes indicators into relationship-aware clusters around their strongest tag or source pivot
- shows live high-risk, corroborated, average-score, and visible-IOC metrics
- encodes risk through node color and corroboration through node size and an outer ring
- labels nodes with IOC type or pivot coverage and provides richer accessible tooltips
- expands the inspector with source count, last-seen time, TLP, tags, context, related-node navigation, and the original reporting link
- preserves the selected finding across density changes and layout remixes
- supports arrow-key navigation, Home/End movement, and Enter/Space selection
- exposes the interactive SVG as an accessible group rather than flattening its controls into an image

Frontend bug fixes:
- case-sensitive URL paths now keep distinct preview expansion state
- placeholder and missing sources no longer create a misleading shared “unknown” campaign
- long intelligence context is bounded in the inspector
- asset revisioning prevents browsers from retaining the older graph controller
- pivots removed by the IOC display cap no longer inflate relationship counters

Validation:
- 154 Python tests pass
- 21 dashboard unit tests pass
- Ruff passes
- Pyright reports 0 errors
- dashboard JavaScript syntax check passes
- desktop 1440px and mobile 390px browser QA pass with no horizontal overflow
- expanded mode renders 36 IOCs / 44 total nodes; maximum mode renders 48 IOCs / 54 total nodes
- mobile defaults to 24 IOCs / 32 total nodes
- selection persistence, arrow-key focus, related-node navigation, density switching, graph metrics, and accessible roles were exercised in headless Brave
- `git diff --check` passes