### PR TITLE
Fix Discovery desk provider aliases and numeric timestamp handling

### DIFF
--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -33,10 +33,16 @@
   };
 
   const timestamp = (value) => {
-    if (typeof value === 'number' && Number.isFinite(value)) {
-      return value > 1e12 ? value / 1000 : value;
+    const text = stringValue(value);
+    if (!text) return null;
+    // Match dashboard parseTimestamp for Unix seconds/milliseconds supplied
+    // as either numbers or strings; do not substitute firstSeen timestamps.
+    const numeric = Number(text);
+    if (Number.isFinite(numeric)) {
+      const time = numeric > 1e12 && numeric < 1e13 ? Math.round(numeric / 1000) : numeric;
+      return Number.isNaN(new Date(time * 1000).getTime()) ? null : time;
     }
-    const parsed = Date.parse(stringValue(value));
+    const parsed = Date.parse(text);
     return Number.isNaN(parsed) ? null : parsed / 1000;
   };
 
@@ -433,7 +439,15 @@
       if (key && !unique.has(key)) unique.set(key, row);
     }
     const rows = Array.from(unique.values());
-    const sourceNames = new Set(rows.flatMap(rowSources).map(lower));
+    // Provider-name tags emitted by our adapters are provenance, including
+    // when the source uses an alias (ci_army_list → cins) or a custom name.
+    // Keep behavior/product/family tags such as tor, scanning, phishing, c2.
+    const sourceNames = new Set([
+      'threatfox', 'cins', 'feodo', 'sslbl', 'spamhaus', 'dshield', 'sans-isc',
+      'openphish', 'greensnow', 'emerging-threats', 'binarydefense', 'ipsum',
+      'urlhaus', 'malwarebazaar',
+      ...rows.flatMap(rowSources).flatMap((source) => stringValue(source).split(',')).map(lower),
+    ]);
     const ignored = new Set(['aggregated', 'blocklist', 'malicious', 'malware', 'high',
       'critical', 'medium', 'low', 'info', 'unknown', 'ioc', 'multi-list']);
     const tagsFor = (row) => Array.from(new Set(

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -426,3 +426,47 @@ test('vulnerability search indexes each provider description independently of th
   }
   assert.deepEqual(core.filterVulnerabilities([item], 'CISA-specific', 'not_established'), []);
 });
+
+
+test('uncommon discovery omits adapter provider aliases while preserving investigative tags', () => {
+  const examples = [
+    ['threatfox_export_json', ' ThreatFox '], ['ci_army_list', 'CINS'],
+    ['feodo_ipblocklist', 'feodo'], ['sslbl_ja3', 'sslbl'],
+    ['spamhaus_drop', 'spamhaus'], ['dshield_block', 'sans-isc'],
+    ['openphish_feed', 'openphish'], ['greensnow_blocklist', 'greensnow'],
+    ['et_compromised', 'emerging-threats'], ['binarydefense_banlist', 'binarydefense'],
+    ['ipsum_level5', 'ipsum'], ['custom-provider-name', 'threatfox'],
+  ];
+  const rows = examples.map(([source, tag], index) => ({
+    ...row, indicator: `provider-${index}.example`, sourceList: [source], tags: [tag],
+  }));
+  assert.equal(core.buildDiscovery(rows, 'uncommon').total, 0);
+  const useful = ['mirai', 'c2', 'phishing', 'scanning', 'tor', 'exit-node'].map((tag, index) => ({
+    ...row, indicator: `lead-${index}.example`, sourceList: ['threatfox_export_json'], tags: ['threatfox', tag],
+  }));
+  const result = core.buildDiscovery([...rows, ...useful], 'uncommon');
+  assert.deepEqual(new Set(result.findings.map(({ label }) => label)), new Set(useful.map((r) => r.tags[1])));
+  assert.equal(result.sampleSize, rows.length + useful.length);
+  assert.match(result.findings[0].reason, /appears on 1 of 18/);
+  assert.deepEqual(core.buildDiscovery([...rows, ...useful].reverse(), 'uncommon'), result);
+  assert.equal(core.buildDiscovery([{ ...row, sourceList: [], source: 'feed-x, feed-y', tags: ['feed-x', 'feed-y'] }], 'uncommon').total, 0);
+});
+
+test('recent discovery accepts equivalent ISO, Unix-number, and numeric-string sightings', () => {
+  const now = 1720003600;
+  const seen = 1720000000;
+  for (const value of [seen, String(seen), ` ${seen} `, seen * 1000, String(seen * 1000), new Date(seen * 1000).toISOString()]) {
+    for (const field of ['lastSeen', 'last_seen']) {
+      const item = { ...row, lastSeen: undefined, last_seen: undefined, [field]: value };
+      const result = core.buildDiscovery([item], 'recent', now);
+      assert.equal(result.total, 1, `${field}=${JSON.stringify(value)}`);
+      assert.equal(result.findings[0].rank, seen);
+    }
+  }
+  for (const value of [null, undefined, '', '  ', 'NaN', 'Infinity', '1e20', 'not a date', String(now + 1), String(now - 86401)]) {
+    // A recent firstSeen/bestTimestamp must never conceal a missing or stale sighting.
+    const item = { ...row, lastSeen: value, firstSeen: now, bestTimestamp: now };
+    assert.equal(core.buildDiscovery([item], 'recent', now).total, 0, String(value));
+  }
+  assert.equal(core.buildDiscovery([{ ...row, lastSeen: String(now - 86400) }], 'recent', now).total, 1);
+});


### PR DESCRIPTION
The uncommon-tag lens could promote provider labels such as cins and threatfox because they differ from configured source names such as ci_army_list and threatfox_export_json. The Recent sightings lens also dropped Unix timestamp strings accepted by the dashboard normalizer.

Exclude the adapters’ known provider-name tags before rarity counting, including when sources are renamed, and split comma-separated source names. Keep behavior and malware-family tags eligible. Parse Unix seconds and milliseconds supplied as numbers or numeric strings consistently with the dashboard, while continuing to exclude invalid, future, and stale last-seen values. A recent first-seen timestamp does not substitute for a missing last-seen value.

Addresses the two review findings on merged PR #95:
- https://github.com/PKHarsimran/SwiftIOC-Automated-Threat-Intelligence-Collector/pull/95#discussion_r3957718681
- https://github.com/PKHarsimran/SwiftIOC-Automated-Threat-Intelligence-Collector/pull/95#discussion_r3957718684

Validation: all 29 frontend tests pass. Added coverage for provider aliases, renamed and comma-separated sources, retained investigative tags, numeric/ISO timestamp equivalence, the 24-hour boundary, and invalid/future/stale sightings. Reproduced both failures against main and verified the corrected outputs.