### PR TITLE
Prioritize exploited CVEs and add recent vulnerability views

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,24 @@ Choose the shortest path for what you are trying to do:
 SwiftIOC deduplicates by `(type, indicator)`: `CVE-2020-1234` and
 `CVE-2020-5678` stay separate even if both appear in NVD or share a generic
 `cve` tag. Reports about **the same CVE** are combined under that CVE ID while
-keeping `reports.cisa_kev` and `reports.nvd` separately. The campaign graph and
+keeping `reports.cisa_kev` and `reports.nvd` separately. The default queue
+puts known-exploited CVEs first, newest KEV additions first; exploitation
+reports follow, then other CVEs, newest NVD publications first within each group. The JSON export uses the same priority ordering, with
+rejected records last. CVE ID year and generic IOC scores do not establish recency.
+
+Use **Added to KEV · 30 days**, **Published · 7 days**, or **Updated · 7 days**
+to focus on recent catalog additions, disclosures, or provider record edits.
+These are different events: an old CVE added to KEV today belongs in the first
+view, and an old CVE edited today belongs in the third, not the newly published
+view. Date windows use UTC provider timestamps and exclude unknown, invalid,
+and future dates. Search and exploitation filters apply within each view.
+
+NVD rejected records are hidden by default, with a count and an opt-in control;
+they remain in exports for auditability. Cards expose provider dates and CISA
+actions. A snapshot older than 24 hours is flagged, and old or missing KEV check
+dates are labeled as historical evidence. Neither a fresh snapshot nor KEV
+membership proves attacks are happening now. These are triage priorities;
+match affected products to your assets before deciding remediation. The campaign graph and
 Discovery desk use observables; CVEs have their own searchable, paginated view.
 
 Each collector run writes these additive exports:

--- a/README.md
+++ b/README.md
@@ -48,9 +48,12 @@ Choose the shortest path for what you are trying to do:
 SwiftIOC deduplicates by `(type, indicator)`: `CVE-2020-1234` and
 `CVE-2020-5678` stay separate even if both appear in NVD or share a generic
 `cve` tag. Reports about **the same CVE** are combined under that CVE ID while
-keeping `reports.cisa_kev` and `reports.nvd` separately. The default queue
-puts known-exploited CVEs first, newest KEV additions first; exploitation
-reports follow, then other CVEs, newest NVD publications first within each group. The JSON export uses the same priority ordering, with
+keeping `reports.cisa_kev` and `reports.nvd` separately. The site opens on
+**Known exploited**, showing only confirmed KEV entries, newest additions first.
+It never fills an empty watchlist with unconfirmed CVEs. **Ransomware evidence**
+requires CISA's explicit `Known` ransomware-use value; `Unknown` does not qualify.
+**All CVEs · prioritized** includes exploitation reports and other CVEs, newest
+NVD publications first within each group. The JSON export uses that full priority ordering, with
 rejected records last. CVE ID year and generic IOC scores do not establish recency.
 
 Use **Added to KEV · 30 days**, **Published · 7 days**, or **Updated · 7 days**
@@ -205,7 +208,7 @@ high-fidelity IOCs from authoritative sources. The project emphasises:
   user, persists output through `/data`, and exposes the collector self-test as
   its health check.
 - **Retention / "top IOCs" curation** – `--max-age-days` drops indicators not
-  seen recently and `--max-store` keeps only the top N by score and recency, so
+  seen recently and `--max-store` prioritizes recently checked KEV entries, then fills the remaining slots by score and recency, so
   the published feed stays small, fresh, and high-signal (think *KEV catalogue,
   but for indicators*) instead of an unbounded dump. The scheduled workflow
   curates to the last 30 days and the top 10,000 indicators.
@@ -380,6 +383,13 @@ score = (confidence base + corroboration bonus) × 0.5^(age / half-life)
   domains in two, curated CIDR blocks and JA3 fingerprints in a month, file
   hashes over six months, and CVEs over a year.
 
+When a storage cap is set, non-rejected CVEs with a KEV catalog check in the
+past 24 hours take priority over generic IOC scores, with newest KEV additions
+first. Stale, missing, or future check dates receive no special retention
+priority. Score expiry and maximum-age rules still apply, and the cap remains
+strict; if qualifying KEV records alone exceed it, older additions are pruned.
+Source failures and per-source limits can still restrict upstream coverage.
+
 With `--persist-feed` (enabled in the scheduled collection workflow) the
 previous `latest.jsonl` is merged into each run, making the published feed
 **stateful**: re-observed indicators refresh to full score with their original
@@ -504,7 +514,7 @@ Run `python -m swiftioc --help` for the full list of switches. Highlights:
 | `--min-score N` | Expire indicators whose decayed score falls below `N` (default `20`). |
 | `--high-confidence-score N` | Score at/above which an indicator enters the curated `high_confidence` feed (default `80`; multi-source indicators always qualify). |
 | `--max-age-days N` | Retention: drop indicators whose `last_seen` is older than `N` days. |
-| `--max-store N` | Retention: keep only the top `N` indicators by score/recency (KEVIntel-style curation; keeps the stored feed small and high-signal). |
+| `--max-store N` | Retention: keep at most `N`; non-rejected KEV entries checked within 24 hours take priority (newest catalog additions first), then other records by score/recency. |
 | `--dashboard-rows N` | Rows in the compact `dashboard.jsonl` the web dashboard downloads (default `1000`, ~2–3% of the full feed's size). |
 | `--site-url URL` | Public site URL used as the RSS `<link>` (override for forks/custom domains). |
 | `--rss-limit N` | Number of items in `feed.xml` (default `50`). |

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -673,21 +673,53 @@
     return url;
   };
 
-  const filterVulnerabilities = (items, search = '', status = 'all') => {
+  // NVD timestamps without offsets are UTC, not the analyst's local time.
+  const vulnerabilityDate = (value, now) => {
+    if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}(?:$|T)/.test(value)) return null;
+    const day = value.slice(0, 10);
+    const calendar = Date.parse(`${day}T00:00:00Z`);
+    if (!Number.isFinite(calendar) || new Date(calendar).toISOString().slice(0, 10) !== day) return null;
+    const utc = value.includes('T') && !/(?:Z|[+-]\d{2}:?\d{2})$/i.test(value) ? `${value}Z` : value;
+    const time = Date.parse(utc) / 1000;
+    return Number.isFinite(time) && time <= now ? time : null;
+  };
+
+  const vulnerabilityFacts = (item, now = Date.now() / 1000) => ({
+    added: vulnerabilityDate(item.reports?.cisa_kev?.date_added, now),
+    checked: vulnerabilityDate(item.reports?.cisa_kev?.catalog_checked_at, now),
+    published: vulnerabilityDate(item.reports?.nvd?.published_at, now),
+    modified: vulnerabilityDate(item.reports?.nvd?.modified_at, now),
+    rejected: lower(item.reports?.nvd?.status) === 'rejected',
+  });
+
+  const filterVulnerabilities = (items, search = '', status = 'all', options = {}) => {
     const query = lower(search).trim();
+    const now = options.now ?? Date.now() / 1000;
+    const view = ['kev30', 'published7', 'updated7'].includes(options.view) ? options.view : 'priority';
     const priority = { known_exploited: 0, reported_exploitation: 1, not_established: 2 };
-    return items.filter((item) => {
+    const recent = (time, days) => time != null && now - time <= days * 86400;
+    const orderDate = (item, facts) => view === 'updated7' ? facts.modified
+      : view === 'published7' ? facts.published
+      : item.exploitation_status === 'known_exploited' ? facts.added : facts.published;
+    return items.map((item) => ({ item, facts: vulnerabilityFacts(item, now) })).filter(({ item, facts }) => {
+      if (!options.includeRejected && facts.rejected) return false;
       if (status !== 'all' && item.exploitation_status !== status) return false;
+      if (view === 'kev30' && (item.exploitation_status !== 'known_exploited' || !recent(facts.added, 30))) return false;
+      if (view === 'published7' && !recent(facts.published, 7)) return false;
+      if (view === 'updated7' && !recent(facts.modified, 7)) return false;
       const kev = item.reports?.cisa_kev || {};
       const nvd = item.reports?.nvd || {};
       return !query || lower([item.cve_id, item.title, item.description, kev.vendor,
         kev.product, kev.description, nvd.description, ...(item.sources || [])].join(' ')).includes(query);
-    }).sort((a, b) => (priority[a.exploitation_status] ?? 3) - (priority[b.exploitation_status] ?? 3)
-      || a.cve_id.localeCompare(b.cve_id));
+    }).sort((a, b) => Number(a.facts.rejected) - Number(b.facts.rejected)
+      || (view === 'priority' ? (priority[a.item.exploitation_status] ?? 3) - (priority[b.item.exploitation_status] ?? 3) : 0)
+      || (orderDate(b.item, b.facts) ?? -Infinity) - (orderDate(a.item, a.facts) ?? -Infinity)
+      || a.item.cve_id.localeCompare(b.item.cve_id)).map(({ item }) => item);
   };
 
   return {
     filterVulnerabilities,
+    vulnerabilityFacts,
     compareRows,
     buildCampaignGraph,
     buildDiscovery,

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -690,12 +690,13 @@
     published: vulnerabilityDate(item.reports?.nvd?.published_at, now),
     modified: vulnerabilityDate(item.reports?.nvd?.modified_at, now),
     rejected: lower(item.reports?.nvd?.status) === 'rejected',
+    ransomware: item.exploitation_status === 'known_exploited' && lower(item.reports?.cisa_kev?.ransomware_use) === 'known',
   });
 
   const filterVulnerabilities = (items, search = '', status = 'all', options = {}) => {
     const query = lower(search).trim();
     const now = options.now ?? Date.now() / 1000;
-    const view = ['kev30', 'published7', 'updated7'].includes(options.view) ? options.view : 'priority';
+    const view = ['exploited', 'ransomware', 'kev30', 'published7', 'updated7'].includes(options.view) ? options.view : 'priority';
     const priority = { known_exploited: 0, reported_exploitation: 1, not_established: 2 };
     const recent = (time, days) => time != null && now - time <= days * 86400;
     const orderDate = (item, facts) => view === 'updated7' ? facts.modified
@@ -704,6 +705,8 @@
     return items.map((item) => ({ item, facts: vulnerabilityFacts(item, now) })).filter(({ item, facts }) => {
       if (!options.includeRejected && facts.rejected) return false;
       if (status !== 'all' && item.exploitation_status !== status) return false;
+      if (view === 'exploited' && item.exploitation_status !== 'known_exploited') return false;
+      if (view === 'ransomware' && !facts.ransomware) return false;
       if (view === 'kev30' && (item.exploitation_status !== 'known_exploited' || !recent(facts.added, 30))) return false;
       if (view === 'published7' && !recent(facts.published, 7)) return false;
       if (view === 'updated7' && !recent(facts.modified, 7)) return false;

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -470,3 +470,52 @@ test('recent discovery accepts equivalent ISO, Unix-number, and numeric-string s
   }
   assert.equal(core.buildDiscovery([{ ...row, lastSeen: String(now - 86400) }], 'recent', now).total, 1);
 });
+
+
+const triageNow = Date.parse('2026-09-08T12:00:00Z') / 1000;
+const triageItem = (id, status, added, published, modified = published, nvdStatus = 'Analyzed') => ({
+  cve_id: id, exploitation_status: status, sources: [], reports: {
+    ...(status === 'known_exploited' ? { cisa_kev: { date_added: added } } : {}),
+    nvd: { published_at: published, modified_at: modified, status: nvdStatus },
+  },
+});
+const triageItems = [
+  triageItem('CVE-2026-1001', 'known_exploited', '2021-01-01', '2021-01-01', '2026-09-08T11:00:00'),
+  triageItem('CVE-1900-1002', 'known_exploited', '2026-09-08', '2001-01-01'),
+  triageItem('CVE-1900-1003', 'not_established', null, '2026-09-08T10:00:00'),
+  triageItem('CVE-2026-1004', 'not_established', null, '2020-01-01', '2026-09-08T11:30:00Z'),
+  triageItem('CVE-2026-1005', 'known_exploited', '2026-09-08', '2026-09-08', '2026-09-08', 'Rejected'),
+  triageItem('CVE-2026-1006', 'not_established', null, '2030-01-01', '2030-01-01'),
+];
+
+test('CVE priority uses exploitation evidence and provider dates, not CVE ID or modification date', () => {
+  const before = JSON.stringify(triageItems);
+  const result = core.filterVulnerabilities(triageItems, '', 'all', { now: triageNow });
+  assert.deepEqual(result.map((r) => r.cve_id), ['CVE-1900-1002', 'CVE-2026-1001', 'CVE-1900-1003', 'CVE-2026-1004', 'CVE-2026-1006']);
+  const withRejected = core.filterVulnerabilities(triageItems, '', 'all', { now: triageNow, includeRejected: true });
+  assert.equal(withRejected.at(-1).cve_id, 'CVE-2026-1005');
+  assert.equal(JSON.stringify(triageItems), before);
+});
+
+test('CVE views distinguish recent catalog addition, disclosure, and modification', () => {
+  const ids = (view, status = 'all') => core.filterVulnerabilities(triageItems, '', status, { now: triageNow, view }).map((r) => r.cve_id);
+  assert.deepEqual(ids('kev30'), ['CVE-1900-1002']);
+  assert.deepEqual(ids('published7'), ['CVE-1900-1003']);
+  assert.deepEqual(ids('published7', 'known_exploited'), []);
+  assert.deepEqual(ids('updated7'), ['CVE-2026-1004', 'CVE-2026-1001', 'CVE-1900-1003']);
+  assert.deepEqual(core.filterVulnerabilities(triageItems, 'CVE-1900-1002', 'all', { now: triageNow, view: 'kev30' }).map((r) => r.cve_id), ['CVE-1900-1002']);
+});
+
+test('CVE dates treat offset-free NVD timestamps as UTC and reject invalid/future dates', () => {
+  const expected = Date.parse('2026-09-08T10:00:00Z') / 1000;
+  for (const date of ['2026-09-08T10:00:00', '2026-09-08T10:00:00Z', '2026-09-08T15:30:00+05:30']) {
+    assert.equal(core.vulnerabilityFacts(triageItem('CVE-1900-1234', 'not_established', null, date), triageNow).published, expected);
+  }
+  for (const date of [null, '', 'not a date', '2030-01-01', '2026-02-30', '2026-13-01']) {
+    const item = triageItem('CVE-1900-1234', 'not_established', null, date);
+    assert.equal(core.vulnerabilityFacts(item, triageNow).published, null);
+    assert.equal(core.filterVulnerabilities([item], '', 'all', { now: triageNow, view: 'published7' }).length, 0);
+  }
+  const boundary = new Date((triageNow - 7 * 86400) * 1000).toISOString();
+  assert.equal(core.filterVulnerabilities([triageItem('CVE-1900-1234', 'not_established', null, boundary)], '', 'all', { now: triageNow, view: 'published7' }).length, 1);
+});

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -519,3 +519,28 @@ test('CVE dates treat offset-free NVD timestamps as UTC and reject invalid/futur
   const boundary = new Date((triageNow - 7 * 86400) * 1000).toISOString();
   assert.equal(core.filterVulnerabilities([triageItem('CVE-1900-1234', 'not_established', null, boundary)], '', 'all', { now: triageNow, view: 'published7' }).length, 1);
 });
+
+
+test('exploited and ransomware views require explicit evidence and never fall back to generic CVEs', () => {
+  const confirmed = triageItem('CVE-1900-1234', 'known_exploited', '2026-09-07', '2020-01-01');
+  confirmed.reports.cisa_kev.ransomware_use = 'Known';
+  const unknown = triageItem('CVE-1900-1235', 'known_exploited', '2026-09-06', '2020-01-01');
+  unknown.reports.cisa_kev.ransomware_use = 'Unknown';
+  const generic = triageItem('CVE-1900-1236', 'not_established', null, '2026-09-08');
+  const items = [generic, unknown, confirmed];
+  assert.deepEqual(core.filterVulnerabilities(items, '', 'all', {view: 'exploited', now: triageNow}).map((r) => r.cve_id), [confirmed.cve_id, unknown.cve_id]);
+  assert.deepEqual(core.filterVulnerabilities(items, '', 'all', {view: 'ransomware', now: triageNow}), [confirmed]);
+  assert.equal(core.filterVulnerabilities([generic], '', 'all', {view: 'exploited', now: triageNow}).length, 0);
+  assert.equal(core.filterVulnerabilities(items, '', 'not_established', {view: 'exploited', now: triageNow}).length, 0);
+  for (const value of ['Unknown', 'Not known', '', null]) {
+    confirmed.reports.cisa_kev.ransomware_use = value;
+    assert.equal(core.vulnerabilityFacts(confirmed, triageNow).ransomware, false);
+  }
+});
+
+test('vulnerability release uses coordinated new asset cache keys', () => {
+  const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+  for (const asset of ['styles.css', 'dashboard-core.js', 'dashboard.js']) {
+    assert.ok(html.includes(`assets/${asset}?v=16`));
+  }
+});

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -3016,7 +3016,7 @@
 
   const initialiseVulnerabilities = () => {
     const root = qs('[data-vulnerability-root]');
-    if (!root || !dashboardCore?.filterVulnerabilities) return;
+    if (!root || !dashboardCore?.filterVulnerabilities || !dashboardCore?.vulnerabilityFacts) return;
     const cards = qs('[data-vulnerability-cards]', root);
     const status = qs('[data-vulnerability-status]', root);
     const search = qs('[data-vulnerability-search]', root);
@@ -3026,13 +3026,17 @@
     const includeRejected = qs('[data-vulnerability-include-rejected]', root);
     const help = qs('[data-vulnerability-view-help]', root);
     const freshness = qs('[data-vulnerability-freshness]', root);
+    // Old HTML may remain in an intermediary cache during a deployment.
+    if (!includeRejected || !help || !freshness || !views.length) return;
     const viewHelp = {
+      exploited: 'Confirmed KEV records only, newest catalog additions first. An empty result means this collection has no matching KEV evidence; other CVEs are available in All CVEs.',
+      ransomware: 'CISA KEV records explicitly marked Known for ransomware campaign use. Unknown and unreported values do not qualify.',
       priority: 'Known exploited first (newest KEV additions), then exploitation reports, then other CVEs. Publication dates order each remaining group.',
       kev30: 'Added to CISA KEV in the past 30 days, newest first. Catalog addition is not the date an attack occurred.',
       published7: 'NVD publication dates in the past 7 days, newest first. A newly published CVE is not necessarily exploited.',
       updated7: 'NVD record modifications in the past 7 days, newest first. An edit does not establish a new vulnerability or new exploitation.',
     };
-    let view = 'priority';
+    let view = 'exploited';
     let snapshotTime = null;
     const previous = qs('[data-vulnerability-prev]', root);
     const next = qs('[data-vulnerability-next]', root);
@@ -3116,6 +3120,7 @@
         addText(timeline, 'p', `NVD published: ${day(facts.published)}`);
         if (facts.modified != null) addText(timeline, 'p', `NVD updated: ${day(facts.modified)}`);
         card.appendChild(timeline);
+        if (facts.ransomware) addText(card, 'p', 'CISA: known ransomware campaign use', 'vulnerability-caution');
         if (facts.rejected) addText(card, 'p', 'Rejected by NVD · review the provider record before acting.', 'vulnerability-caution');
         if (item.exploitation_status === 'known_exploited' && (facts.checked == null || now - facts.checked > 86400)) {
           addText(card, 'p', `Historical KEV evidence · catalog check ${facts.checked == null ? 'unknown' : day(facts.checked)}. Refresh to verify current coverage.`, 'vulnerability-caution');

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -3022,6 +3022,18 @@
     const search = qs('[data-vulnerability-search]', root);
     const filter = qs('[data-vulnerability-status-filter]', root);
     const refresh = qs('[data-vulnerability-refresh]', root);
+    const views = qsa('[data-vulnerability-view]', root);
+    const includeRejected = qs('[data-vulnerability-include-rejected]', root);
+    const help = qs('[data-vulnerability-view-help]', root);
+    const freshness = qs('[data-vulnerability-freshness]', root);
+    const viewHelp = {
+      priority: 'Known exploited first (newest KEV additions), then exploitation reports, then other CVEs. Publication dates order each remaining group.',
+      kev30: 'Added to CISA KEV in the past 30 days, newest first. Catalog addition is not the date an attack occurred.',
+      published7: 'NVD publication dates in the past 7 days, newest first. A newly published CVE is not necessarily exploited.',
+      updated7: 'NVD record modifications in the past 7 days, newest first. An edit does not establish a new vulnerability or new exploitation.',
+    };
+    let view = 'priority';
+    let snapshotTime = null;
     const previous = qs('[data-vulnerability-prev]', root);
     const next = qs('[data-vulnerability-next]', root);
     const pageLabel = qs('[data-vulnerability-page]', root);
@@ -3063,7 +3075,18 @@
       card.appendChild(details);
     };
     const render = () => {
-      const matches = dashboardCore.filterVulnerabilities(items, search.value, filter.value);
+      const now = Date.now() / 1000;
+      const matches = dashboardCore.filterVulnerabilities(items, search.value, filter.value, { view, includeRejected: includeRejected.checked, now });
+      const rejectedCount = items.filter((item) => dashboardCore.vulnerabilityFacts(item, now).rejected).length;
+      views.forEach((button) => {
+        button.setAttribute('aria-pressed', String(button.dataset.vulnerabilityView === view));
+        button.disabled = loading;
+      });
+      help.textContent = viewHelp[view];
+      includeRejected.disabled = loading;
+      freshness.hidden = loading || failed || snapshotTime == null || (now - snapshotTime >= 0 && now - snapshotTime <= 86400);
+      freshness.textContent = snapshotTime > now ? 'Snapshot timestamp is in the future. Check the collector clock before treating this data as current.'
+        : 'Snapshot is over 24 hours old. Recent views may be incomplete; refresh and check run diagnostics. Provider dates below describe their own records.';
       const pages = Math.ceil(matches.length / pageSize);
       page = Math.min(page, Math.max(0, pages - 1));
       cards.replaceChildren();
@@ -3074,7 +3097,7 @@
       search.disabled = filter.disabled = loading;
       status.textContent = loading ? 'Loading the vulnerability collection…' : failed
         ? 'Collection unavailable. Refresh to retry; no previous results are displayed.'
-        : `${matches.length} of ${items.length} CVEs · ${items.filter((item) => item.exploitation_status === 'known_exploited').length} with CISA KEV evidence · Snapshot ${generatedAt}${!matches.length ? ' · No matching vulnerabilities.' : ''}`;
+        : `${matches.length} of ${items.length} CVEs · ${matches.filter((item) => item.exploitation_status === 'known_exploited').length} matching with CISA KEV evidence${!includeRejected.checked && rejectedCount ? ` · ${rejectedCount} rejected records hidden` : ''} · Snapshot ${generatedAt}${!matches.length ? ' · No matching vulnerabilities.' : ''}`;
       if (loading || failed) return;
       matches.slice(page * pageSize, (page + 1) * pageSize).forEach((item) => {
         const card = document.createElement('article');
@@ -3085,6 +3108,19 @@
         if (item.title && item.title !== item.cve_id) addText(card, 'p', item.title, 'vulnerability-title');
         const kev = item.reports?.cisa_kev;
         const nvd = item.reports?.nvd;
+        const facts = dashboardCore.vulnerabilityFacts(item, now);
+        const day = (time) => time == null ? 'Unknown / invalid' : new Date(time * 1000).toISOString().slice(0, 10);
+        const timeline = document.createElement('div');
+        timeline.className = 'vulnerability-dates';
+        if (kev) addText(timeline, 'p', `Added to KEV: ${day(facts.added)}`);
+        addText(timeline, 'p', `NVD published: ${day(facts.published)}`);
+        if (facts.modified != null) addText(timeline, 'p', `NVD updated: ${day(facts.modified)}`);
+        card.appendChild(timeline);
+        if (facts.rejected) addText(card, 'p', 'Rejected by NVD · review the provider record before acting.', 'vulnerability-caution');
+        if (item.exploitation_status === 'known_exploited' && (facts.checked == null || now - facts.checked > 86400)) {
+          addText(card, 'p', `Historical KEV evidence · catalog check ${facts.checked == null ? 'unknown' : day(facts.checked)}. Refresh to verify current coverage.`, 'vulnerability-caution');
+        }
+        if (kev?.required_action) addText(card, 'p', `CISA action: ${kev.required_action}`, 'vulnerability-action');
         addText(card, 'p', `Severity: ${nvd?.severity || 'Not supplied'} · ${kev?.product || 'Product not supplied'}${nvd?.status ? ` · NVD: ${nvd.status}` : ''}`, 'vulnerability-meta');
         // Keep long provider descriptions available without making cards unbounded.
         const summary = document.createElement('details');
@@ -3122,6 +3158,7 @@
       loading = true;
       failed = false;
       items = [];
+      snapshotTime = null;
       page = 0;
       render();
       const controller = new AbortController();
@@ -3140,6 +3177,7 @@
           seen.add(item.cve_id);
         }
         items = data.items;
+        snapshotTime = Date.parse(data.generated_at) / 1000;
         generatedAt = new Date(data.generated_at).toLocaleString();
       } catch (error) {
         items = [];
@@ -3150,6 +3188,15 @@
         render();
       }
     };
+    views.forEach((button) => button.addEventListener('click', () => {
+      view = button.dataset.vulnerabilityView;
+      page = 0;
+      render();
+    }));
+    includeRejected.addEventListener('change', () => { page = 0; render(); });
+    // Re-evaluate rolling windows and freshness when an analyst returns to an
+    // open tab, without resetting focus or collapsing evidence every minute.
+    document.addEventListener('visibilitychange', () => { if (!document.hidden && !loading) render(); });
     [search, filter].forEach((control) => control.addEventListener(control === search ? 'input' : 'change', () => { page = 0; render(); }));
     previous.addEventListener('click', () => { page -= 1; render(); });
     next.addEventListener('click', () => { page += 1; render(); });

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -3746,3 +3746,10 @@ body::before {
 .vulnerability-card > button { margin-top: auto; align-self: start; }
 .vulnerability-pagination { display: flex; flex-wrap: wrap; justify-content: center; align-items: center; gap: 1rem; margin-block: 1.25rem; color: #b7c6d8; font-size: 0.8rem; }
 @media (max-width: 650px) { .vulnerability-toolbar { flex-direction: column; align-items: stretch; } .vulnerability-toolbar label { flex-basis: auto; } }
+
+.vulnerability-views { margin-top: 1.5rem; }
+.vulnerability-dates { padding: 0.6rem 0.8rem; margin-top: 0.9rem; border-left: 2px solid #75b9d2; background: #132739; color: #c0d5e8; font-size: 0.75rem; line-height: 1.6; }
+.vulnerability-dates p { margin: 0.2rem 0; }
+.vulnerability-rejected-control { display: flex; align-items: center; gap: 0.5rem; font-size: 0.8rem; color: #b7c6d8; }
+.vulnerability-caution, .vulnerability-freshness { padding: 0.75rem; border: 1px solid #806739; border-radius: 0.5rem; background: #342a1955; color: #f1d6a6; font-size: 0.76rem; line-height: 1.6; }
+.vulnerability-action { color: #d6e6ef; font-size: 0.8rem; line-height: 1.6; overflow-wrap: anywhere; }

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=15" />
+    <link rel="stylesheet" href="assets/styles.css?v=16" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -331,12 +331,14 @@
           <a class="button ghost" href="collections/vulnerabilities.json" data-vulnerability-download>Get collection JSON ↗</a>
         </div>
         <div class="discovery-lenses vulnerability-views" role="group" aria-label="Vulnerability view">
-          <button type="button" data-vulnerability-view="priority" aria-pressed="true">Priority queue</button>
+          <button type="button" data-vulnerability-view="exploited" aria-pressed="true">Known exploited</button>
+          <button type="button" data-vulnerability-view="ransomware" aria-pressed="false">Ransomware evidence</button>
+          <button type="button" data-vulnerability-view="priority" aria-pressed="false">All CVEs · prioritized</button>
           <button type="button" data-vulnerability-view="kev30" aria-pressed="false">Added to KEV · 30 days</button>
           <button type="button" data-vulnerability-view="published7" aria-pressed="false">Published · 7 days</button>
           <button type="button" data-vulnerability-view="updated7" aria-pressed="false">Updated · 7 days</button>
         </div>
-        <p class="discovery-scope" data-vulnerability-view-help>Known exploited first (newest KEV additions), then exploitation reports, then other CVEs. Publication dates order each remaining group.</p>
+        <p class="discovery-scope" data-vulnerability-view-help>Confirmed KEV records only, newest catalog additions first. An empty result means this collection has no matching KEV evidence; other CVEs are available in All CVEs.</p>
         <div class="vulnerability-toolbar">
           <label>Find a vulnerability
             <input type="search" data-vulnerability-search placeholder="CVE, vendor, product, or description" autocomplete="off" />
@@ -984,7 +986,7 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=15"></script>
-    <script defer src="assets/dashboard.js?v=15"></script>
+    <script defer src="assets/dashboard-core.js?v=16"></script>
+    <script defer src="assets/dashboard.js?v=16"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -325,11 +325,18 @@
         <div class="discovery-heading">
           <div>
             <p class="eyebrow">Vulnerability collection · one record per CVE</p>
-            <h2 id="vulnerability-heading">Understand what needs patching.</h2>
+            <h2 id="vulnerability-heading">Known exploited. Newly disclosed. Prioritized.</h2>
             <p>Separate vulnerabilities from network and file indicators. Inspect known exploitation, affected products, and each provider’s evidence without joining unrelated CVEs into a campaign.</p>
           </div>
           <a class="button ghost" href="collections/vulnerabilities.json" data-vulnerability-download>Get collection JSON ↗</a>
         </div>
+        <div class="discovery-lenses vulnerability-views" role="group" aria-label="Vulnerability view">
+          <button type="button" data-vulnerability-view="priority" aria-pressed="true">Priority queue</button>
+          <button type="button" data-vulnerability-view="kev30" aria-pressed="false">Added to KEV · 30 days</button>
+          <button type="button" data-vulnerability-view="published7" aria-pressed="false">Published · 7 days</button>
+          <button type="button" data-vulnerability-view="updated7" aria-pressed="false">Updated · 7 days</button>
+        </div>
+        <p class="discovery-scope" data-vulnerability-view-help>Known exploited first (newest KEV additions), then exploitation reports, then other CVEs. Publication dates order each remaining group.</p>
         <div class="vulnerability-toolbar">
           <label>Find a vulnerability
             <input type="search" data-vulnerability-search placeholder="CVE, vendor, product, or description" autocomplete="off" />
@@ -344,6 +351,8 @@
           </label>
           <button type="button" class="button ghost" data-vulnerability-refresh>Refresh collection</button>
         </div>
+        <label class="vulnerability-rejected-control"><input type="checkbox" data-vulnerability-include-rejected /> Include NVD rejected records</label>
+        <p class="vulnerability-freshness" data-vulnerability-freshness role="status" hidden></p>
         <p class="discovery-status" data-vulnerability-status role="status">Loading the vulnerability collection…</p>
         <div class="discovery-cards vulnerability-cards" data-vulnerability-cards></div>
         <div class="vulnerability-pagination">

--- a/scripts/test_vulnerability_ui.cjs
+++ b/scripts/test_vulnerability_ui.cjs
@@ -11,7 +11,8 @@ const assert = require('node:assert/strict');
       ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH } : {}),
   });
   try {
-    const page = await browser.newPage({ reducedMotion: 'reduce', viewport: { width: 1440, height: 1000 } });
+    const page = await browser.newPage({ reducedMotion: 'reduce', timezoneId: 'Asia/Kolkata', viewport: { width: 1440, height: 1000 } });
+    await page.addInitScript(() => { Date.now = () => Date.parse('2026-09-08T12:00:00Z'); });
     const errors = [];
     page.on('pageerror', (error) => errors.push(error.message));
     let mode = 'success';
@@ -24,9 +25,9 @@ const assert = require('node:assert/strict');
       exploitation_status: index < 2 ? 'known_exploited' : 'not_established',
       reports: {
         ...(index < 2 ? { cisa_kev: { vendor: 'FixtureVendor', product: 'Router', required_action: 'Apply the vendor update',
-          description: 'CISA-only remediation context', date_added: '2026-09-01', catalog_checked_at: '2026-09-08T00:00:00Z',
+          description: 'CISA-only remediation context', date_added: index === 0 ? '2026-09-07' : '2020-01-01', catalog_checked_at: '2026-09-08T00:00:00Z',
           reference: 'javascript:alert(1)' } } : {}),
-        nvd: { severity: 'critical', description: 'Independent NVD description', status: 'Analyzed',
+        nvd: { published_at: index === 2 ? '2026-09-08T10:00:00' : '2020-01-01', modified_at: '2026-09-08T11:00:00', severity: 'critical', description: 'Independent NVD description', status: 'Analyzed',
           reference: 'https://nvd.nist.gov/vuln/detail/CVE-2026-1000' },
       },
     }));
@@ -34,9 +35,10 @@ const assert = require('node:assert/strict');
       if (mode === 'failure') return route.fulfill({ status: 503, body: 'Unavailable' });
       if (mode === 'malformed') return route.fulfill({ contentType: 'application/json', body: '{"items":' });
       const payloadItems = mode === 'invalid-record' ? [{ ...items[0], cve_id: [items[0].cve_id] }]
-        : mode === 'overlong-id' ? [{ ...items[0], cve_id: longId + '0' }] : items;
+        : mode === 'overlong-id' ? [{ ...items[0], cve_id: longId + '0' }]
+        : mode === 'rejected' ? items.map((item, index) => index === 2 ? { ...item, reports: { ...item.reports, nvd: { ...item.reports.nvd, status: 'Rejected' } } } : item) : items;
       return route.fulfill({ contentType: 'application/json', body: JSON.stringify({
-        schema_version: 1, generated_at: '2026-09-08T00:00:00Z', items: mode === 'empty' ? [] : payloadItems,
+        schema_version: 1, generated_at: mode === 'stale' ? '2026-09-01T00:00:00Z' : mode === 'future' ? '2026-09-10T00:00:00Z' : '2026-09-08T00:00:00Z', items: mode === 'empty' ? [] : payloadItems,
       }) });
     });
     await page.goto(process.env.BASE_URL || 'http://127.0.0.1:8765', { waitUntil: 'domcontentloaded' });
@@ -47,6 +49,18 @@ const assert = require('node:assert/strict');
     const refresh = page.locator('[data-vulnerability-refresh]');
     await status.filter({ hasText: '8 of 8 CVEs' }).waitFor();
     assert.equal(await cards.count(), 6);
+    assert.equal(await cards.first().locator('h3').innerText(), 'CVE-2026-1000');
+    await page.locator('[data-vulnerability-view="kev30"]').click();
+    assert.equal(await cards.count(), 1);
+    assert.match(await cards.first().innerText(), /Added to KEV: 2026-09-07/);
+    await page.locator('[data-vulnerability-view="published7"]').click();
+    assert.equal(await cards.locator('h3').innerText(), 'CVE-2026-1002');
+    await filter.selectOption('known_exploited');
+    assert.equal(await cards.count(), 0);
+    await filter.selectOption('all');
+    await page.locator('[data-vulnerability-view="updated7"]').click();
+    assert.match(await status.innerText(), /8 of 8 CVEs/);
+    await page.locator('[data-vulnerability-view="priority"]').click();
     await page.locator('[data-vulnerability-next]').click();
     assert.equal(await cards.count(), 2);
     assert.match(await page.locator('[data-vulnerability-page]').innerText(), /Page 2 of 2/);
@@ -94,6 +108,27 @@ const assert = require('node:assert/strict');
       await status.filter({ hasText: '8 of 8 CVEs' }).waitFor();
       assert.equal(await cards.count(), 6);
     }
+    mode = 'rejected';
+    await refresh.click();
+    await status.filter({ hasText: '7 of 8 CVEs' }).waitFor();
+    assert.match(await status.innerText(), /1 rejected records hidden/);
+    await page.locator('[data-vulnerability-include-rejected]').check();
+    await status.filter({ hasText: '8 of 8 CVEs' }).waitFor();
+    await search.fill('CVE-2026-1002');
+    assert.match(await cards.first().innerText(), /Rejected by NVD/);
+    await search.fill('');
+    await page.locator('[data-vulnerability-include-rejected]').uncheck();
+    for (const freshnessMode of ['stale', 'future']) {
+      mode = freshnessMode;
+      await refresh.click();
+      await status.filter({ hasText: '8 of 8 CVEs' }).waitFor();
+      assert.equal(await page.locator('[data-vulnerability-freshness]').isVisible(), true);
+      assert.match(await page.locator('[data-vulnerability-freshness]').innerText(), freshnessMode === 'stale' ? /over 24 hours/ : /in the future/);
+    }
+    mode = 'success';
+    await refresh.click();
+    await status.filter({ hasText: '8 of 8 CVEs' }).waitFor();
+    assert.equal(await page.locator('[data-vulnerability-freshness]').isVisible(), false);
     mode = 'empty';
     await refresh.click();
     await status.filter({ hasText: '0 of 0 CVEs' }).waitFor();

--- a/scripts/test_vulnerability_ui.cjs
+++ b/scripts/test_vulnerability_ui.cjs
@@ -25,7 +25,7 @@ const assert = require('node:assert/strict');
       exploitation_status: index < 2 ? 'known_exploited' : 'not_established',
       reports: {
         ...(index < 2 ? { cisa_kev: { vendor: 'FixtureVendor', product: 'Router', required_action: 'Apply the vendor update',
-          description: 'CISA-only remediation context', date_added: index === 0 ? '2026-09-07' : '2020-01-01', catalog_checked_at: '2026-09-08T00:00:00Z',
+          ransomware_use: index === 0 ? 'Known' : 'Unknown', description: 'CISA-only remediation context', date_added: index === 0 ? '2026-09-07' : '2020-01-01', catalog_checked_at: '2026-09-08T00:00:00Z',
           reference: 'javascript:alert(1)' } } : {}),
         nvd: { published_at: index === 2 ? '2026-09-08T10:00:00' : '2020-01-01', modified_at: '2026-09-08T11:00:00', severity: 'critical', description: 'Independent NVD description', status: 'Analyzed',
           reference: 'https://nvd.nist.gov/vuln/detail/CVE-2026-1000' },
@@ -47,7 +47,12 @@ const assert = require('node:assert/strict');
     const search = page.locator('[data-vulnerability-search]');
     const filter = page.locator('[data-vulnerability-status-filter]');
     const refresh = page.locator('[data-vulnerability-refresh]');
-    await status.filter({ hasText: '8 of 8 CVEs' }).waitFor();
+    await status.filter({ hasText: '2 of 8 CVEs' }).waitFor();
+    assert.equal(await cards.count(), 2);
+    await page.locator('[data-vulnerability-view="ransomware"]').click();
+    assert.equal(await cards.count(), 1);
+    assert.match(await cards.first().innerText(), /known ransomware campaign use/);
+    await page.locator('[data-vulnerability-view="priority"]').click();
     assert.equal(await cards.count(), 6);
     assert.equal(await cards.first().locator('h3').innerText(), 'CVE-2026-1000');
     await page.locator('[data-vulnerability-view="kev30"]').click();

--- a/swiftioc/cli.py
+++ b/swiftioc/cli.py
@@ -113,7 +113,7 @@ def main() -> int:
     ap.add_argument("--max-age-days", type=int, default=None,
                     help="Retention: drop indicators whose last_seen is older than N days")
     ap.add_argument("--max-store", type=int, default=None,
-                    help="Retention: keep only the top N indicators by score/recency (KEVIntel-style curation)")
+                    help="Retention: keep at most N; recently checked KEV CVEs first, then score/recency")
     ap.add_argument("--dashboard-rows", type=int, default=1000,
                     help="Rows in the compact dashboard.jsonl the web dashboard downloads (default 1000)")
     ap.add_argument("--site-url", type=str,

--- a/swiftioc/collections.py
+++ b/swiftioc/collections.py
@@ -1,14 +1,15 @@
 """Separate actionable observables from per-CVE vulnerability evidence."""
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
-from .models import Indicator, normalize_value
+from .models import Indicator, normalize_value, now_utc, parse_dt
 from .writers import write_json_document, write_jsonl
 
 
-def vulnerability_records(rows: List[Indicator]) -> List[Dict[str, Any]]:
+def vulnerability_records(rows: List[Indicator], *, now: Optional[datetime] = None) -> List[Dict[str, Any]]:
     """One record per exact CVE identity, never per generic tag or provider."""
     records: Dict[str, Dict[str, Any]] = {}
     for row in rows:
@@ -39,12 +40,25 @@ def vulnerability_records(rows: List[Indicator]) -> List[Dict[str, Any]]:
         if isinstance(nvd, dict) and nvd.get("description"):
             record["description"] = nvd["description"]
     priority = {"known_exploited": 0, "reported_exploitation": 1, "not_established": 2}
-    return sorted(records.values(), key=lambda r: (priority[r["exploitation_status"]], r["cve_id"]))
+    cutoff = now or now_utc()
+
+    def sort_key(record: Dict[str, Any]) -> tuple:
+        kev = record["reports"].get("cisa_kev") or {}
+        nvd = record["reports"].get("nvd") or {}
+        kev = kev if isinstance(kev, dict) else {}
+        nvd = nvd if isinstance(nvd, dict) else {}
+        date = kev.get("date_added") if record["exploitation_status"] == "known_exploited" else nvd.get("published_at")
+        parsed = parse_dt(date)
+        newest = parsed.timestamp() if parsed and parsed <= cutoff else float("-inf")
+        rejected = str(nvd.get("status") or "").strip().lower() == "rejected"
+        return rejected, priority[record["exploitation_status"]], -newest, record["cve_id"]
+
+    return sorted(records.values(), key=sort_key)
 
 
 def write_collections(out_dir: Path, rows: List[Indicator], *, generated_at: str) -> Dict[str, int]:
     """Add typed exports while preserving the legacy combined feed contract."""
-    vulnerabilities = vulnerability_records(rows)
+    vulnerabilities = vulnerability_records(rows, now=parse_dt(generated_at))
     observables = [row for row in rows if row.type != "cve"]
     counts = {
         "observables": len(observables), "vulnerabilities": len(vulnerabilities),

--- a/swiftioc/scoring.py
+++ b/swiftioc/scoring.py
@@ -101,8 +101,10 @@ def apply_retention(
     """Curate the stored feed to the most recent + top-scoring indicators.
 
     This is the "top IOCs" retention (KEVIntel-style): first drop anything not
-    seen within ``max_age_days``, then keep only the ``max_store`` strongest by
-    (score, corroboration, recency). Returns ``(rows, aged_out, pruned)``.
+    seen within ``max_age_days``. Within ``max_store``, non-rejected CVEs with
+    KEV evidence checked within 24 hours take priority (newest additions first).
+    Remaining rows retain score/corroboration/recency ordering.
+    Returns ``(rows, aged_out, pruned)``.
     Both bounds are optional and off by default.
     """
     now = now or now_utc()
@@ -121,11 +123,17 @@ def apply_retention(
         # (a fetch-order artifact) rather than a real recency signal.
         # first_seen is stable across runs and reflects genuine discovery
         # recency.
-        rows = sorted(
-            rows,
-            key=lambda r: (r.score, source_count(r), r.first_seen, r.indicator),
-            reverse=True,
-        )
+        def retention_key(row: Indicator) -> tuple:
+            kev = row.vulnerability.get("cisa_kev")
+            nvd = row.vulnerability.get("nvd")
+            checked = parse_dt(kev.get("catalog_checked_at")) if isinstance(kev, dict) else None
+            rejected = isinstance(nvd, dict) and str(nvd.get("status") or "").strip().lower() == "rejected"
+            protected = bool(row.type == "cve" and checked and timedelta(0) <= now - checked <= timedelta(hours=24) and not rejected)
+            added = parse_dt(kev.get("date_added")) if protected and isinstance(kev, dict) else None
+            kev_recency = added.timestamp() if added and added <= now else float("-inf")
+            return protected, kev_recency, row.score, source_count(row), row.first_seen, row.indicator
+
+        rows = sorted(rows, key=retention_key, reverse=True)
         pruned = len(rows) - max_store
         rows = rows[:max_store]
     return rows, aged_out, pruned

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ this suite) so nothing touches the network.
 from __future__ import annotations
 
 import json
+from typing import Any, Dict
 
 import swiftioc as si
 
@@ -219,3 +220,22 @@ def test_cli_rejects_truncated_delta_baseline(tmp_path, monkeypatch):
     assert delta["baseline_available"] is False
     assert delta["events"] == []
     assert delta["counts"] == {"added": 0, "updated": 0, "removed": 0}
+
+
+
+def test_cli_retains_fresh_kev_before_higher_scoring_ioc_when_capped(tmp_path, monkeypatch):
+    sources = tmp_path / "sources.yml"
+    _write_sources_yml(sources)
+    now = si.iso(si.now_utc())
+    base: Dict[str, Any] = dict(first_seen=now, last_seen=now, confidence="high", tlp="CLEAR", tags="", reference="https://example.invalid", context="test")
+    kev = si.Indicator(indicator="CVE-1900-1234", type="cve", source="kev", vulnerability={
+        "cisa_kev": {"catalog_checked_at": now, "date_added": now}}, **base)
+    ip = si.Indicator(indicator="8.8.8.8", type="ipv4", source="a,b,c", **base)
+    monkeypatch.setattr("swiftioc.cli.collect_from_yaml", lambda *a, **kw: ([ip, kev], {"kev": 1, "a": 1}, {"raw_total": 2}))
+    out_dir = tmp_path / "out"
+    assert _run_main(monkeypatch, ["swiftioc", "--sources", str(sources), "--out-dir", str(out_dir), "--max-store", "1"]) == 0
+    document = json.loads((out_dir / "collections/vulnerabilities.json").read_text())
+    assert [r["cve_id"] for r in document["items"]] == ["CVE-1900-1234"]
+    retained = json.loads((out_dir / "iocs/latest.jsonl").read_text())
+    assert retained["type"] == "cve"
+    assert (out_dir / "collections/observables.jsonl").read_text() == ""

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -136,3 +136,25 @@ def test_invalid_cve_ids_are_not_accepted_or_truncated(cve, monkeypatch):
     assert si.fetch_nvd_recent("https://example.invalid", "ref", "nvd", ws) == []
     assert si.classify(cve) != "cve"
     assert not [r for r in si.extract_indicators_from_text(cve) if r[0] == "cve"]
+
+
+
+def test_vulnerability_export_prioritizes_latest_kev_additions_and_publications(tmp_path):
+    now = si.parse_dt("2026-09-08T12:00:00Z")
+    rows = [
+        indicator("CVE-2026-1001", vulnerability={"cisa_kev": {"date_added": "2021-01-01"}}),
+        indicator("CVE-1900-1002", vulnerability={"cisa_kev": {"date_added": "2026-09-08"}}),
+        indicator("CVE-1900-1003", vulnerability={"nvd": {"published_at": "2026-09-08T10:00:00"}}),
+        indicator("CVE-2026-1004", vulnerability={"nvd": {"published_at": "2020-01-01", "modified_at": "2026-09-08T11:30:00Z"}}),
+        indicator("CVE-2026-1005", vulnerability={"cisa_kev": {"date_added": "2026-09-08"}, "nvd": {"status": "Rejected"}}),
+        indicator("CVE-2026-1006", vulnerability={"nvd": {"published_at": "2030-01-01"}}),
+        indicator("CVE-2026-1007", vulnerability={"nvd": {"published_at": "2026-02-30"}}),
+    ]
+    before = deepcopy(rows)
+    expected = ["CVE-1900-1002", "CVE-2026-1001", "CVE-1900-1003", "CVE-2026-1004", "CVE-2026-1006", "CVE-2026-1007", "CVE-2026-1005"]
+    assert [r["cve_id"] for r in vulnerability_records(rows, now=now)] == expected
+    assert rows == before
+    write_collections(tmp_path, rows, generated_at="2026-09-08T12:00:00Z")
+    doc = json.loads((tmp_path / "vulnerabilities.json").read_text())
+    assert [r["cve_id"] for r in doc["items"]] == expected
+    assert doc["counts"]["vulnerabilities"] == 7  # Rejected entries remain auditable.

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -158,3 +158,47 @@ def test_vulnerability_export_prioritizes_latest_kev_additions_and_publications(
     doc = json.loads((tmp_path / "vulnerabilities.json").read_text())
     assert [r["cve_id"] for r in doc["items"]] == expected
     assert doc["counts"]["vulnerabilities"] == 7  # Rejected entries remain auditable.
+
+
+
+def test_retention_reserves_space_for_recently_checked_kev_evidence():
+    now = si.now_utc()
+    high_ioc = indicator("8.8.8.8", "ipv4", score=99)
+    old_kev = indicator("CVE-1900-1001", score=95, vulnerability={"cisa_kev": {
+        "catalog_checked_at": si.iso(now), "date_added": "2020-01-01"}})
+    new_kev = indicator("CVE-1900-1002", score=80, vulnerability={"cisa_kev": {
+        "catalog_checked_at": si.iso(now), "date_added": si.iso(now - timedelta(hours=1))}})
+    before = deepcopy([high_ioc, old_kev, new_kev])
+    kept, aged, pruned = si.apply_retention([high_ioc, old_kev, new_kev], max_store=2, now=now)
+    assert [r.indicator for r in kept] == [new_kev.indicator, old_kev.indicator]
+    assert aged == 0 and pruned == 1
+    one, _, _ = si.apply_retention([old_kev, new_kev], max_store=1, now=now)
+    assert one == [new_kev]
+    assert [high_ioc, old_kev, new_kev] == before
+    cutoff_now = si.parse_dt(si.iso(now))
+    assert cutoff_now is not None
+    old_kev.vulnerability["cisa_kev"]["catalog_checked_at"] = si.iso(cutoff_now - timedelta(hours=24))
+    boundary, _, _ = si.apply_retention([high_ioc, old_kev], max_store=1, now=cutoff_now)
+    assert boundary == [old_kev]
+    old_kev.vulnerability["cisa_kev"]["catalog_checked_at"] = si.iso(cutoff_now - timedelta(hours=24, seconds=1))
+    stale, _, _ = si.apply_retention([high_ioc, old_kev], max_store=1, now=cutoff_now)
+    assert stale == [high_ioc]
+    new_kev.last_seen = si.iso(now - timedelta(days=40))
+    retained, aged, _ = si.apply_retention([high_ioc, new_kev], max_store=1, max_age_days=30, now=now)
+    assert retained == [high_ioc] and aged == 1  # Never bypass configured expiry.
+
+
+@pytest.mark.parametrize(("checked", "status"), [
+    (None, "Analyzed"), ("invalid", "Analyzed"),
+    ("2020-01-01", "Analyzed"), ("2099-01-01", "Analyzed"),
+    ("fresh", "Rejected"),
+])
+def test_retention_does_not_promote_stale_unknown_future_or_rejected_kev(checked, status):
+    now = si.now_utc()
+    row = indicator("CVE-1900-1001", score=50, tags="cve,exploited-in-the-wild", vulnerability={
+        "cisa_kev": {"catalog_checked_at": si.iso(now) if checked == "fresh" else checked, "date_added": "2020-01-01"},
+        "nvd": {"status": status},
+    })
+    high_ioc = indicator("8.8.8.8", "ipv4", score=99)
+    retained, _, _ = si.apply_retention([row, high_ioc], max_store=1, now=now)
+    assert retained == [high_ioc]


### PR DESCRIPTION
The vulnerability collection previously sorted exploitation groups by CVE ID, burying recent KEV additions behind older identifiers. Generic IOC scores could also crowd verified KEV records out of a capped feed.

The dashboard now opens on Known exploited: confirmed KEV entries only, newest catalog additions first, without filling empty results with unconfirmed CVEs. Ransomware evidence requires CISA's explicit Known value. All CVEs remains available with exploitation-first priority, alongside views for KEV additions within 30 days, NVD publications within 7 days, and modifications within 7 days. Search and exploitation filters apply within each view. JSON exports retain the complete retained collection in priority order.

Within the configured storage cap, non-rejected CVEs whose KEV catalog evidence was checked within 24 hours take priority, newest additions first. Remaining records retain score/corroboration/recency ordering. This can displace generic IOCs under the same cap. Expiry and maximum-age rules still apply; stale, missing, or future check dates get no special preference, and the cap remains strict even if KEV records alone exceed it.

Cards expose provider dates, CISA required actions, and ransomware evidence. NVD rejected records are hidden by default with an opt-in control and count, but remain in exports. Stale/future snapshots and old/missing KEV checks are flagged. Offset-free NVD timestamps are treated as UTC; invalid/future dates cannot enter recent views. The UI distinguishes catalog addition, disclosure, and modification from the time of an attack. Returning to a tab re-evaluates rolling windows and freshness.

All three frontend asset cache keys are bumped together, and the vulnerability controller guards against mismatched old HTML/core assets during rollout. README and CLI help document the new defaults and retention policy. Source windows, source failures, and per-source limits can still restrict coverage.

Validation: 178 Python tests, 34 frontend tests (including a non-UTC timezone), Ruff, built-in self-tests, and Pyright (0 errors; 5 existing dependency-source warnings). Browser regression checks passed for confirmed-exploitation defaults, ransomware filtering, priority ordering, date views, combined filters, rejected-record visibility, snapshot warnings, failed refreshes, pagination, safe rendering, and mobile overflow. CLI integration verifies that a recently checked KEV survives a one-record cap ahead of a higher-scoring IOC.