### PR TITLE
Add an evidence-led discovery desk and fix graph state bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ high-fidelity IOCs from authoritative sources. The project emphasises:
   other CI/CD environments.
 
 ## 🚀 Features
+- **Discovery desk** – switch between corroborated reports, sightings from the last 24 hours, and uncommon tags in the filtered preview. Each lead explains its selection, opens source evidence, and can be saved to the investigation queue. Export a JSON evidence brief with the reasons attached. Sample rarity is explicitly distinguished from global rarity.
 - **Analyst-first live dashboard** – search raw or defanged IOCs, combine
   multi-select type/source/tag/score/age filters, inspect score rationale, and
   shortlist findings in a private investigation queue that persists in the

--- a/docs/THREAT_CAMPAIGN_GRAPH.md
+++ b/docs/THREAT_CAMPAIGN_GRAPH.md
@@ -9,7 +9,7 @@ The graph creates two kinds of pivot:
 - **Tag pivots** connect indicators that share a malware family, behavior, campaign, or other source-supplied tag.
 - **Source pivots** connect indicators reported by the same intelligence provider.
 
-Generic severity and feed-management tags are excluded, as are tags that duplicate a source name. Singleton pivots are omitted because they do not express a relationship. Remaining pivots are ranked by membership, IOC score, and corroboration, then bounded to six pivots and 24 indicators so rendering remains predictable on a phone or workstation.
+Generic severity and feed-management tags are excluded, as are tags that duplicate a source name. Singleton pivots are omitted because they do not express a relationship. Remaining pivots are ranked by membership, IOC score, and corroboration, then bounded to eight pivots and the selected limit of 24, 36, or 48 indicators so rendering remains predictable on a phone or workstation.
 
 These links are investigative hints. A shared tag or source is not proof that two indicators belong to the same campaign or threat actor, and the dashboard states that limitation beside the graph.
 
@@ -29,3 +29,13 @@ Node color communicates risk, node size and the outer ring communicate corrobora
 - Rendering is bounded by the selected detail level and capped at 48 indicators plus eight pivots.
 - Motion uses opacity and stroke animation and respects `prefers-reduced-motion`.
 - Keyboard users can focus each node and select it with Enter or Space.
+
+## Discovery desk
+
+The desk above the graph uses the same filtered preview and offers three lenses:
+
+- **Cross-source:** at least two distinct named reporting sources. Placeholder sources are ignored and names are deduplicated without assuming independence.
+- **Recent sightings:** a valid last-seen timestamp within the past 24 hours; future dates are excluded. A recent sighting is not necessarily new activity.
+- **Uncommon tags:** a nongeneric tag found on at most three distinct indicators in the filtered sample. Feed-name tags are excluded. This does not measure prevalence across the full feed or internet.
+
+Each lens displays up to six ranked leads, with source evidence, context, last-seen time, and queue/copy actions. Export evidence brief saves the visible findings and their reasons as JSON. Filtering and refresh failures update the desk and graph together; failed refreshes clear findings and disable brief exports. No external enrichment service is called.

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -423,6 +423,59 @@
     };
   };
 
+  // Rank evidence already present in the loaded sample; never infer global
+  // rarity, attribution, or new activity from absence in a compact feed.
+  const buildDiscovery = (value, mode = 'corroborated', now = Date.now() / 1000) => {
+    const unique = new Map();
+    for (const row of Array.isArray(value) ? value : []) {
+      const key = investigationKey(row);
+      if (key && !unique.has(key)) unique.set(key, row);
+    }
+    const rows = Array.from(unique.values());
+    const sourceNames = new Set(rows.flatMap(rowSources).map(lower));
+    const ignored = new Set(['aggregated', 'blocklist', 'malicious', 'malware', 'high',
+      'critical', 'medium', 'low', 'info', 'unknown', 'ioc', 'multi-list']);
+    const tagsFor = (row) => Array.from(new Set(
+      (Array.isArray(row.tags) ? row.tags : []).map(lower)
+        .filter((tag) => tag && !ignored.has(tag) && !sourceNames.has(tag))
+    ));
+    const counts = new Map();
+    rows.forEach((row) => tagsFor(row).forEach((tag) => counts.set(tag, (counts.get(tag) || 0) + 1)));
+    const findings = [];
+    for (const row of rows) {
+      const sources = Array.from(new Set(rowSources(row).flatMap((source) =>
+        stringValue(source).split(',').map(lower)
+      ).filter((source) => source && !['unknown', 'n/a', 'none', 'unspecified'].includes(source))));
+      let rank;
+      let reason;
+      let label;
+      if (mode === 'recent') {
+        const seen = timestamp(row.lastSeen ?? row.last_seen);
+        const age = seen == null ? Infinity : now - seen;
+        if (age < 0 || age > 86400) continue;
+        rank = seen;
+        label = 'Seen within 24h';
+        reason = 'Last reported within the past 24 hours. A recent sighting does not mean newly discovered activity.';
+      } else if (mode === 'uncommon') {
+        const rare = tagsFor(row).filter((tag) => counts.get(tag) <= 3)
+          .sort((a, b) => counts.get(a) - counts.get(b) || a.localeCompare(b))[0];
+        if (!rare) continue;
+        rank = 4 - counts.get(rare);
+        label = rare;
+        reason = `“${rare}” appears on ${counts.get(rare)} of ${rows.length} indicators in this filtered sample. This is sample rarity, not global rarity.`;
+      } else {
+        if (sources.length < 2) continue;
+        rank = sources.length;
+        label = `${sources.length} reporting sources`;
+        reason = `Reported by ${sources.join(', ')}. Multiple reports provide corroboration, but do not establish source independence.`;
+      }
+      findings.push({ row, label, reason, rank });
+    }
+    findings.sort((a, b) => b.rank - a.rank || effectiveScore(b.row) - effectiveScore(a.row) ||
+      investigationKey(a.row).localeCompare(investigationKey(b.row)));
+    return { total: findings.length, sampleSize: rows.length, findings: findings.slice(0, 6) };
+  };
+
   const scoreBand = (row) => {
     const score = effectiveScore(row);
     if (score >= 80) return 'high';
@@ -608,6 +661,7 @@
   return {
     compareRows,
     buildCampaignGraph,
+    buildDiscovery,
     effectiveScore,
     investigationKey,
     detectionRows,

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -353,3 +353,37 @@ test('dashboard markup keeps IDs and labelled controls consistent', () => {
     'Responsive display rules must not expose hidden detail rows'
   );
 });
+
+test('discovery ranks actual source names, deduplicates IOCs, and explains corroboration', () => {
+  const a = { ...row, indicator: 'a.example', sourceList: ['Feed-A', 'feed-a', 'unknown'], sourceCount: 99 };
+  const b = { ...row, indicator: 'b.example', sourceList: ['Feed-A', 'Feed-B'] };
+  const result = core.buildDiscovery([a, b, b], 'corroborated');
+  assert.equal(result.sampleSize, 2);
+  assert.equal(result.total, 1);
+  assert.equal(result.findings[0].row.indicator, 'b.example');
+  assert.match(result.findings[0].reason, /do not establish source independence/);
+});
+
+test('recent discovery excludes future, invalid, and old sightings', () => {
+  const now = Date.parse('2026-09-08T12:00:00Z') / 1000;
+  const rows = [
+    { ...row, indicator: 'fresh.example', lastSeen: '2026-09-08T11:00:00Z' },
+    { ...row, indicator: 'future.example', lastSeen: '2026-09-09T11:00:00Z' },
+    { ...row, indicator: 'old.example', lastSeen: '2026-09-06T11:00:00Z' },
+    { ...row, indicator: 'invalid.example', lastSeen: 'not a date' },
+  ];
+  const result = core.buildDiscovery(rows, 'recent', now);
+  assert.deepEqual(result.findings.map(({ row }) => row.indicator), ['fresh.example']);
+});
+
+test('uncommon discovery measures distinct indicators and omits generic and source tags', () => {
+  const rows = Array.from({ length: 5 }, (_, i) => ({
+    ...row, indicator: `${i}.example`, tags: ['high', 'feed-a', 'shared', ...(i === 0 ? ['unusual', 'unusual'] : [])],
+  }));
+  const result = core.buildDiscovery(rows, 'uncommon');
+  assert.equal(result.total, 1);
+  assert.equal(result.findings[0].label, 'unusual');
+  assert.match(result.findings[0].reason, /1 of 5/);
+  assert.deepEqual(core.buildDiscovery(rows.slice().reverse(), 'uncommon'), result);
+  assert.equal(core.buildDiscovery([], 'uncommon').findings.length, 0);
+});

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -2673,7 +2673,7 @@
       const matches = filteredRows().sort(compare);
       state.matches = matches;
       window.dispatchEvent(new CustomEvent('swiftioc:preview-filtered', {
-        detail: { rows: matches },
+        detail: { rows: matches, origin: state.origin },
       }));
       const displayed = matches.slice(0, state.limit);
       render(displayed);
@@ -2828,7 +2828,7 @@
         state.rows = [];
         state.matches = [];
         window.dispatchEvent(new CustomEvent('swiftioc:preview-filtered', {
-          detail: { rows: [] },
+          detail: { rows: [], error: true },
         }));
         render([]);
         updateSummary([], []);
@@ -3014,6 +3014,110 @@
     return span;
   };
 
+  const initialiseDiscovery = () => {
+    const root = qs('[data-discovery-root]');
+    if (!root || !dashboardCore?.buildDiscovery) return;
+    const cards = qs('[data-discovery-cards]', root);
+    const status = qs('[data-discovery-status]', root);
+    const empty = qs('[data-discovery-empty]', root);
+    const exportButton = qs('[data-discovery-export]', root);
+    const lenses = qsa('[data-discovery-mode]', root);
+    let rows = [];
+    let mode = 'corroborated';
+    let snapshot = null;
+    let feedFailed = false;
+    let origin = '';
+    const render = () => {
+      snapshot = dashboardCore.buildDiscovery(rows, mode);
+      cards.replaceChildren();
+      lenses.forEach((button) => button.setAttribute('aria-pressed', String(button.dataset.discoveryMode === mode)));
+      exportButton.disabled = !snapshot.findings.length;
+      empty.hidden = snapshot.findings.length > 0;
+      empty.textContent = feedFailed
+        ? 'The feed is unavailable. Retry from the live preview below to restore your discovery results.'
+        : 'No leads match this lens. Try another lens or broaden the preview filters below.';
+      status.textContent = feedFailed ? 'Feed unavailable · evidence export paused' :
+        `${snapshot.findings.length} of ${snapshot.total} matching leads · ${snapshot.sampleSize} indicators in the filtered sample${isCacheOrigin(origin) ? ' · cached snapshot' : ''}`;
+      snapshot.findings.forEach((finding, index) => {
+        const row = finding.row;
+        const card = document.createElement('article');
+        card.className = 'discovery-card';
+        const top = document.createElement('div');
+        top.className = 'discovery-card-top';
+        const number = document.createElement('span');
+        number.textContent = String(index + 1).padStart(2, '0');
+        const type = document.createElement('span');
+        type.textContent = row.type || 'Indicator';
+        const score = document.createElement('span');
+        score.className = 'discovery-score';
+        score.textContent = `Score ${dashboardCore.effectiveScore(row)}`;
+        top.append(number, type, score);
+        const title = document.createElement('h3');
+        title.textContent = row.indicator;
+        const label = document.createElement('p');
+        label.className = 'discovery-reason-label';
+        label.textContent = finding.label;
+        const reason = document.createElement('p');
+        reason.className = 'discovery-reason';
+        reason.textContent = finding.reason;
+        const details = document.createElement('details');
+        const summary = document.createElement('summary');
+        summary.textContent = 'Inspect the evidence';
+        const context = document.createElement('p');
+        context.textContent = row.context || 'No additional context supplied by this source.';
+        const seen = document.createElement('p');
+        seen.textContent = `Last seen: ${row.lastSeenDisplay || row.lastSeen || 'Unknown'} · TLP: ${row.tlp || 'Unmarked'}`;
+        details.append(summary, seen, context);
+        const report = safeHttpUrl(row.reference);
+        if (report) {
+          const link = document.createElement('a');
+          link.href = report;
+          link.target = '_blank';
+          link.rel = 'noopener noreferrer';
+          link.textContent = 'Open reporting source ↗';
+          details.appendChild(link);
+        }
+        const actions = document.createElement('div');
+        actions.className = 'discovery-card-actions';
+        const copy = document.createElement('button');
+        copy.type = 'button';
+        copy.className = 'button ghost';
+        copy.textContent = 'Copy IOC';
+        copy.addEventListener('click', () => copyOrPrompt(row.indicator, 'Indicator copied.', 'Copy this indicator:'));
+        actions.append(makeInvestigationButton(row), copy);
+        card.append(top, title, label, reason, details, actions);
+        cards.appendChild(card);
+      });
+    };
+    lenses.forEach((button) => button.addEventListener('click', () => {
+      mode = button.dataset.discoveryMode;
+      render();
+    }));
+    exportButton.addEventListener('click', () => {
+      if (!snapshot?.findings.length) return;
+      downloadDetection(JSON.stringify({
+        schema_version: 1,
+        generated_at: new Date().toISOString(),
+        lens: mode,
+        sample_size: snapshot.sampleSize,
+        matching_leads: snapshot.total,
+        scope: 'Six highlighted leads at most, derived from the filtered compact preview. No global rarity or attribution implied.',
+        findings: snapshot.findings.map(({ row, label, reason }) => ({
+          indicator: row.indicator, type: row.type, score: dashboardCore.effectiveScore(row),
+          sources: row.sourceList, last_seen: row.lastSeen, tags: row.tags,
+          reference: row.reference, label, reason,
+        })),
+      }, null, 2), 'swiftioc-evidence-brief.json', 'application/json');
+    });
+    window.addEventListener('swiftioc:preview-filtered', (event) => {
+      if (!Array.isArray(event.detail?.rows)) return;
+      rows = event.detail.rows;
+      feedFailed = Boolean(event.detail.error);
+      origin = event.detail.origin || '';
+      render();
+    });
+  };
+
   const initialiseCampaignGraph = () => {
     const root = qs('[data-campaign-root]');
     const svg = qs('[data-campaign-graph]', root);
@@ -3120,6 +3224,7 @@
         const active = element.dataset.graphNode === node.id;
         const related = connected.has(element.dataset.graphNode);
         element.classList.toggle('is-selected', active);
+        element.setAttribute('aria-pressed', String(active));
         element.classList.toggle('is-connected', related);
         element.classList.toggle('is-dimmed', !active && !related);
       });
@@ -3263,6 +3368,7 @@
             ? `${node.pivotKind} pivot ${node.label}, ${node.totalCount} indicators`
             : `${node.row?.type || 'indicator'} ${node.label}, score ${node.score}`,
           'data-graph-node': node.id,
+          'aria-pressed': 'false',
         });
         group.style.setProperty('--node-delay', `${Math.min(index * 30, 480)}ms`);
         if (node.kind === 'indicator' && node.sourceCount >= 2) {
@@ -3351,21 +3457,7 @@
       entries = event.detail.rows;
       render();
     });
-    subscribeToDataset((dataset) => {
-      if (dataset && !isCacheOrigin(dataset.origin)) {
-        entries = dataset.entries || [];
-        render();
-      }
-    });
-    loadDataset({})
-      .then(({ dataset }) => {
-        entries = dataset.entries || [];
-        render();
-      })
-      .catch((error) => {
-        root.hidden = true;
-        console.warn('Campaign graph failed to load', error);
-      });
+
   };
 
   const makeThreatCard = (row) => {
@@ -3978,6 +4070,7 @@
   initialiseTableToggles();
   initialiseInvestigationWorkspace();
   initialiseStatusBanner();
+  initialiseDiscovery();
   initialiseCampaignGraph();
   initialiseTopThreats();
   initialiseIocLookup();

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -3035,8 +3035,8 @@ input.lookup-input {
 
 .campaign-node {
   cursor: pointer;
-  opacity: 0;
-  animation: campaign-node-in 520ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  opacity: 1;
+  animation: campaign-node-in 520ms cubic-bezier(0.22, 1, 0.36, 1) backwards;
   animation-delay: var(--node-delay, 0ms);
   transition: opacity 180ms ease;
 }
@@ -3682,4 +3682,51 @@ body::before {
     transform: none;
     transition: none !important;
   }
+}
+
+/* Discovery desk: readable evidence first, actions within reach. */
+.discovery-desk {
+  margin-block: 1.5rem;
+  padding: clamp(1rem, 3vw, 2rem);
+  border: 1px solid #33465d;
+  border-radius: 1.2rem;
+  background: radial-gradient(ellipse at 90% 0, #12354b80, transparent 55%), #0a1422;
+}
+.discovery-heading { display: flex; align-items: center; justify-content: space-between; gap: 1.5rem; }
+.discovery-heading h2 { font-size: clamp(1.65rem, 3vw, 2.5rem); letter-spacing: -0.04em; margin: 0.25rem 0 0.65rem; }
+.discovery-heading p:not(.eyebrow) { max-width: 44rem; color: #afc1d5; line-height: 1.6; }
+.discovery-heading > a { flex-shrink: 0; text-decoration: none; }
+.discovery-toolbar { display: flex; flex-wrap: wrap; justify-content: space-between; gap: 1rem; margin-top: 1.3rem; }
+.discovery-lenses { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.discovery-lenses button { padding: 0.7rem 0.9rem; border: 1px solid #3a4a61; border-radius: 0.6rem; color: #b8cce1; background: #0b1728; cursor: pointer; transition: background 160ms ease, color 160ms ease; }
+.discovery-lenses button[aria-pressed='true'] { background: #b2f4e4; border-color: #b2f4e4; color: #08352d; font-weight: 700; }
+.discovery-lenses button:hover { border-color: #b2f4e4; }
+.discovery-lenses button:focus-visible, .discovery-card summary:focus-visible { outline: 2px solid #b2f4e4; outline-offset: 4px; }
+.discovery-status { margin-block: 1rem; color: #92abc4; font-size: 0.78rem; }
+.discovery-cards { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.85rem; align-items: stretch; }
+.discovery-card { display: flex; flex-direction: column; min-width: 0; padding: 1.15rem; border: 1px solid #314359; border-radius: 0.8rem; background: #101d2d; transition: border-color 180ms ease, transform 180ms ease; }
+.discovery-card:hover { border-color: #649f9a; transform: translateY(-2px); }
+.discovery-card-top { display: flex; flex-wrap: wrap; align-items: center; gap: 0.6rem; color: #91a8c0; font-size: 0.7rem; }
+.discovery-score { margin-left: auto; color: #c8e9f0; }
+.discovery-card h3 { margin-block: 1rem; font-family: ui-monospace, monospace; font-size: 0.92rem; line-height: 1.5; overflow-wrap: anywhere; }
+.discovery-reason-label { color: #b2f4e4; font-size: 0.78rem; font-weight: 650; overflow-wrap: anywhere; }
+.discovery-reason { color: #b7c6d8; line-height: 1.6; font-size: 0.78rem; overflow-wrap: anywhere; }
+.discovery-card details { border-top: 1px solid #314359; margin-top: 0.8rem; padding-block: 0.8rem; color: #b7c6d8; font-size: 0.76rem; overflow-wrap: anywhere; }
+.discovery-card details p { margin-top: 0.8rem; line-height: 1.6; }
+.discovery-card summary { cursor: pointer; color: #d4e1ed; padding-block: 0.25rem; }
+.discovery-card-actions { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: auto; }
+.discovery-card-actions button { min-height: 2.5rem; }
+.discovery-empty { padding: 2rem 1rem; border: 1px dashed #4b657b; border-radius: 0.8rem; color: #b7c6d8; line-height: 1.6; }
+.discovery-scope { margin: 1.25rem 0 0; max-width: 65rem; color: #91a8c0; font-size: 0.74rem; line-height: 1.6; }
+@media (max-width: 1050px) { .discovery-cards { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 640px) {
+  .discovery-heading { align-items: start; flex-direction: column; gap: 0.5rem; }
+  .discovery-cards { grid-template-columns: minmax(0, 1fr); }
+  .discovery-lenses { display: grid; width: 100%; grid-template-columns: minmax(0, 1fr); }
+  .discovery-lenses button { text-align: left; }
+  .discovery-toolbar > button { width: 100%; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .discovery-card, .discovery-lenses button, .campaign-node, .campaign-node-core { transition: none !important; }
+  .discovery-card:hover { transform: none; }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=14" />
+    <link rel="stylesheet" href="assets/styles.css?v=15" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -91,6 +91,7 @@
         </a>
         <div class="nav-links">
           <a href="#ioc-lookup">Check an IOC</a>
+          <a href="#discovery">Discover</a>
           <a href="#campaign-graph">Campaign graph</a>
           <a href="#live-preview">Browse feed</a>
           <a href="#sources">Sources</a>
@@ -317,6 +318,29 @@
           <a class="button-link primary" href="iocs/delta.json" download>Delta JSON</a>
           <a class="button-link" href="iocs/delta.jsonl" download>Event stream</a>
         </div>
+      </section>
+
+      <section class="discovery-desk" id="discovery" aria-labelledby="discovery-heading" data-discovery-root>
+        <div class="discovery-heading">
+          <div>
+            <p class="eyebrow">The discovery desk</p>
+            <h2 id="discovery-heading">Find your next lead.</h2>
+            <p>Follow the evidence behind the score. Explore corroboration, recent sightings, and uncommon tags in the loaded preview.</p>
+          </div>
+          <a class="button ghost" href="#live-preview">Refine the sample ↓</a>
+        </div>
+        <div class="discovery-toolbar">
+          <div class="discovery-lenses" role="group" aria-label="Discovery lens">
+            <button type="button" data-discovery-mode="corroborated" aria-pressed="true">01 · Cross-source</button>
+            <button type="button" data-discovery-mode="recent" aria-pressed="false">02 · Recent sightings</button>
+            <button type="button" data-discovery-mode="uncommon" aria-pressed="false">03 · Uncommon tags</button>
+          </div>
+          <button type="button" class="button ghost" data-discovery-export disabled>Export evidence brief</button>
+        </div>
+        <p class="discovery-status" data-discovery-status role="status">Loading the discovery sample…</p>
+        <div class="discovery-cards" data-discovery-cards></div>
+        <p class="discovery-empty" data-discovery-empty hidden>No leads match this lens. Try another lens or broaden the preview filters below.</p>
+        <p class="discovery-scope">Derived from the compact preview, not the complete feed. Preview filters apply here. Nothing is uploaded when you explore or export.</p>
       </section>
 
       <section
@@ -916,7 +940,7 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=14"></script>
-    <script defer src="assets/dashboard.js?v=14"></script>
+    <script defer src="assets/dashboard-core.js?v=15"></script>
+    <script defer src="assets/dashboard.js?v=15"></script>
   </body>
 </html>


### PR DESCRIPTION
The dashboard previously required analysts to build their own filters to find leads. The new Discovery desk offers three explainable lenses over the filtered preview: distinct reporting sources, sightings from the last 24 hours, and tags appearing on at most three sampled indicators.

Each lens highlights up to six leads with the reason for selection, expandable source context, reporting links, queue actions, and IOC copying. An evidence brief export saves the visible findings and their reasons as JSON. Counts explicitly describe the loaded sample; rarity does not imply global rarity and multiple reports do not imply independent sources.

The responsive card layout adds a Discover navigation entry, readable mint selection states, aligned actions, and keyboard focus styles. Preview filters and failures update discovery and the graph together. A failed refresh clears findings and disables brief exports.

This also fixes two graph bugs: independent dataset callbacks could overwrite filtered graph results, and an opacity animation left nodes invisible with reduced motion or overrode selection dimming after it finished. Graph nodes now expose their selected state through aria-pressed.

Validation:
- 24 frontend unit tests pass, including source deduplication, future/old timestamp rejection, and uncommon-tag sample counts.
- 154 Python tests pass; Ruff passes; Pyright reports zero errors with existing dependency-source warnings.
- Headless Brave at 1440px and 390px: no horizontal overflow or JavaScript exceptions; lens switching, expandable evidence, queue actions, JSON downloads, and disabled exports after failure verified.
- Actual preview filtering and a routed HTTP 503 refresh verified discovery and graph clearing together.
- Normal-motion dimming and reduced-motion graph visibility verified.
- JavaScript syntax and git diff whitespace checks pass.