### PR TITLE
Separate vulnerability collections from observable campaign relationships

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -177,6 +177,7 @@ jobs:
             public/index.md
             public/misp/**
             public/detections/**
+            public/collections/**
             public/feed.xml
             public/badge.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ sources.yml
 .idea/
 .vscode/
 .DS_Store
+
+# Typed collections are regenerated and published with the full Pages artifact.
+public/collections/

--- a/README.md
+++ b/README.md
@@ -36,11 +36,62 @@ Choose the shortest path for what you are trying to do:
 | --- | --- | --- |
 | A SOC analyst or threat hunter | [Live dashboard](https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/) | Search, filters, score explanations, source context, and a private browser-local investigation queue. |
 | Feeding a SIEM, EDR, firewall, or SOAR | [High-confidence JSONL](https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/iocs/high_confidence.jsonl) | The strongest current indicators in a stream-friendly format. |
+| Tracking vulnerabilities and patch work | [Vulnerability collection](https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/#vulnerabilities) | One record per CVE, separate CISA/NVD reports, product search, and explicit exploitation evidence. |
 | Building continuous automation | [SOC Delta output guide](#-outputs--diagnostics) | Additions, material updates, and removals since the previous validated snapshot. |
 | Using a CTI platform | [Interoperability outputs](#-outputs--diagnostics) or the live [MISP manifest](https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/misp/manifest.json) | STIX, TAXII, and MISP objects with stable identifiers for repeatable imports. |
 | Investigating historical activity | [`ioc_timeline.py`](scripts/ioc_timeline.py) | Answer whether an IOC was present, when it appeared, and how its score changed. |
 | Running your own collector | [Quick start](#-quick-start) | A configurable local, container, cron, or GitHub Actions deployment. |
 | Contributing a parser or fix | [Development and testing](#-development--testing) | Setup, test commands, and contribution guidance. |
+
+### Vulnerabilities and observables are separate collections
+
+SwiftIOC deduplicates by `(type, indicator)`: `CVE-2020-1234` and
+`CVE-2020-5678` stay separate even if both appear in NVD or share a generic
+`cve` tag. Reports about **the same CVE** are combined under that CVE ID while
+keeping `reports.cisa_kev` and `reports.nvd` separately. The campaign graph and
+Discovery desk use observables; CVEs have their own searchable, paginated view.
+
+Each collector run writes these additive exports:
+
+| Collection | Contents | Intended use |
+| --- | --- | --- |
+| [`collections/vulnerabilities.json`](https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/collections/vulnerabilities.json) | Versioned document with `generated_at`, coverage scope, counts, and `items`, one per CVE. | Vulnerability triage and patch investigations. |
+| [`collections/observables.jsonl`](https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/collections/observables.jsonl) | All retained non-CVE records, using the existing indicator schema. | IOC integrations that need CVEs excluded; apply your own score/type policy. |
+
+The vulnerability export uses three exploitation labels:
+
+- `known_exploited`: structured evidence from the CISA KEV adapter. The
+  [CISA catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)
+  records vulnerabilities known to have been exploited. A catalog entry does
+  not say an attack is happening now or that your own assets are affected.
+- `reported_exploitation`: a source or legacy feed supplied an
+  `exploited-in-the-wild` tag, without structured KEV evidence in this record.
+- `not_established`: this retained record does not establish exploitation.
+  It does **not** mean the vulnerability has never been exploited. NVD severity
+  and SwiftIOC relevance scores alone never promote this label.
+
+CISA reports preserve vendor, product, description, required action, catalog
+addition date, directive due date, ransomware-use value, and catalog check
+time. NVD reports preserve description, publication/modification dates,
+status, and available severity. These dates describe provider records, not
+attack times. CISA due dates concern its directive; they are not universal
+patch deadlines. Review NVD status, including rejected records, before triage.
+
+Both collections cover the **retained feed**, not the entire KEV or NVD
+catalogs. Source windows, per-source caps, request failures, expiry, and
+retention limits can reduce coverage. With `--persist-feed`, a missing provider
+report is retained with its original dates; a fresh report from that provider
+replaces its previous fields. Check the provider dates and run diagnostics
+before treating evidence as fresh. Collection generation time is not a source
+observation time.
+
+No migration or new CLI flag is required. `iocs/latest.*` and high-confidence
+outputs remain combined feeds for compatibility; their JSON records now carry
+an additive `vulnerability` object (empty for observables). CSV columns remain
+unchanged. Existing snapshots load with an empty object and gain structured
+reports on the next successful source fetch. The new collection files are
+regenerated during publishing; a static checkout needs a collector run to
+populate them.
 
 ### Pick the right feed
 
@@ -635,12 +686,22 @@ ruff check .          # lint
 pyright               # static type check
 python -m swiftioc --self-test   # built-in sanity assertions
 pytest -q             # offline unit tests (parsers, STIX, dedup, changelog)
+node --test public/assets/dashboard-core.test.js  # frontend data logic
 ```
 
 The `tests/` suite is fully offline—parsers that would hit the network have
 their HTTP layer monkeypatched—so it is safe to run anywhere and catches feed
 format drift before it reaches production. When `stix2` is installed the suite
 also validates the generated bundle against the reference library.
+
+For the vulnerability view’s browser regression checks, install Playwright
+in your development environment (`npm install --no-save --package-lock=false
+playwright`, then `npx playwright install chromium`). Serve `public/` with
+`python -m http.server 8765 --directory public` and, in a second terminal, run
+`node scripts/test_vulnerability_ui.cjs`. The test injects synthetic CVE data
+and covers filtering, pagination, safe rendering, mobile overflow, refresh
+failure, retry, and empty collections. Set `BASE_URL` for another local port or
+`PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to use an existing Chromium browser.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add a new feed parser and the
 full contribution workflow.

--- a/README.md
+++ b/README.md
@@ -516,6 +516,11 @@ Delta feeds describe indicators added to the published snapshot, removed from
 it, or materially changed since the previous run. A removal means the IOC is no
 longer in the current SwiftIOC snapshot; it does not assert that the IOC is
 benign. The first run emits an empty delta until a baseline exists.
+Changes to vulnerability provider reports (including severity, status, required
+actions, and due dates) emit `updated` events with `changes.vulnerability` and
+the complete current record. A change only to CISA's local
+`catalog_checked_at` poll timestamp does not trigger an alert. Provider report
+additions and removals do trigger updates.
 
 The collector populates the following structure (paths relative to `--out-dir`):
 

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -291,7 +291,7 @@
   };
 
   const buildCampaignGraph = (value, options = {}) => {
-    const rows = Array.isArray(value) ? value.filter((row) => row?.indicator) : [];
+    const rows = Array.isArray(value) ? value.filter((row) => row?.indicator && lower(row.type) !== 'cve') : [];
     const mode = ['all', 'tags', 'sources'].includes(options.mode) ? options.mode : 'all';
     const maxPivots = Math.max(1, Math.min(Number(options.maxPivots) || 6, 10));
     const maxIndicators = Math.max(2, Math.min(Number(options.maxIndicators) || 24, 50));
@@ -428,6 +428,7 @@
   const buildDiscovery = (value, mode = 'corroborated', now = Date.now() / 1000) => {
     const unique = new Map();
     for (const row of Array.isArray(value) ? value : []) {
+      if (lower(row?.type) === 'cve') continue;
       const key = investigationKey(row);
       if (key && !unique.has(key)) unique.set(key, row);
     }
@@ -658,7 +659,20 @@
     return url;
   };
 
+  const filterVulnerabilities = (items, search = '', status = 'all') => {
+    const query = lower(search).trim();
+    const priority = { known_exploited: 0, reported_exploitation: 1, not_established: 2 };
+    return items.filter((item) => {
+      if (status !== 'all' && item.exploitation_status !== status) return false;
+      const kev = item.reports?.cisa_kev || {};
+      return !query || lower([item.cve_id, item.title, item.description, kev.vendor,
+        kev.product, ...(item.sources || [])].join(' ')).includes(query);
+    }).sort((a, b) => (priority[a.exploitation_status] ?? 3) - (priority[b.exploitation_status] ?? 3)
+      || a.cve_id.localeCompare(b.cve_id));
+  };
+
   return {
+    filterVulnerabilities,
     compareRows,
     buildCampaignGraph,
     buildDiscovery,

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -665,8 +665,9 @@
     return items.filter((item) => {
       if (status !== 'all' && item.exploitation_status !== status) return false;
       const kev = item.reports?.cisa_kev || {};
+      const nvd = item.reports?.nvd || {};
       return !query || lower([item.cve_id, item.title, item.description, kev.vendor,
-        kev.product, ...(item.sources || [])].join(' ')).includes(query);
+        kev.product, kev.description, nvd.description, ...(item.sources || [])].join(' ')).includes(query);
     }).sort((a, b) => (priority[a.exploitation_status] ?? 3) - (priority[b.exploitation_status] ?? 3)
       || a.cve_id.localeCompare(b.cve_id));
   };

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -411,3 +411,18 @@ test('vulnerability filters keep exact CVE records and separate severity from ex
   assert.equal(core.filterVulnerabilities(items, 'missing').length, 0);
   assert.equal(JSON.stringify(items), before);
 });
+
+
+test('vulnerability search indexes each provider description independently of the summary', () => {
+  const item = {
+    cve_id: 'CVE-1900-1234', exploitation_status: 'known_exploited',
+    description: 'Combined summary', reports: {
+      cisa_kev: { description: 'CISA-specific remediation context' },
+      nvd: { description: 'NVD-specific technical details' },
+    },
+  };
+  for (const query of ['combined summary', 'CISA-SPECIFIC', 'nvd-specific']) {
+    assert.deepEqual(core.filterVulnerabilities([item], query), [item]);
+  }
+  assert.deepEqual(core.filterVulnerabilities([item], 'CISA-specific', 'not_established'), []);
+});

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -387,3 +387,27 @@ test('uncommon discovery measures distinct indicators and omits generic and sour
   assert.deepEqual(core.buildDiscovery(rows.slice().reverse(), 'uncommon'), result);
   assert.equal(core.buildDiscovery([], 'uncommon').findings.length, 0);
 });
+
+test('CVE provider and generic tags never become observable graph or discovery relationships', () => {
+  const cves = ['CVE-2020-1234', 'CVE-2020-5678'].map((indicator) => ({
+    ...row, type: 'cve', indicator, tags: ['cve', 'nvd'], tagsLower: ['cve', 'nvd'],
+  }));
+  assert.deepEqual(core.buildCampaignGraph([...cves, row]), core.buildCampaignGraph([row]));
+  assert.deepEqual(core.buildDiscovery([...cves, row], 'corroborated'), core.buildDiscovery([row], 'corroborated'));
+});
+
+test('vulnerability filters keep exact CVE records and separate severity from exploitation', () => {
+  const items = [
+    { cve_id: 'CVE-2020-9999', exploitation_status: 'not_established', sources: ['nvd'], reports: { nvd: { severity: 'critical' } } },
+    { cve_id: 'CVE-2020-5678', exploitation_status: 'reported_exploitation', sources: ['rss'], reports: {} },
+    { cve_id: 'CVE-2020-1234', exploitation_status: 'known_exploited', sources: ['kev', 'nvd'], reports: { cisa_kev: { vendor: 'Vendor A', product: 'Router' } } },
+  ];
+  const before = JSON.stringify(items);
+  assert.deepEqual(core.filterVulnerabilities(items).map((r) => r.cve_id), ['CVE-2020-1234', 'CVE-2020-5678', 'CVE-2020-9999']);
+  assert.equal(core.filterVulnerabilities(items, 'cve-2020-9999', 'known_exploited').length, 0);
+  assert.equal(core.filterVulnerabilities(items, 'ROUTER')[0].cve_id, 'CVE-2020-1234');
+  assert.equal(core.filterVulnerabilities(items, 'vendor a')[0].cve_id, 'CVE-2020-1234');
+  assert.equal(core.filterVulnerabilities(items, 'nvd').length, 2);
+  assert.equal(core.filterVulnerabilities(items, 'missing').length, 0);
+  assert.equal(JSON.stringify(items), before);
+});

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -3014,6 +3014,149 @@
     return span;
   };
 
+  const initialiseVulnerabilities = () => {
+    const root = qs('[data-vulnerability-root]');
+    if (!root || !dashboardCore?.filterVulnerabilities) return;
+    const cards = qs('[data-vulnerability-cards]', root);
+    const status = qs('[data-vulnerability-status]', root);
+    const search = qs('[data-vulnerability-search]', root);
+    const filter = qs('[data-vulnerability-status-filter]', root);
+    const refresh = qs('[data-vulnerability-refresh]', root);
+    const previous = qs('[data-vulnerability-prev]', root);
+    const next = qs('[data-vulnerability-next]', root);
+    const pageLabel = qs('[data-vulnerability-page]', root);
+    const download = qs('[data-vulnerability-download]', root);
+    download.href = resolveIocUrl('collections/vulnerabilities.json');
+    qs('[data-observables-download]', root).href = resolveIocUrl('collections/observables.jsonl');
+    const labels = {
+      known_exploited: 'CISA KEV · known exploited',
+      reported_exploitation: 'Exploitation reported · KEV evidence unavailable',
+      not_established: 'Exploitation not established by this feed',
+    };
+    let items = [];
+    let generatedAt = '';
+    let page = 0;
+    let loading = false;
+    let failed = false;
+    const pageSize = 6;
+    const addText = (parent, tag, value, className = '') => {
+      const element = document.createElement(tag);
+      element.textContent = value;
+      element.className = className;
+      parent.appendChild(element);
+      return element;
+    };
+    const addReport = (card, title, report, fields) => {
+      if (!report || typeof report !== 'object' || Array.isArray(report)) return;
+      const details = document.createElement('details');
+      addText(details, 'summary', title);
+      fields.forEach(([key, label]) => {
+        if (report[key] != null && report[key] !== '') addText(details, 'p', `${label}: ${report[key]}`);
+      });
+      const reference = safeHttpUrl(report.reference);
+      if (reference) {
+        const link = addText(details, 'a', 'Open provider record ↗');
+        link.href = reference;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+      }
+      card.appendChild(details);
+    };
+    const render = () => {
+      const matches = dashboardCore.filterVulnerabilities(items, search.value, filter.value);
+      const pages = Math.ceil(matches.length / pageSize);
+      page = Math.min(page, Math.max(0, pages - 1));
+      cards.replaceChildren();
+      previous.disabled = loading || page === 0;
+      next.disabled = loading || page + 1 >= pages;
+      pageLabel.textContent = `Page ${pages ? page + 1 : 0} of ${pages}`;
+      refresh.disabled = loading;
+      search.disabled = filter.disabled = loading;
+      status.textContent = loading ? 'Loading the vulnerability collection…' : failed
+        ? 'Collection unavailable. Refresh to retry; no previous results are displayed.'
+        : `${matches.length} of ${items.length} CVEs · ${items.filter((item) => item.exploitation_status === 'known_exploited').length} with CISA KEV evidence · Snapshot ${generatedAt}${!matches.length ? ' · No matching vulnerabilities.' : ''}`;
+      if (loading || failed) return;
+      matches.slice(page * pageSize, (page + 1) * pageSize).forEach((item) => {
+        const card = document.createElement('article');
+        card.className = 'discovery-card vulnerability-card';
+        card.dataset.exploitation = item.exploitation_status;
+        addText(card, 'p', labels[item.exploitation_status], 'vulnerability-evidence');
+        addText(card, 'h3', item.cve_id);
+        if (item.title && item.title !== item.cve_id) addText(card, 'p', item.title, 'vulnerability-title');
+        const kev = item.reports?.cisa_kev;
+        const nvd = item.reports?.nvd;
+        addText(card, 'p', `Severity: ${nvd?.severity || 'Not supplied'} · ${kev?.product || 'Product not supplied'}${nvd?.status ? ` · NVD: ${nvd.status}` : ''}`, 'vulnerability-meta');
+        // Keep long provider descriptions available without making cards unbounded.
+        const summary = document.createElement('details');
+        addText(summary, 'summary', 'Read description');
+        addText(summary, 'p', item.description || 'No description supplied.');
+        card.appendChild(summary);
+        addReport(card, 'CISA KEV evidence & action', kev, [
+          ['vendor', 'Vendor'], ['product', 'Product'], ['description', 'CISA description'],
+          ['date_added', 'Added to catalog'], ['catalog_checked_at', 'Catalog checked'],
+          ['required_action', 'Required action'], ['due_date', 'CISA due date (federal directive)'],
+          ['ransomware_use', 'Known ransomware campaign use'], ['notes', 'Notes'],
+        ]);
+        addReport(card, 'NVD publication & severity', nvd, [
+          ['published_at', 'Published'], ['modified_at', 'Modified'], ['status', 'NVD status'],
+          ['severity', 'Severity'], ['description', 'NVD description'],
+        ]);
+        addText(card, 'p', `Reporting sources: ${item.sources.join(', ') || 'Not supplied'}`, 'vulnerability-meta');
+        if (!kev && !nvd) {
+          const reference = safeHttpUrl(item.reference);
+          if (reference) {
+            const link = addText(card, 'a', 'Open reporting source ↗', 'vulnerability-meta');
+            link.href = reference;
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+          }
+        }
+        const copy = addText(card, 'button', 'Copy CVE', 'button ghost');
+        copy.type = 'button';
+        copy.addEventListener('click', () => copyOrPrompt(item.cve_id, 'CVE copied.', 'Copy this CVE:'));
+        card.appendChild(copy);
+        cards.appendChild(card);
+      });
+    };
+    const load = async () => {
+      loading = true;
+      failed = false;
+      items = [];
+      page = 0;
+      render();
+      const controller = new AbortController();
+      const timer = window.setTimeout(() => controller.abort(), 20000);
+      try {
+        const response = await fetch(resolveIocUrl('collections/vulnerabilities.json'), { cache: 'no-cache', signal: controller.signal });
+        if (!response.ok) throw new Error('Collection unavailable');
+        const data = await response.json();
+        if (data.schema_version !== 1 || !Array.isArray(data.items) || typeof data.generated_at !== 'string' || !Number.isFinite(Date.parse(data.generated_at))) throw new Error('Invalid collection');
+        const seen = new Set();
+        for (const item of data.items) {
+          if (!item || typeof item.cve_id !== 'string' || !/^CVE-\d{4}-\d{4,}$/.test(item.cve_id) || seen.has(item.cve_id)
+            || !Object.hasOwn(labels, item.exploitation_status) || !Array.isArray(item.sources)
+            || !item.sources.every((source) => typeof source === 'string')
+            || !item.reports || typeof item.reports !== 'object' || Array.isArray(item.reports)) throw new Error('Invalid CVE record');
+          seen.add(item.cve_id);
+        }
+        items = data.items;
+        generatedAt = new Date(data.generated_at).toLocaleString();
+      } catch (error) {
+        items = [];
+        failed = true;
+      } finally {
+        window.clearTimeout(timer);
+        loading = false;
+        render();
+      }
+    };
+    [search, filter].forEach((control) => control.addEventListener(control === search ? 'input' : 'change', () => { page = 0; render(); }));
+    previous.addEventListener('click', () => { page -= 1; render(); });
+    next.addEventListener('click', () => { page += 1; render(); });
+    refresh.addEventListener('click', load);
+    load();
+  };
+
   const initialiseDiscovery = () => {
     const root = qs('[data-discovery-root]');
     if (!root || !dashboardCore?.buildDiscovery) return;
@@ -4070,6 +4213,7 @@
   initialiseTableToggles();
   initialiseInvestigationWorkspace();
   initialiseStatusBanner();
+  initialiseVulnerabilities();
   initialiseDiscovery();
   initialiseCampaignGraph();
   initialiseTopThreats();

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -3133,7 +3133,7 @@
         if (data.schema_version !== 1 || !Array.isArray(data.items) || typeof data.generated_at !== 'string' || !Number.isFinite(Date.parse(data.generated_at))) throw new Error('Invalid collection');
         const seen = new Set();
         for (const item of data.items) {
-          if (!item || typeof item.cve_id !== 'string' || !/^CVE-\d{4}-\d{4,}$/.test(item.cve_id) || seen.has(item.cve_id)
+          if (!item || typeof item.cve_id !== 'string' || !/^CVE-[0-9]{4}-[0-9]{4,19}$/.test(item.cve_id) || seen.has(item.cve_id)
             || !Object.hasOwn(labels, item.exploitation_status) || !Array.isArray(item.sources)
             || !item.sources.every((source) => typeof source === 'string')
             || !item.reports || typeof item.reports !== 'object' || Array.isArray(item.reports)) throw new Error('Invalid CVE record');

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -3730,3 +3730,19 @@ body::before {
   .discovery-card, .discovery-lenses button, .campaign-node, .campaign-node-core { transition: none !important; }
   .discovery-card:hover { transform: none; }
 }
+
+/* Vulnerabilities are evidence records, separate from observable campaign pivots. */
+.vulnerability-cards { align-items: start; }
+.vulnerability-desk { scroll-margin-top: 6rem; border-color: #706149; background: radial-gradient(ellipse at 100% 0, #42351d55, transparent 60%), #0c1826; }
+.vulnerability-toolbar { display: flex; flex-wrap: wrap; align-items: end; gap: 1rem; margin-block: 1.5rem; }
+.vulnerability-toolbar label { display: grid; flex: 1 1 16rem; gap: 0.5rem; color: #b7c6d8; font-size: 0.8rem; min-width: 0; }
+.vulnerability-toolbar input, .vulnerability-toolbar select { width: 100%; min-width: 0; box-sizing: border-box; min-height: 2.8rem; padding: 0.7rem; background: #111d2c; color: #eef3f8; border: 1px solid #64748b; border-radius: 0.5rem; font: inherit; }
+.vulnerability-toolbar :focus-visible { outline: 2px solid #f5d195; outline-offset: 3px; }
+.vulnerability-card[data-exploitation="known_exploited"] { border-top: 3px solid #f2b96b; }
+.vulnerability-evidence { color: #cad7e6; font-size: 0.73rem; line-height: 1.5; margin: 0; }
+.vulnerability-card[data-exploitation="known_exploited"] .vulnerability-evidence { color: #f5cd97; }
+.vulnerability-title { color: #e4ecf5; font-size: 0.9rem; line-height: 1.5; margin-top: 0; overflow-wrap: anywhere; }
+.vulnerability-meta { color: #aebfd2; font-size: 0.76rem; line-height: 1.6; overflow-wrap: anywhere; }
+.vulnerability-card > button { margin-top: auto; align-self: start; }
+.vulnerability-pagination { display: flex; flex-wrap: wrap; justify-content: center; align-items: center; gap: 1rem; margin-block: 1.25rem; color: #b7c6d8; font-size: 0.8rem; }
+@media (max-width: 650px) { .vulnerability-toolbar { flex-direction: column; align-items: stretch; } .vulnerability-toolbar label { flex-basis: auto; } }

--- a/public/index.html
+++ b/public/index.html
@@ -92,6 +92,7 @@
         <div class="nav-links">
           <a href="#ioc-lookup">Check an IOC</a>
           <a href="#discovery">Discover</a>
+          <a href="#vulnerabilities">Vulnerabilities</a>
           <a href="#campaign-graph">Campaign graph</a>
           <a href="#live-preview">Browse feed</a>
           <a href="#sources">Sources</a>
@@ -320,6 +321,40 @@
         </div>
       </section>
 
+      <section class="discovery-desk vulnerability-desk" id="vulnerabilities" aria-labelledby="vulnerability-heading" data-vulnerability-root>
+        <div class="discovery-heading">
+          <div>
+            <p class="eyebrow">Vulnerability collection · one record per CVE</p>
+            <h2 id="vulnerability-heading">Understand what needs patching.</h2>
+            <p>Separate vulnerabilities from network and file indicators. Inspect known exploitation, affected products, and each provider’s evidence without joining unrelated CVEs into a campaign.</p>
+          </div>
+          <a class="button ghost" href="collections/vulnerabilities.json" data-vulnerability-download>Get collection JSON ↗</a>
+        </div>
+        <div class="vulnerability-toolbar">
+          <label>Find a vulnerability
+            <input type="search" data-vulnerability-search placeholder="CVE, vendor, product, or description" autocomplete="off" />
+          </label>
+          <label>Exploitation evidence
+            <select data-vulnerability-status-filter>
+              <option value="all">All vulnerabilities</option>
+              <option value="known_exploited">CISA KEV · known exploited</option>
+              <option value="reported_exploitation">Reported · without structured KEV evidence</option>
+              <option value="not_established">Not established by this feed</option>
+            </select>
+          </label>
+          <button type="button" class="button ghost" data-vulnerability-refresh>Refresh collection</button>
+        </div>
+        <p class="discovery-status" data-vulnerability-status role="status">Loading the vulnerability collection…</p>
+        <div class="discovery-cards vulnerability-cards" data-vulnerability-cards></div>
+        <div class="vulnerability-pagination">
+          <button type="button" class="button ghost" data-vulnerability-prev disabled>Previous</button>
+          <span data-vulnerability-page>Page 0 of 0</span>
+          <button type="button" class="button ghost" data-vulnerability-next disabled>Next</button>
+        </div>
+        <p class="discovery-scope">This collection covers the retained feed, not the complete KEV or NVD catalogs. Source windows, outages, and retention affect coverage. KEV membership records known exploitation; it does not date an attack or confirm one is happening now. Severity alone does not establish exploitation. These filters are independent of the IOC preview.</p>
+        <p class="discovery-scope">Building an IOC integration? <a href="collections/observables.jsonl" data-observables-download>Download the observable-only collection</a>. Existing combined exports remain available.</p>
+      </section>
+
       <section class="discovery-desk" id="discovery" aria-labelledby="discovery-heading" data-discovery-root>
         <div class="discovery-heading">
           <div>
@@ -340,7 +375,7 @@
         <p class="discovery-status" data-discovery-status role="status">Loading the discovery sample…</p>
         <div class="discovery-cards" data-discovery-cards></div>
         <p class="discovery-empty" data-discovery-empty hidden>No leads match this lens. Try another lens or broaden the preview filters below.</p>
-        <p class="discovery-scope">Derived from the compact preview, not the complete feed. Preview filters apply here. Nothing is uploaded when you explore or export.</p>
+        <p class="discovery-scope">Observables from the compact preview, not the complete feed. CVEs are listed in the vulnerability collection above. Preview filters apply here. Nothing is uploaded when you explore or export.</p>
       </section>
 
       <section
@@ -355,7 +390,7 @@
             <p class="eyebrow">Campaign lens · inferred relationships</p>
             <h2 id="campaign-graph-heading" class="panel-title">Threat Campaign Graph</h2>
             <p class="panel-subtitle">
-              Explore shared tags and reporting sources. These are investigation pivots,
+              Explore shared tags and reporting sources for observables. CVEs have their own collection above. These are investigation pivots,
               not claims of common threat-actor ownership.
             </p>
           </div>

--- a/scripts/test_vulnerability_ui.cjs
+++ b/scripts/test_vulnerability_ui.cjs
@@ -15,15 +15,16 @@ const assert = require('node:assert/strict');
     const errors = [];
     page.on('pageerror', (error) => errors.push(error.message));
     let mode = 'success';
+    const longId = 'CVE-1900-1234567890123456789';
     const items = Array.from({ length: 8 }, (_, index) => ({
-      cve_id: `CVE-2026-${1000 + index}`,
+      cve_id: index === 7 ? longId : `CVE-2026-${1000 + index}`,
       title: index === 0 ? 'Synthetic router vulnerability' : `Separate issue ${index}`,
       description: '<img src=x onerror="window.injected=true"> Synthetic evidence, not a real advisory.',
       sources: index < 2 ? ['kev', 'nvd'] : ['nvd'],
       exploitation_status: index < 2 ? 'known_exploited' : 'not_established',
       reports: {
         ...(index < 2 ? { cisa_kev: { vendor: 'FixtureVendor', product: 'Router', required_action: 'Apply the vendor update',
-          date_added: '2026-09-01', catalog_checked_at: '2026-09-08T00:00:00Z',
+          description: 'CISA-only remediation context', date_added: '2026-09-01', catalog_checked_at: '2026-09-08T00:00:00Z',
           reference: 'javascript:alert(1)' } } : {}),
         nvd: { severity: 'critical', description: 'Independent NVD description', status: 'Analyzed',
           reference: 'https://nvd.nist.gov/vuln/detail/CVE-2026-1000' },
@@ -32,7 +33,8 @@ const assert = require('node:assert/strict');
     await page.route('**/collections/vulnerabilities.json', (route) => {
       if (mode === 'failure') return route.fulfill({ status: 503, body: 'Unavailable' });
       if (mode === 'malformed') return route.fulfill({ contentType: 'application/json', body: '{"items":' });
-      const payloadItems = mode === 'invalid-record' ? [{ ...items[0], cve_id: [items[0].cve_id] }] : items;
+      const payloadItems = mode === 'invalid-record' ? [{ ...items[0], cve_id: [items[0].cve_id] }]
+        : mode === 'overlong-id' ? [{ ...items[0], cve_id: longId + '0' }] : items;
       return route.fulfill({ contentType: 'application/json', body: JSON.stringify({
         schema_version: 1, generated_at: '2026-09-08T00:00:00Z', items: mode === 'empty' ? [] : payloadItems,
       }) });
@@ -53,10 +55,15 @@ const assert = require('node:assert/strict');
     await search.fill('cve-2026-1001');
     assert.equal(await cards.count(), 1);
     assert.equal(await cards.locator('h3').innerText(), 'CVE-2026-1001');
-    await search.fill('cve-2026-1007');
+    await search.fill(longId);
     assert.equal(await cards.count(), 0);
     await filter.selectOption('all');
     assert.equal(await cards.count(), 1);
+    assert.equal(await cards.locator('h3').innerText(), longId);
+    await search.fill('CISA-only remediation');
+    assert.equal(await cards.count(), 2);
+    await search.fill('Independent NVD description');
+    assert.match(await status.innerText(), /8 of 8 CVEs/);
     await search.fill('FixtureVendor');
     assert.equal(await cards.count(), 2);
     await search.fill('');
@@ -70,10 +77,13 @@ const assert = require('node:assert/strict');
     await page.locator('.vulnerability-card details[open]').evaluateAll((details) => details.forEach((detail) => { detail.open = false; }));
     if (process.env.SCREENSHOT_DIR) await page.screenshot({ path: `${process.env.SCREENSHOT_DIR}/vulnerabilities-desktop.png` });
     await page.setViewportSize({ width: 390, height: 844 });
+    await search.fill(longId);
+    assert.equal(await cards.count(), 1);
     await page.locator('#vulnerabilities').evaluate((element) => element.scrollIntoView({ block: 'start' }));
     assert.equal(await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth), false);
     if (process.env.SCREENSHOT_DIR) await page.screenshot({ path: `${process.env.SCREENSHOT_DIR}/vulnerabilities-mobile.png` });
-    for (const failure of ['failure', 'malformed', 'invalid-record']) {
+    await search.fill('');
+    for (const failure of ['failure', 'malformed', 'invalid-record', 'overlong-id']) {
       mode = failure;
       await refresh.click();
       await status.filter({ hasText: 'Collection unavailable' }).waitFor();

--- a/scripts/test_vulnerability_ui.cjs
+++ b/scripts/test_vulnerability_ui.cjs
@@ -1,0 +1,97 @@
+/* Browser regression checks. Serve public/ locally; requires Playwright + Chromium.
+ * BASE_URL defaults to http://127.0.0.1:8765. All vulnerability data is synthetic.
+ */
+const { chromium } = require('playwright');
+const assert = require('node:assert/strict');
+
+(async () => {
+  const browser = await chromium.launch({
+    headless: true,
+    ...(process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+      ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH } : {}),
+  });
+  try {
+    const page = await browser.newPage({ reducedMotion: 'reduce', viewport: { width: 1440, height: 1000 } });
+    const errors = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+    let mode = 'success';
+    const items = Array.from({ length: 8 }, (_, index) => ({
+      cve_id: `CVE-2026-${1000 + index}`,
+      title: index === 0 ? 'Synthetic router vulnerability' : `Separate issue ${index}`,
+      description: '<img src=x onerror="window.injected=true"> Synthetic evidence, not a real advisory.',
+      sources: index < 2 ? ['kev', 'nvd'] : ['nvd'],
+      exploitation_status: index < 2 ? 'known_exploited' : 'not_established',
+      reports: {
+        ...(index < 2 ? { cisa_kev: { vendor: 'FixtureVendor', product: 'Router', required_action: 'Apply the vendor update',
+          date_added: '2026-09-01', catalog_checked_at: '2026-09-08T00:00:00Z',
+          reference: 'javascript:alert(1)' } } : {}),
+        nvd: { severity: 'critical', description: 'Independent NVD description', status: 'Analyzed',
+          reference: 'https://nvd.nist.gov/vuln/detail/CVE-2026-1000' },
+      },
+    }));
+    await page.route('**/collections/vulnerabilities.json', (route) => {
+      if (mode === 'failure') return route.fulfill({ status: 503, body: 'Unavailable' });
+      if (mode === 'malformed') return route.fulfill({ contentType: 'application/json', body: '{"items":' });
+      const payloadItems = mode === 'invalid-record' ? [{ ...items[0], cve_id: [items[0].cve_id] }] : items;
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify({
+        schema_version: 1, generated_at: '2026-09-08T00:00:00Z', items: mode === 'empty' ? [] : payloadItems,
+      }) });
+    });
+    await page.goto(process.env.BASE_URL || 'http://127.0.0.1:8765', { waitUntil: 'domcontentloaded' });
+    const status = page.locator('[data-vulnerability-status]');
+    const cards = page.locator('.vulnerability-card');
+    const search = page.locator('[data-vulnerability-search]');
+    const filter = page.locator('[data-vulnerability-status-filter]');
+    const refresh = page.locator('[data-vulnerability-refresh]');
+    await status.filter({ hasText: '8 of 8 CVEs' }).waitFor();
+    assert.equal(await cards.count(), 6);
+    await page.locator('[data-vulnerability-next]').click();
+    assert.equal(await cards.count(), 2);
+    assert.match(await page.locator('[data-vulnerability-page]').innerText(), /Page 2 of 2/);
+    await filter.selectOption('known_exploited');
+    assert.equal(await cards.count(), 2);
+    await search.fill('cve-2026-1001');
+    assert.equal(await cards.count(), 1);
+    assert.equal(await cards.locator('h3').innerText(), 'CVE-2026-1001');
+    await search.fill('cve-2026-1007');
+    assert.equal(await cards.count(), 0);
+    await filter.selectOption('all');
+    assert.equal(await cards.count(), 1);
+    await search.fill('FixtureVendor');
+    assert.equal(await cards.count(), 2);
+    await search.fill('');
+    await cards.first().getByText('Read description', { exact: true }).click();
+    await cards.first().getByText('CISA KEV evidence & action', { exact: true }).click();
+    assert.equal(await cards.locator('img').count(), 0);
+    assert.equal(await cards.locator('a[href^="javascript:"]').count(), 0);
+    assert.match(await cards.first().innerText(), /Apply the vendor update/);
+    assert.equal(await page.evaluate(() => window.injected), undefined);
+    await page.locator('#vulnerabilities').evaluate((element) => element.scrollIntoView({ block: 'start' }));
+    await page.locator('.vulnerability-card details[open]').evaluateAll((details) => details.forEach((detail) => { detail.open = false; }));
+    if (process.env.SCREENSHOT_DIR) await page.screenshot({ path: `${process.env.SCREENSHOT_DIR}/vulnerabilities-desktop.png` });
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.locator('#vulnerabilities').evaluate((element) => element.scrollIntoView({ block: 'start' }));
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth), false);
+    if (process.env.SCREENSHOT_DIR) await page.screenshot({ path: `${process.env.SCREENSHOT_DIR}/vulnerabilities-mobile.png` });
+    for (const failure of ['failure', 'malformed', 'invalid-record']) {
+      mode = failure;
+      await refresh.click();
+      await status.filter({ hasText: 'Collection unavailable' }).waitFor();
+      assert.equal(await cards.count(), 0);
+      assert.equal(await page.locator('[data-vulnerability-next]').isDisabled(), true);
+      mode = 'success';
+      await refresh.click();
+      await status.filter({ hasText: '8 of 8 CVEs' }).waitFor();
+      assert.equal(await cards.count(), 6);
+    }
+    mode = 'empty';
+    await refresh.click();
+    await status.filter({ hasText: '0 of 0 CVEs' }).waitFor();
+    assert.equal(await cards.count(), 0);
+    assert.equal(await page.locator('[data-vulnerability-prev]').isDisabled(), true);
+    assert.deepEqual(errors, []);
+    console.log('PASS: CVE identity, filters, pagination, safe rendering, mobile layout, failed refresh, malformed data, retry, and empty collection.');
+  } finally {
+    await browser.close();
+  }
+})().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/swiftioc/cli.py
+++ b/swiftioc/cli.py
@@ -13,6 +13,7 @@ import yaml
 
 from . import http_client
 from .collect import collect_from_yaml, parse_name_int_pairs, top_tags, type_breakdown
+from .collections import write_collections
 from .detections import write_detection_pack
 from .http_client import UA_POOL, get_fetch_metrics, logger
 from .logging_utils import configure_logging
@@ -309,6 +310,7 @@ def main() -> int:
     )
 
     run_ts = iso(now_utc())
+    collection_counts = write_collections(out_dir / "collections", rows, generated_at=run_ts)
     detection_manifest = write_detection_pack(
         out_dir / "detections", high_conf, generated_at=run_ts
     )
@@ -407,6 +409,7 @@ def main() -> int:
         "window_hours": args.window_hours,
         "total": len(rows),
         "total_before_dedup": raw_total,
+        "collections": collection_counts,
         "duplicates_removed": duplicates_removed,
         "false_positives_removed": stats.get("false_positives_removed", 0),
         "persist_feed": bool(args.persist_feed),

--- a/swiftioc/collect.py
+++ b/swiftioc/collect.py
@@ -222,6 +222,11 @@ def collect_from_yaml(
             uniq[k] = i
             continue
         prev = uniq[k]
+        if i.type == "cve":
+            prev.vulnerability = {**prev.vulnerability, **i.vulnerability}
+        old_first, new_first = parse_dt(prev.first_seen), parse_dt(i.first_seen)
+        if new_first and (old_first is None or new_first < old_first):
+            prev.first_seen = i.first_seen
         # last_seen
         try:
             p = parse_dt(prev.last_seen) or now_utc()

--- a/swiftioc/collections.py
+++ b/swiftioc/collections.py
@@ -1,0 +1,61 @@
+"""Separate actionable observables from per-CVE vulnerability evidence."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .models import Indicator, normalize_value
+from .writers import write_json_document, write_jsonl
+
+
+def vulnerability_records(rows: List[Indicator]) -> List[Dict[str, Any]]:
+    """One record per exact CVE identity, never per generic tag or provider."""
+    records: Dict[str, Dict[str, Any]] = {}
+    for row in rows:
+        if row.type != "cve":
+            continue
+        cve_id = normalize_value("cve", row.indicator)
+        record = records.setdefault(cve_id, {
+            "cve_id": cve_id, "sources": [], "reports": {}, "tags": [],
+            "description": row.context, "reference": row.reference,
+        })
+        record["sources"] = sorted(set(record["sources"]) | set(filter(None, row.source.split(","))))
+        record["tags"] = sorted(set(record["tags"]) | set(filter(None, row.tags.split(","))))
+        record["reports"].update(row.vulnerability)
+    for record in records.values():
+        reports = record["reports"]
+        kev = reports.get("cisa_kev")
+        nvd = reports.get("nvd")
+        if isinstance(kev, dict) and kev:
+            record["exploitation_status"] = "known_exploited"
+            record["title"] = kev.get("title") or record["cve_id"]
+        elif "exploited-in-the-wild" in record["tags"]:
+            # Legacy feeds and third-party reports lack structured KEV evidence.
+            record["exploitation_status"] = "reported_exploitation"
+            record["title"] = record["cve_id"]
+        else:
+            record["exploitation_status"] = "not_established"
+            record["title"] = record["cve_id"]
+        if isinstance(nvd, dict) and nvd.get("description"):
+            record["description"] = nvd["description"]
+    priority = {"known_exploited": 0, "reported_exploitation": 1, "not_established": 2}
+    return sorted(records.values(), key=lambda r: (priority[r["exploitation_status"]], r["cve_id"]))
+
+
+def write_collections(out_dir: Path, rows: List[Indicator], *, generated_at: str) -> Dict[str, int]:
+    """Add typed exports while preserving the legacy combined feed contract."""
+    vulnerabilities = vulnerability_records(rows)
+    observables = [row for row in rows if row.type != "cve"]
+    counts = {
+        "observables": len(observables), "vulnerabilities": len(vulnerabilities),
+        "known_exploited": sum(r["exploitation_status"] == "known_exploited" for r in vulnerabilities),
+        "reported_exploitation": sum(r["exploitation_status"] == "reported_exploitation" for r in vulnerabilities),
+        "not_established": sum(r["exploitation_status"] == "not_established" for r in vulnerabilities),
+    }
+    write_jsonl(out_dir / "observables.jsonl", observables)
+    write_json_document(out_dir / "vulnerabilities.json", {
+        "schema_version": 1, "generated_at": generated_at,
+        "scope": "Vulnerabilities in the retained feed; source windows, failures and retention may limit coverage.",
+        "counts": counts, "items": vulnerabilities,
+    })
+    return counts

--- a/swiftioc/models.py
+++ b/swiftioc/models.py
@@ -158,7 +158,9 @@ DOMAIN_RE = re.compile(r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?:\.[A-Za-z0-9-]{
 MD5_RE = re.compile(r"[a-fA-F0-9]{32}")
 SHA1_RE = re.compile(r"[a-fA-F0-9]{40}")
 SHA256_RE = re.compile(r"[A-Fa-f0-9]{64}")
-CVE_RE = re.compile(r"CVE-\d{4}-\d{4,7}", re.I)
+# CVE Record Format allows 4–19 sequence digits. Boundaries also prevent
+# inline extraction from truncating an overlong or otherwise embedded ID.
+CVE_RE = re.compile(r"\bCVE-[0-9]{4}-[0-9]{4,19}\b", re.I)
 
 
 def classify(v: str) -> Optional[str]:
@@ -201,4 +203,3 @@ def classify(v: str) -> Optional[str]:
 
 def merge_conf(a: str, b: str) -> str:
     return a if CONF_RANK.get(a, 0) >= CONF_RANK.get(b, 0) else b
-

--- a/swiftioc/models.py
+++ b/swiftioc/models.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 import ipaddress
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from dateutil import parser as dtparser
 
@@ -36,6 +36,8 @@ class Indicator:
     # How many collection runs have re-observed this indicator (persisted
     # across runs via the living feed). 1 = seen in this run only.
     sightings: int = 1
+    # Provider-specific CVE evidence; confidence/relevance is not exploitation.
+    vulnerability: Dict[str, Any] = field(default_factory=dict)
 
     def key(self) -> Tuple[str, str]:
         return (self.type, self.indicator)
@@ -130,6 +132,8 @@ def normalize_value(itype: str, value: str) -> str:
     intact — lowercasing credentials would both mangle them and risk merging
     distinct indicators during dedup).
     """
+    if itype == "cve":
+        return value.strip().upper()
     if itype == "domain":
         return value.lower()
     if itype == "url":

--- a/swiftioc/parsers.py
+++ b/swiftioc/parsers.py
@@ -31,6 +31,7 @@ import swiftioc as _pkg
 from .extract import extract_indicators_from_text
 from .http_client import ensure_text, logger
 from .models import (
+    CVE_RE,
     DATE_FIELD_RE,
     JA3_RE,
     SHA256_RE,
@@ -97,18 +98,30 @@ def fetch_cisa_kev(url: str, ref_url: str, source: str, ws: datetime) -> List[In
     out: List[Indicator] = []
     now = now_utc()
     for it in data.get("vulnerabilities", []) or []:
+        if not isinstance(it, dict):
+            continue
         cve = it.get("cveID")
         pub = parse_dt(it.get("dateAdded"))
-        if not cve:
+        if not isinstance(cve, str) or not CVE_RE.fullmatch(cve.strip()):
             continue
         out.append(
             Indicator(
-                indicator=cve, type="cve", source=source,
+                indicator=cve.strip().upper(), type="cve", source=source,
                 first_seen=iso(pub or now), last_seen=iso(now),
                 confidence="high", tlp="CLEAR",
                 tags="cve,exploited-in-the-wild",
                 reference=ref_url or "",
-                context=it.get("notes") or it.get("shortDescription") or "CISA KEV",
+                context=it.get("shortDescription") or it.get("notes") or "CISA KEV",
+                vulnerability={"cisa_kev": {
+                    "source": source, "reference": ref_url,
+                    "catalog_checked_at": iso(now),
+                    "date_added": it.get("dateAdded"),
+                    "vendor": it.get("vendorProject"), "product": it.get("product"),
+                    "title": it.get("vulnerabilityName"),
+                    "description": it.get("shortDescription"),
+                    "required_action": it.get("requiredAction"), "due_date": it.get("dueDate"),
+                    "ransomware_use": it.get("knownRansomwareCampaignUse"), "notes": it.get("notes"),
+                }},
             )
         )
     return out
@@ -208,7 +221,7 @@ def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime, *, api_k
         if not isinstance(cve, dict):
             continue
         cve_id = cve.get("id")
-        if not isinstance(cve_id, str):
+        if not isinstance(cve_id, str) or not CVE_RE.fullmatch(cve_id.strip()):
             continue
         published = parse_dt(cve.get("published"))
         last_modified = parse_dt(cve.get("lastModified"))
@@ -238,7 +251,7 @@ def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime, *, api_k
         context = description or "NVD recent CVE"
         out.append(
             Indicator(
-                indicator=cve_id.upper(),
+                indicator=cve_id.strip().upper(),
                 type="cve",
                 source=source,
                 first_seen=iso(first_seen or now),
@@ -248,6 +261,13 @@ def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime, *, api_k
                 tags=",".join(sorted(tags)),
                 reference=ref_url or "",
                 context=context,
+                vulnerability={"nvd": {
+                    "source": source,
+                    "reference": "https://nvd.nist.gov/vuln/detail/" + cve_id.strip().upper(),
+                    "published_at": cve.get("published"), "modified_at": cve.get("lastModified"),
+                    "status": cve.get("vulnStatus"), "severity": severity,
+                    "description": description,
+                }},
             )
         )
     return out

--- a/swiftioc/scoring.py
+++ b/swiftioc/scoring.py
@@ -2,13 +2,14 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from dataclasses import fields as dataclass_fields, replace
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from .fp import is_false_positive
-from .models import Indicator, classify, merge_conf, now_utc, parse_dt
+from .models import Indicator, classify, merge_conf, normalize_value, now_utc, parse_dt
 
 
 # ---------------- scoring: corroboration + age decay ----------------
@@ -166,6 +167,12 @@ def load_previous_feed(path: Path) -> List[Indicator]:
                 continue
             ind.type = actual_type
             ind.indicator = ind.indicator.strip().lower()
+        if ind.type == "cve":
+            if not isinstance(ind.indicator, str) or classify(ind.indicator.strip()) != "cve":
+                continue
+            ind.indicator = normalize_value("cve", ind.indicator)
+        if not isinstance(ind.vulnerability, dict):
+            ind.vulnerability = {}
         if is_false_positive(ind.type, ind.indicator):
             continue
         out.append(ind)
@@ -192,10 +199,12 @@ def merge_with_previous(current: List[Indicator], previous: List[Indicator]) -> 
             # mutates current rows; sharing this object with ``previous`` made
             # SOC Delta compare the new score with itself and hid decay/band
             # changes. It also corrupted removal payloads with the new score.
-            uniq[k] = replace(prev)
+            uniq[k] = replace(prev, vulnerability=deepcopy(prev.vulnerability))
             carried += 1
             continue
         cur = uniq[k]
+        if cur.type == "cve":
+            cur.vulnerability = deepcopy({**prev.vulnerability, **cur.vulnerability})
         p_first = parse_dt(prev.first_seen)
         c_first = parse_dt(cur.first_seen)
         if p_first and (c_first is None or p_first < c_first):

--- a/swiftioc/writers.py
+++ b/swiftioc/writers.py
@@ -123,6 +123,15 @@ def _score_band(score: int) -> str:
     return "aging"
 
 
+def _vulnerability_evidence(reports: Dict[str, Any]) -> Dict[str, Any]:
+    """Compare provider evidence without alerting on every KEV catalog poll."""
+    return {
+        provider: {key: value for key, value in report.items() if key != "catalog_checked_at"}
+        if provider == "cisa_kev" and isinstance(report, dict) else report
+        for provider, report in reports.items()
+    }
+
+
 def build_delta(
     previous: List[Indicator],
     current: List[Indicator],
@@ -137,6 +146,8 @@ def build_delta(
     run as thousands of new alerts would make the feed unsafe for automation.
     Score updates are material only when they cross a dashboard band or move by
     at least five points, which suppresses routine decay noise.
+    Provider evidence changes are material; the local KEV catalog poll time
+    alone is not. Event payloads still retain the complete provider reports.
     """
     events: List[Dict[str, Any]] = []
     if baseline_available:
@@ -155,6 +166,11 @@ def build_delta(
                 old_value, new_value = getattr(old, field), getattr(new, field)
                 if old_value != new_value:
                     changes[field] = {"from": old_value, "to": new_value}
+            if _vulnerability_evidence(old.vulnerability) != _vulnerability_evidence(new.vulnerability):
+                changes["vulnerability"] = {
+                    "from": asdict(old)["vulnerability"],
+                    "to": asdict(new)["vulnerability"],
+                }
             if old.score != new.score and (
                 abs(new.score - old.score) >= 5 or _score_band(old.score) != _score_band(new.score)
             ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,6 +71,7 @@ def test_cli_main_end_to_end_writes_expected_outputs(tmp_path, monkeypatch):
         "iocs/stix2.json", "iocs/high_confidence.csv", "iocs/high_confidence.jsonl",
         "iocs/dashboard.jsonl", "badge.json", "diagnostics/run.json", "diagnostics/REPORT.md",
         "iocs/delta.json", "iocs/delta.jsonl",
+        "collections/observables.jsonl", "collections/vulnerabilities.json",
         "iocs/taxii2-envelope.json",
         "changelog/CHANGELOG.md",
         "detections/manifest.json", "detections/README.md",
@@ -80,6 +81,8 @@ def test_cli_main_end_to_end_writes_expected_outputs(tmp_path, monkeypatch):
         assert (out_dir / rel).exists(), f"missing output: {rel}"
 
     diag = json.loads((out_dir / "diagnostics" / "run.json").read_text(encoding="utf-8"))
+    assert diag["collections"]["observables"] == 3
+    assert diag["collections"]["vulnerabilities"] == 0
     assert diag["total_before_dedup"] == 5
     # 5 raw rows (3 from src_a, 2 from src_b, both overlapping src_a's first
     # two) dedup to 3 unique indicators -> 2 genuine duplicates removed.

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,0 +1,99 @@
+"""CVE identity and provider evidence must survive collection and persistence."""
+import json
+from copy import deepcopy
+from datetime import timedelta
+from typing import Any, Dict
+
+import swiftioc as si
+from swiftioc.collections import vulnerability_records, write_collections
+
+
+def indicator(value, kind="cve", **kwargs):
+    values: Dict[str, Any] = dict(indicator=value, type=kind, source="nvd", first_seen="2020-01-01T00:00:00Z",
+                  last_seen=si.iso(si.now_utc()), confidence="high", tlp="CLEAR", tags="cve,nvd",
+                  reference="https://nvd.nist.gov/", context="Description")
+    values.update(kwargs)
+    return si.Indicator(**values)
+
+
+def test_collect_keeps_distinct_cves_and_each_providers_evidence(monkeypatch):
+    now = si.iso(si.now_utc())
+    kev = {"vulnerabilities": [
+        {"cveID": "cve-2020-1234", "dateAdded": "2022-02-01", "vendorProject": "Vendor A",
+         "product": "Router", "shortDescription": "CISA description", "requiredAction": "Patch",
+         "dueDate": "2022-03-01", "knownRansomwareCampaignUse": "Unknown"},
+        {"cveID": "CVE-2020-5678", "dateAdded": "2023-01-01", "product": "Other product"},
+        {"cveID": "CVE-2020-1234 trailing text"}, {"cveID": None}, None, 123,
+    ]}
+    nvd = {"vulnerabilities": [{"cve": {
+        "id": cve, "published": "2020-01-01T00:00:00Z", "lastModified": now,
+        "descriptions": [{"lang": "en", "value": "NVD description"}],
+        "metrics": {"cvssMetricV31": [{"cvssData": {"baseSeverity": "CRITICAL"}}]},
+    }} for cve in ["CVE-2020-1234", "CVE-2020-9999", "bad-id"]]}
+    monkeypatch.setattr(si, "http_get", lambda url, **kw: json.dumps(kev if kw["name"] == "kev" else nvd))
+    rows, counts, _ = si.collect_from_yaml(
+        {"apis": [{"name": name, "parse": name, "url": "https://example.invalid"} for name in ["kev", "nvd"]]},
+        window_hours=48, skip_rss=True, max_per_source=None, urlhaus_status="any", source_window={},
+        grace_on_404=set(), ci_safe_rss=False,
+    )
+    assert counts == {"kev": 2, "nvd": 2}
+    assert len(rows) == 3
+    records = {r["cve_id"]: r for r in vulnerability_records(rows)}
+    merged = records["CVE-2020-1234"]
+    assert merged["sources"] == ["kev", "nvd"]
+    assert merged["reports"]["cisa_kev"]["description"] == "CISA description"
+    assert merged["reports"]["cisa_kev"]["required_action"] == "Patch"
+    assert merged["reports"]["nvd"]["description"] == "NVD description"
+    assert merged["reports"]["nvd"]["published_at"] == "2020-01-01T00:00:00Z"
+    assert merged["exploitation_status"] == "known_exploited"
+    assert records["CVE-2020-5678"]["exploitation_status"] == "known_exploited"
+    assert records["CVE-2020-9999"]["exploitation_status"] == "not_established"
+    assert next(r for r in rows if r.indicator == "CVE-2020-1234").first_seen == "2020-01-01T00:00:00Z"
+
+
+def test_provider_evidence_roundtrip_and_missing_source_preservation(tmp_path):
+    previous = indicator("CVE-2020-1234", source="kev", vulnerability={"cisa_kev": {
+        "required_action": "Old action", "catalog_checked_at": "2026-01-01T00:00:00Z"}})
+    path = tmp_path / "latest.jsonl"
+    si.write_jsonl(path, [previous])
+    baseline = si.load_previous_feed(path)
+    before = deepcopy(baseline)
+    current = indicator("CVE-2020-1234", vulnerability={"nvd": {"description": "New report"}})
+    merged, carried = si.merge_with_previous([current], baseline)
+    assert carried == 0
+    assert set(merged[0].vulnerability) == {"cisa_kev", "nvd"}
+    assert merged[0].vulnerability["cisa_kev"]["catalog_checked_at"] == "2026-01-01T00:00:00Z"
+    merged[0].vulnerability["cisa_kev"]["required_action"] = "Mutated"
+    assert baseline == before
+    carried_rows, carried = si.merge_with_previous([], baseline)
+    assert carried == 1
+    carried_rows[0].vulnerability["cisa_kev"]["required_action"] = "Also mutated"
+    assert baseline == before
+    updated, _ = si.merge_with_previous([indicator("CVE-2020-1234", vulnerability={
+        "cisa_kev": {"required_action": "Fresh action"}})], baseline)
+    assert updated[0].vulnerability["cisa_kev"] == {"required_action": "Fresh action"}
+
+
+def test_legacy_cve_ids_normalize_and_do_not_claim_structured_kev_evidence(tmp_path):
+    path = tmp_path / "latest.jsonl"
+    si.write_jsonl(path, [indicator("cve-2020-1234", tags="cve,exploited-in-the-wild")])
+    loaded = si.load_previous_feed(path)
+    assert loaded[0].indicator == "CVE-2020-1234"
+    assert vulnerability_records(loaded)[0]["exploitation_status"] == "reported_exploitation"
+
+
+def test_typed_exports_partition_and_replace_empty_collection(tmp_path):
+    rows = [indicator("CVE-2020-1234", vulnerability={"cisa_kev": {"product": "Router"}}),
+            indicator("CVE-2020-2345", tags="cve,exploited-in-the-wild"),
+            indicator("CVE-2020-3456"), indicator("8.8.8.8", "ipv4", tags="malware")]
+    counts = write_collections(tmp_path, rows, generated_at=si.iso(si.now_utc()))
+    assert counts == dict(observables=1, vulnerabilities=3, known_exploited=1,
+                          reported_exploitation=1, not_established=1)
+    observable = json.loads((tmp_path / "observables.jsonl").read_text())
+    assert observable["indicator"] == "8.8.8.8"
+    document = json.loads((tmp_path / "vulnerabilities.json").read_text())
+    assert document["schema_version"] == 1
+    assert [r["cve_id"] for r in document["items"]] == ["CVE-2020-1234", "CVE-2020-2345", "CVE-2020-3456"]
+    write_collections(tmp_path, [], generated_at=si.iso(si.now_utc() + timedelta(hours=1)))
+    assert json.loads((tmp_path / "vulnerabilities.json").read_text())["items"] == []
+    assert (tmp_path / "observables.jsonl").read_text() == ""

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -4,6 +4,8 @@ from copy import deepcopy
 from datetime import timedelta
 from typing import Any, Dict
 
+import pytest
+
 import swiftioc as si
 from swiftioc.collections import vulnerability_records, write_collections
 
@@ -97,3 +99,40 @@ def test_typed_exports_partition_and_replace_empty_collection(tmp_path):
     write_collections(tmp_path, [], generated_at=si.iso(si.now_utc() + timedelta(hours=1)))
     assert json.loads((tmp_path / "vulnerabilities.json").read_text())["items"] == []
     assert (tmp_path / "observables.jsonl").read_text() == ""
+
+
+@pytest.mark.parametrize("digits", [4, 7, 8, 19])
+def test_full_cve_sequence_range_survives_parsers_snapshot_and_collections(digits, monkeypatch, tmp_path):
+    cve = "CVE-1900-" + "1" * digits
+    now = si.iso(si.now_utc())
+    payload = {"vulnerabilities": [{
+        "cveID": cve.lower(), "dateAdded": "2026-09-08",
+        "cve": {"id": cve.lower(), "lastModified": now},
+    }]}
+    monkeypatch.setattr(si, "http_get", lambda *args, **kwargs: json.dumps(payload))
+    ws = si.now_utc() - timedelta(days=1)
+    kev = si.fetch_cisa_kev("https://example.invalid", "ref", "kev", ws)
+    nvd = si.fetch_nvd_recent("https://example.invalid", "ref", "nvd", ws)
+    assert [r.indicator for r in kev] == [cve]
+    assert [r.indicator for r in nvd] == [cve]
+    assert si.classify(cve) == "cve"
+    assert ("cve", cve) in si.extract_indicators_from_text(f"Advisory ({cve}).")
+    path = tmp_path / "latest.jsonl"
+    si.write_jsonl(path, kev + nvd)
+    loaded = si.load_previous_feed(path)
+    assert len(loaded) == 2
+    records = vulnerability_records(loaded)
+    assert len(records) == 1
+    assert records[0]["cve_id"] == cve
+    assert set(records[0]["reports"]) == {"cisa_kev", "nvd"}
+
+
+@pytest.mark.parametrize("cve", ["CVE-1900-123", "CVE-1900-" + "1" * 20, "CVE-1900-１２３４"])
+def test_invalid_cve_ids_are_not_accepted_or_truncated(cve, monkeypatch):
+    payload = {"vulnerabilities": [{"cveID": cve, "cve": {"id": cve}}]}
+    monkeypatch.setattr(si, "http_get", lambda *args, **kwargs: json.dumps(payload))
+    ws = si.now_utc() - timedelta(days=1)
+    assert si.fetch_cisa_kev("https://example.invalid", "ref", "kev", ws) == []
+    assert si.fetch_nvd_recent("https://example.invalid", "ref", "nvd", ws) == []
+    assert si.classify(cve) != "cve"
+    assert not [r for r in si.extract_indicators_from_text(cve) if r[0] == "cve"]

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
+
+import pytest
 
 import swiftioc as si
 
@@ -70,3 +73,42 @@ def test_carried_forward_rescoring_does_not_mutate_delta_baseline():
         [previous], [], generated_at="2026-09-08T08:00:00Z"
     )
     assert removed["events"][0]["previous"]["score"] == 65
+
+
+@pytest.mark.parametrize(("provider", "field", "old_value", "new_value"), [
+    ("nvd", "severity", "high", "critical"),
+    ("nvd", "status", "Analyzed", "Rejected"),
+    ("cisa_kev", "required_action", "Apply update", "Discontinue use"),
+    ("cisa_kev", "due_date", "2026-09-30", "2026-09-15"),
+])
+def test_delta_reports_provider_evidence_changes(provider, field, old_value, new_value):
+    old = indicator("CVE-1900-1234")
+    old.type = "cve"
+    old.vulnerability = {"cisa_kev": {"catalog_checked_at": "2026-09-08T00:00:00Z"}}
+    old.vulnerability.setdefault(provider, {})[field] = old_value
+    new = deepcopy(old)
+    new.vulnerability[provider][field] = new_value
+    new.vulnerability["cisa_kev"]["catalog_checked_at"] = "2026-09-08T04:00:00Z"
+    baseline = deepcopy(old)
+    delta = si.build_delta([old], [new], generated_at="2026-09-08T04:00:00Z")
+    assert delta["counts"] == {"added": 0, "updated": 1, "removed": 0}
+    event = delta["events"][0]
+    assert event["changes"] == {"vulnerability": {"from": old.vulnerability, "to": new.vulnerability}}
+    assert event["current"]["vulnerability"] == new.vulnerability
+    assert old == baseline
+
+
+def test_delta_ignores_catalog_poll_time_without_losing_provider_report_changes():
+    old = indicator("CVE-1900-1234")
+    old.type = "cve"
+    old.vulnerability = {"cisa_kev": {"required_action": "Apply update", "catalog_checked_at": "2026-09-08T00:00:00Z"}}
+    new = deepcopy(old)
+    new.vulnerability["cisa_kev"]["catalog_checked_at"] = "2026-09-08T04:00:00Z"
+    assert si.build_delta([old], [new], generated_at="now")["events"] == []
+    legacy = deepcopy(old)
+    legacy.vulnerability = {}
+    for before, after in [(legacy, new), (new, legacy)]:
+        delta = si.build_delta([before], [after], generated_at="now")
+        assert delta["counts"]["updated"] == 1
+        assert delta["events"][0]["changes"]["vulnerability"]["to"] == after.vulnerability
+    assert si.build_delta([old], [new], generated_at="now", baseline_available=False)["events"] == []

--- a/tests/test_malwarebazaar.py
+++ b/tests/test_malwarebazaar.py
@@ -107,7 +107,7 @@ def test_previous_feed_repairs_issue_82_and_preserves_history(tmp_path):
     path.write_text(json.dumps(original) + "\n")
     rows = si.load_previous_feed(path)
     assert len(rows) == 1
-    assert asdict(rows[0]) == {**original, "type": "sha1"}
+    assert asdict(rows[0]) == {**original, "type": "sha1", "vulnerability": {}}
     # Repair is idempotent and keeps old observations without inventing SHA256.
     path.write_text(json.dumps(asdict(rows[0])) + "\n")
     assert si.load_previous_feed(path) == rows


### PR DESCRIPTION
Distinct CVE IDs were already preserved by collector deduplication, but the campaign graph joined unrelated vulnerabilities through generic CVE tags and common providers. CISA KEV and NVD context was also flattened during deduplication, losing provider-specific details.

This PR adds a dedicated vulnerability collection and dashboard view: one record per CVE, searchable by ID/vendor/product/description, with pagination and separate CISA/NVD evidence. Structured KEV evidence marks known exploitation; legacy/source exploitation tags are labeled separately, and NVD severity alone does not establish exploitation. CVEs no longer participate in the observable campaign graph or Discovery desk.

The collector now publishes collections/vulnerabilities.json and collections/observables.jsonl, preserves provider reports across persisted runs without mutating the baseline, and keeps the earliest first-seen date when merging duplicate observations. Existing combined feeds and CSV columns remain compatible; JSON indicator records gain an additive vulnerability field. Malformed KEV entries are skipped individually.

Search includes both provider descriptions independently of the combined summary. CVE validation accepts the full 4–19 digit sequence range across adapters, stored snapshots, inline extraction, and the browser. SOC Delta emits provider-evidence changes (including severity, status, required action, and due date), while excluding catalog-check timestamps alone to avoid routine alert noise.

The UI clears results after failed refreshes, validates loaded records, supports retry and empty states, renders provider content safely, and displays NVD status and provider-specific dates. The README documents the schema, labels, migration behavior, and coverage limits. These collections cover the retained feed, not complete upstream catalogs; retained provider evidence keeps its original dates.

Validation: 170 Python tests, 27 frontend logic tests, Ruff, built-in self-tests, and Pyright (0 errors; 5 existing dependency-source warnings). Added and ran a reproducible Playwright browser check for exact CVE selection, filters, pagination, safe rendering, mobile overflow, failed refreshes, invalid data, retry, and empty collections. Desktop and mobile screenshots were visually reviewed.