### PR TITLE
Simplify the dashboard with a quieter analyst-focused theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ high-fidelity IOCs from authoritative sources. The project emphasises:
   shortlist findings in a private investigation queue that persists in the
   browser. Queue contents can be copied or exported as CSV/JSON without being
   sent to a server. The interface includes responsive threat visualisations and
-  motion that automatically disables when reduced motion is requested.
+  collapsible tools, with reduced-motion support for interactions.
 - **YAML-driven feeds** – feed metadata lives in `sources.yml` so collections can
   be changed without touching Python code. The example file includes adapters for
   CISA KEV, NVD, URLhaus, MalwareBazaar, ThreatFox, Feodo Tracker, SSLBL JA3,
@@ -614,12 +614,14 @@ sources), or new (last 48h) indicators. Analysts can add table or lookup results
 to a private browser-local investigation queue and export that shortlist without
 uploading it anywhere.
 
-The interface includes an animated feed radar, progressive metrics, score-band
-motion, and responsive threat cards. Animations use transform/opacity paths and
-are disabled when the browser reports `prefers-reduced-motion: reduce`. Mobile
-breakpoints convert the preview into card-style rows, collapsed details remain
-hidden until requested, and human-facing IOC metadata stays defanged to reduce
-accidental activation.
+The dashboard uses a restrained graphite-and-olive theme with a compact header
+and responsive evidence cards. Collection statistics, the relationship graph,
+source tables, and downloads open on demand; existing section bookmarks open
+the relevant tool automatically. On small screens the IOC preview starts with
+six rows, with larger row counts available from the Rows control and preserved
+in shared links. Keyboard-accessible disclosures work without JavaScript.
+Reduced-motion preferences are respected, and human-facing IOC metadata stays
+defanged to reduce accidental activation.
 
 ## ⚙️ Running in GitHub Actions
 SwiftIOC runs cleanly inside GitHub Actions and emits artifacts that can be

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -640,7 +640,7 @@
     return state;
   };
 
-  const writeViewUrl = (currentUrl, state, includeSearch = false) => {
+  const writeViewUrl = (currentUrl, state, includeSearch = false, defaultLimit = 12) => {
     const url = new URL(currentUrl);
     ['type', 'source', 'tag', 'score_band', 'age_band', 'signal', 'score', 'age', 'rows', 'sort', 'dir']
       .forEach((key) => url.searchParams.delete(key));
@@ -662,7 +662,7 @@
     if (state.signal !== 'all') url.searchParams.set('signal', state.signal);
     if (state.minScore) url.searchParams.set('score', String(state.minScore));
     if (state.age !== 'all') url.searchParams.set('age', state.age);
-    if (state.limit !== 12) url.searchParams.set('rows', String(state.limit));
+    if (includeSearch || state.limit !== defaultLimit) url.searchParams.set('rows', String(state.limit));
     if (state.sort !== 'score') url.searchParams.set('sort', state.sort);
     if (state.direction !== 'desc') url.searchParams.set('dir', state.direction);
     if (includeSearch && state.search) {

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -597,7 +597,7 @@
     return sourceDifference || lower(a.indicator).localeCompare(lower(b.indicator));
   };
 
-  const readViewState = (search = '', hash = '') => {
+  const readViewState = (search = '', hash = '', defaultLimit = 12) => {
     const params = new URLSearchParams(search);
     const signal = lower(params.get('signal'));
     const score = Number(params.get('score')) || 0;
@@ -620,9 +620,9 @@
         : 'all',
       minScore: [0, 40, 60, 80].includes(score) ? score : 0,
       age: ['all', '24', '48', '168', '720'].includes(age) ? age : 'all',
-      limit: [12, 25, 50, 100].includes(Number(params.get('rows')))
+      limit: [6, 12, 25, 50, 100].includes(Number(params.get('rows')))
         ? Number(params.get('rows'))
-        : 12,
+        : ([6, 12].includes(defaultLimit) ? defaultLimit : 12),
       sort: ['indicator', 'type', 'score', 'sources', 'lastSeen'].includes(
         params.get('sort')
       ) ? params.get('sort') : 'score',

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -338,7 +338,7 @@ test('dashboard markup keeps IDs and labelled controls consistent', () => {
   assert.match(html, /data-campaign-density/);
   assert.match(html, /data-campaign-related-list/);
   assert.match(html, /data-campaign-reference/);
-  assert.match(html, /class="signal-radar"/);
+  assert.match(html, /data-tool-disclosure/);
   assert.match(html, /data-delta-root/);
   assert.match(html, /iocs\/delta\.jsonl/);
   assert.match(html, /iocs\/taxii2-envelope\.json/);
@@ -541,6 +541,16 @@ test('exploited and ransomware views require explicit evidence and never fall ba
 test('vulnerability release uses coordinated new asset cache keys', () => {
   const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
   for (const asset of ['styles.css', 'dashboard-core.js', 'dashboard.js']) {
-    assert.ok(html.includes(`assets/${asset}?v=16`));
+    assert.ok(html.includes(`assets/${asset}?v=17`));
   }
+});
+
+test('compact preview honors mobile defaults and explicit shared row counts', () => {
+  assert.equal(core.readViewState('', '', 6).limit, 6);
+  assert.equal(core.readViewState('?rows=12', '', 6).limit, 12);
+  assert.equal(core.readViewState('?rows=999', '', 6).limit, 6);
+  assert.equal(core.readViewState('', '', -1).limit, 12);
+  const compact = core.readViewState('?rows=6');
+  const url = core.writeViewUrl('https://example.test/', compact);
+  assert.equal(core.readViewState(url.search, url.hash).limit, 6);
 });

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -553,4 +553,8 @@ test('compact preview honors mobile defaults and explicit shared row counts', ()
   const compact = core.readViewState('?rows=6');
   const url = core.writeViewUrl('https://example.test/', compact);
   assert.equal(core.readViewState(url.search, url.hash).limit, 6);
+  const mobileTwelve = core.writeViewUrl('https://example.test/', defaults, false, 6);
+  assert.equal(core.readViewState(mobileTwelve.search, '', 6).limit, 12);
+  const sharedDesktop = core.writeViewUrl('https://example.test/', defaults, true);
+  assert.equal(core.readViewState(sharedDesktop.search, sharedDesktop.hash, 6).limit, 12);
 });

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -2169,6 +2169,7 @@
       relative: qs('[data-preview-relative]', container),
     };
 
+    const defaultPreviewLimit = window.matchMedia?.('(max-width: 640px)').matches ? 6 : DEFAULT_PREVIEW_LIMIT;
     const state = {
       rows: [],
       types: [],
@@ -2183,7 +2184,7 @@
       minScore: 0,
       age: 'all',
       search: '',
-      limit: window.matchMedia?.('(max-width: 640px)').matches ? 6 : DEFAULT_PREVIEW_LIMIT,
+      limit: defaultPreviewLimit,
       sort: 'score',
       direction: 'desc',
       expanded: new Set(),
@@ -2237,7 +2238,8 @@
         const url = dashboardCore.writeViewUrl(
           window.location.href,
           state,
-          includeSearch
+          includeSearch,
+          defaultPreviewLimit
         );
         window.history.replaceState(null, '', url);
         return url;
@@ -2250,7 +2252,7 @@
       if (state.signal !== 'all') url.searchParams.set('signal', state.signal);
       if (state.minScore) url.searchParams.set('score', String(state.minScore));
       if (state.age !== 'all') url.searchParams.set('age', state.age);
-      if (state.limit !== DEFAULT_PREVIEW_LIMIT) {
+      if (includeSearch || state.limit !== defaultPreviewLimit) {
         url.searchParams.set('rows', String(state.limit));
       }
       if (state.sort !== 'score') url.searchParams.set('sort', state.sort);

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -2183,7 +2183,7 @@
       minScore: 0,
       age: 'all',
       search: '',
-      limit: DEFAULT_PREVIEW_LIMIT,
+      limit: window.matchMedia?.('(max-width: 640px)').matches ? 6 : DEFAULT_PREVIEW_LIMIT,
       sort: 'score',
       direction: 'desc',
       expanded: new Set(),
@@ -2202,7 +2202,8 @@
           state,
           dashboardCore.readViewState(
             window.location.search,
-            window.location.hash
+            window.location.hash,
+            state.limit
           )
         );
         return;
@@ -2215,7 +2216,7 @@
       state.minScore = Number(params.get('score')) || 0;
       state.age = params.get('age') || 'all';
       const limit = Number(params.get('rows'));
-      if ([12, 25, 50, 100].includes(limit)) state.limit = limit;
+      if ([6, 12, 25, 50, 100].includes(limit)) state.limit = limit;
       const sort = params.get('sort');
       if (['indicator', 'type', 'score', 'sources', 'lastSeen'].includes(sort)) {
         state.sort = sort;
@@ -2889,7 +2890,7 @@
 
     limitSelect?.addEventListener('change', () => {
       const limit = Number(limitSelect.value);
-      if ([12, 25, 50, 100].includes(limit)) {
+      if ([6, 12, 25, 50, 100].includes(limit)) {
         state.limit = limit;
         apply();
       }
@@ -4194,74 +4195,42 @@
       });
   };
 
-  const initialiseVisualEffects = () => {
-    const targets = qsa([
-      '.page-header',
-      '.ioc-lookup',
-      '.investigation-workspace',
-      '.status-banner',
-      '.metrics-strip',
-      '.score-distribution',
-      '.delta-strip',
-      '.campaign-graph-section',
-      '.dashboard-main > .panel',
-      '.top-threats',
-      '#exports',
-    ].join(','));
-    document.documentElement.classList.add('motion-enhanced');
-    targets.forEach((target, index) => {
-      target.classList.add('reveal-card');
-      target.style.setProperty('--reveal-order', String(index % 4));
+  // Open collapsed tools for existing section bookmarks and in-page links.
+  // Fragment lookup uses IDs, not CSS selectors: malformed/shared IOC fragments
+  // cannot throw or accidentally select another element.
+  const initialiseSectionNavigation = () => {
+    const reveal = () => {
+      let id;
+      try { id = decodeURIComponent(window.location.hash.slice(1)); }
+      catch { return; }
+      if (!id || id.startsWith('ioc=') || id.startsWith('view=')) return;
+      const target = document.getElementById(id);
+      if (!target) return;
+      let parent = target.parentElement;
+      let opened = false;
+      while (parent) {
+        if (parent.matches('details') && !parent.open) {
+          parent.open = true;
+          opened = true;
+        }
+        parent = parent.parentElement;
+      }
+      if (opened) window.requestAnimationFrame(() => target.scrollIntoView({ block: 'start' }));
+    };
+    window.addEventListener('hashchange', reveal);
+    // Clicking the same hash again must also reopen a manually closed tool.
+    document.addEventListener('click', (event) => {
+      const link = event.target.closest('a[href^="#"]');
+      if (link && link.hash === window.location.hash) reveal();
     });
-
-    if (reducedMotion?.matches || typeof IntersectionObserver !== 'function') {
-      targets.forEach((target) => target.classList.add('is-visible'));
-    } else {
-      const observer = new IntersectionObserver((entries) => {
-        entries.forEach((entry) => {
-          if (!entry.isIntersecting) return;
-          entry.target.classList.add('is-visible');
-          observer.unobserve(entry.target);
-        });
-      }, { rootMargin: '0px 0px -7% 0px', threshold: 0.06 });
-      targets.forEach((target) => observer.observe(target));
-    }
-
-    if (
-      reducedMotion?.matches ||
-      !window.matchMedia?.('(hover: hover) and (pointer: fine)').matches
-    ) return;
-    qsa([
-      '.ioc-lookup',
-      '.investigation-workspace',
-      '.metric-card',
-      '.panel',
-      '.score-distribution',
-      '.top-threats',
-    ].join(',')).forEach((target) => {
-      let frame = null;
-      target.classList.add('pointer-reactive');
-      target.addEventListener('pointermove', (event) => {
-        if (frame) return;
-        frame = window.requestAnimationFrame(() => {
-          const rect = target.getBoundingClientRect();
-          target.style.setProperty('--spot-x', `${event.clientX - rect.left}px`);
-          target.style.setProperty('--spot-y', `${event.clientY - rect.top}px`);
-          frame = null;
-        });
-      });
-      target.addEventListener('pointerleave', () => {
-        target.style.removeProperty('--spot-x');
-        target.style.removeProperty('--spot-y');
-      });
-    });
+    reveal();
   };
 
   /* ==========================================================================
    *  BOOTSTRAP
    * ========================================================================= */
 
-  initialiseVisualEffects();
+  initialiseSectionNavigation();
   initialiseTableToggles();
   initialiseInvestigationWorkspace();
   initialiseStatusBanner();

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -3335,354 +3335,8 @@ input.lookup-input {
   }
 }
 
-/* ===========================================================================
- * Immersive threat-operations visual layer
- * ======================================================================= */
-
-[hidden] {
-  display: none !important;
-}
-
-body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
-  background-image:
-    linear-gradient(rgba(56, 189, 248, 0.025) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(56, 189, 248, 0.025) 1px, transparent 1px);
-  background-size: 52px 52px;
-  mask-image: linear-gradient(to bottom, black, transparent 78%);
-  animation: ambient-grid-drift 24s linear infinite;
-}
-
-.page-wrapper {
-  z-index: 1;
-}
-
-.page-header {
-  position: relative;
-  min-height: 20rem;
-  justify-content: center;
-  overflow: hidden;
-  padding: clamp(1.5rem, 4vw, 3.5rem);
-  border: 1px solid rgba(56, 189, 248, 0.22);
-  border-radius: 1.25rem;
-  background:
-    radial-gradient(circle at 82% 50%, rgba(14, 165, 233, 0.17), transparent 23rem),
-    linear-gradient(115deg, rgba(8, 15, 28, 0.96), rgba(8, 20, 38, 0.84));
-  box-shadow: 0 28px 80px rgba(2, 6, 23, 0.42);
-}
-
-.page-header::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background:
-    linear-gradient(90deg, rgba(56, 189, 248, 0.1) 1px, transparent 1px),
-    linear-gradient(rgba(56, 189, 248, 0.08) 1px, transparent 1px);
-  background-size: 34px 34px;
-  mask-image: radial-gradient(circle at 82% 50%, black, transparent 43%);
-  opacity: 0.62;
-}
-
-.page-header-main {
-  position: relative;
-  z-index: 2;
-  width: 100%;
-}
-
-.page-header-main > div:first-child {
-  max-width: 48rem;
-}
-
-.signal-radar {
-  position: absolute;
-  top: 50%;
-  right: clamp(1rem, 8vw, 6rem);
-  width: clamp(15rem, 26vw, 22rem);
-  aspect-ratio: 1;
-  border: 1px solid rgba(125, 211, 252, 0.2);
-  border-radius: 50%;
-  opacity: 0.72;
-  transform: translateY(-50%);
-}
-
-.radar-ring,
-.radar-crosshair,
-.radar-sweep,
-.radar-blip {
-  position: absolute;
-}
-
-.radar-ring {
-  inset: 50%;
-  border: 1px solid rgba(125, 211, 252, 0.24);
-  border-radius: 50%;
-  transform: translate(-50%, -50%);
-}
-
-.radar-ring-one { width: 34%; height: 34%; }
-.radar-ring-two { width: 66%; height: 66%; }
-.radar-ring-three { width: 100%; height: 100%; }
-
-.radar-crosshair {
-  inset: 0;
-  border-radius: 50%;
-  background:
-    linear-gradient(transparent calc(50% - 0.5px), rgba(125, 211, 252, 0.22) 50%, transparent calc(50% + 0.5px)),
-    linear-gradient(90deg, transparent calc(50% - 0.5px), rgba(125, 211, 252, 0.22) 50%, transparent calc(50% + 0.5px));
-}
-
-.radar-sweep {
-  inset: 0;
-  border-radius: 50%;
-  background: conic-gradient(from 0deg, rgba(34, 211, 238, 0.5), transparent 17%, transparent);
-  animation: radar-scan 5.5s linear infinite;
-}
-
-.radar-blip {
-  width: 0.48rem;
-  height: 0.48rem;
-  border-radius: 50%;
-  background: #67e8f9;
-  box-shadow: 0 0 0 0 rgba(103, 232, 249, 0.55);
-  animation: radar-blip 2.4s ease-out infinite;
-}
-
-.blip-one { top: 23%; left: 58%; }
-.blip-two { top: 64%; left: 72%; animation-delay: -0.8s; }
-.blip-three { top: 53%; left: 28%; animation-delay: -1.6s; }
-
-.hero-download {
-  position: relative;
-  z-index: 3;
-  overflow: hidden;
-  backdrop-filter: blur(14px);
-  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
-}
-
-.hero-download::after {
-  content: '';
-  position: absolute;
-  inset: -60% auto -60% -45%;
-  width: 35%;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.28), transparent);
-  transform: skewX(-18deg);
-  transition: left 520ms ease;
-}
-
-.hero-download:hover {
-  transform: translateY(-3px);
-}
-
-.hero-download:hover::after {
-  left: 125%;
-}
-
-.status-dot {
-  animation: status-beacon 2.6s ease-out infinite;
-}
-
-.metric-card {
-  position: relative;
-  overflow: hidden;
-  transition: transform 200ms ease, border-color 200ms ease, box-shadow 200ms ease;
-}
-
-.metric-card::before {
-  content: '';
-  position: absolute;
-  inset: 0 0 auto;
-  height: 2px;
-  background: linear-gradient(90deg, transparent, #38bdf8, #a78bfa, transparent);
-  opacity: 0.72;
-  transform: scaleX(0.25);
-  transition: transform 320ms ease, opacity 320ms ease;
-}
-
-.metric-card:hover {
-  border-color: rgba(125, 211, 252, 0.62);
-  box-shadow: 0 22px 48px rgba(2, 6, 23, 0.44), 0 0 35px rgba(14, 165, 233, 0.08);
-  transform: translateY(-4px);
-}
-
-.metric-card:hover::before {
-  opacity: 1;
-  transform: scaleX(1);
-}
-
-.metric-value {
-  background: linear-gradient(110deg, #f8fafc 18%, #7dd3fc 50%, #c4b5fd 82%);
-  background-clip: text;
-  color: transparent;
-}
-
-.score-bar {
-  overflow: hidden;
-  box-shadow: inset 0 0 18px rgba(2, 6, 23, 0.65), 0 0 28px rgba(14, 165, 233, 0.08);
-}
-
-.score-seg {
-  transform-origin: left center;
-  animation: score-segment-in 720ms cubic-bezier(0.22, 1, 0.36, 1) both;
-  animation-delay: var(--segment-delay, 0ms);
-}
-
-.pointer-reactive {
-  position: relative;
-}
-
-.pointer-reactive::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
-  border-radius: inherit;
-  background: radial-gradient(
-    22rem circle at var(--spot-x, -30rem) var(--spot-y, -30rem),
-    rgba(125, 211, 252, 0.105),
-    transparent 44%
-  );
-}
-
-.pointer-reactive > * {
-  position: relative;
-  z-index: 1;
-}
-
-.motion-enhanced .reveal-card {
-  opacity: 0;
-  transform: translateY(22px) scale(0.992);
-  transition:
-    opacity 620ms ease calc(var(--reveal-order, 0) * 45ms),
-    transform 620ms cubic-bezier(0.22, 1, 0.36, 1) calc(var(--reveal-order, 0) * 45ms);
-}
-
-.motion-enhanced .reveal-card.is-visible {
-  opacity: 1;
-  transform: none;
-}
-
-.preview-row-enter {
-  animation: preview-row-in 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
-  animation-delay: var(--row-delay, 0ms);
-}
-
-.top-threats.is-visible .threat-card {
-  animation: threat-card-in 540ms cubic-bezier(0.22, 1, 0.36, 1) both;
-}
-
-.top-threats.is-visible .threat-card:nth-child(2) { animation-delay: 70ms; }
-.top-threats.is-visible .threat-card:nth-child(3) { animation-delay: 140ms; }
-.top-threats.is-visible .threat-card:nth-child(4) { animation-delay: 210ms; }
-.top-threats.is-visible .threat-card:nth-child(5) { animation-delay: 280ms; }
-.top-threats.is-visible .threat-card:nth-child(6) { animation-delay: 350ms; }
-
-.toast:not([hidden]) {
-  animation: toast-arrive 280ms cubic-bezier(0.22, 1, 0.36, 1) both;
-}
-
-@keyframes ambient-grid-drift {
-  to { background-position: 52px 52px; }
-}
-
-@keyframes radar-scan {
-  to { transform: rotate(360deg); }
-}
-
-@keyframes radar-blip {
-  0%, 28% { opacity: 0; box-shadow: 0 0 0 0 rgba(103, 232, 249, 0.55); }
-  35% { opacity: 1; }
-  72%, 100% { opacity: 0; box-shadow: 0 0 0 0.85rem rgba(103, 232, 249, 0); }
-}
-
-@keyframes status-beacon {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.68; transform: scale(0.78); }
-}
-
-@keyframes score-segment-in {
-  from { opacity: 0.35; transform: scaleX(0); }
-  to { opacity: 1; transform: scaleX(1); }
-}
-
-@keyframes preview-row-in {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: none; }
-}
-
-@keyframes threat-card-in {
-  from { opacity: 0; transform: translateY(14px) scale(0.97); }
-  to { opacity: 1; transform: none; }
-}
-
-@keyframes toast-arrive {
-  from { opacity: 0; transform: translateY(0.65rem) scale(0.97); }
-  to { opacity: 1; transform: none; }
-}
-
-@keyframes campaign-edge-in {
-  from { opacity: 0; stroke-dashoffset: 24; }
-  to { stroke-dashoffset: 0; }
-}
-
-@keyframes campaign-node-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@media (max-width: 820px) {
-  .page-header {
-    min-height: 24rem;
-  }
-
-  .signal-radar {
-    right: -5rem;
-    opacity: 0.28;
-  }
-}
-
-@media (max-width: 540px) {
-  .page-header {
-    min-height: 0;
-    padding: 1.35rem;
-  }
-
-  .signal-radar {
-    top: 22%;
-    right: -7rem;
-    width: 17rem;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  body::before,
-  .radar-sweep,
-  .radar-blip,
-  .status-dot,
-  .score-seg,
-  .preview-row-enter,
-  .top-threats.is-visible .threat-card,
-  .campaign-edge,
-  .campaign-node,
-  .toast:not([hidden]) {
-    animation: none !important;
-  }
-
-  .motion-enhanced .reveal-card,
-  .hero-download,
-  .hero-download::after,
-  .metric-card,
-  .metric-card::before {
-    opacity: 1;
-    transform: none;
-    transition: none !important;
-  }
-}
+/* Always honor programmatic visibility, including inside disclosures. */
+[hidden] { display: none !important; }
 
 /* Discovery desk: readable evidence first, actions within reach. */
 .discovery-desk {
@@ -3753,3 +3407,185 @@ body::before {
 .vulnerability-rejected-control { display: flex; align-items: center; gap: 0.5rem; font-size: 0.8rem; color: #b7c6d8; }
 .vulnerability-caution, .vulnerability-freshness { padding: 0.75rem; border: 1px solid #806739; border-radius: 0.5rem; background: #342a1955; color: #f1d6a6; font-size: 0.76rem; line-height: 1.6; }
 .vulnerability-action { color: #d6e6ef; font-size: 0.8rem; line-height: 1.6; overflow-wrap: anywhere; }
+
+/* Analyst desk: warm graphite, restrained olive accents, clear section hierarchy.
+   Severity colors retain their meaning; decorative surfaces stay neutral. */
+:root {
+  --bg-color: #191c19;
+  --bg-gradient: #191c19;
+  --card-bg-soft: #202420;
+  --card-bg-strong: #252a25;
+  --border-subtle: #303730;
+  --border-soft: #424b41;
+  --border-strong: #7e8b78;
+  --border-control: #65705f;
+  --accent: #bfcc9b;
+  --accent-soft: #d2deaf;
+  --accent-subtle: #323c2d;
+  --text-primary: #e4e6dc;
+  --text-strong: #f2f1e8;
+  --text-muted: #a9b0a3;
+  --text-soft: #a9b0a3;
+  --focus-color: #d2deaf;
+  --focus-ring: 0 0 0 2px #d2deaf;
+  --shadow-soft: none;
+  --shadow-subtle: none;
+  --radius-card: 0.45rem;
+}
+body { background: var(--bg-color); }
+.page-wrapper { max-width: 1280px; padding: 0 2rem 2rem; }
+.top-nav {
+  top: 0; margin: 0; padding: 0.65rem 0;
+  border: 0; border-bottom: 1px solid var(--border-soft); border-radius: 0;
+  background: #191c19f5; box-shadow: none; backdrop-filter: blur(12px);
+}
+.brand { align-items: center; gap: 0.85rem; }
+.brand-mark {
+  padding: 0; border: 0; border-radius: 0; background: none;
+  color: var(--text-strong); text-transform: none; font-size: 1.25rem;
+  letter-spacing: -0.05em; font-weight: 750;
+}
+.brand-mark::before { content: ''; width: 0.5rem; height: 1.1rem; margin-right: 0.5rem; background: var(--accent); }
+.brand-tagline { border-left: 1px solid var(--border-soft); padding-left: 0.85rem; font-size: 0.7rem; }
+.nav-links { gap: 0.15rem; }
+.nav-links a { border-radius: 0.25rem; border-color: transparent; }
+.nav-links a:hover { background: #2c332a; border-color: transparent; transform: none; }
+.page-header { margin: 2.75rem 0 1.75rem; padding: 0; min-height: 0; border: 0; background: none; box-shadow: none; }
+.page-header-main { align-items: center; gap: 2rem; }
+h1.section-title { max-width: none; font-family: Georgia, 'Times New Roman', serif; font-size: clamp(2rem, 3.7vw, 3rem); font-weight: 400; line-height: 1.15; letter-spacing: -0.035em; }
+.page-header-subtitle { max-width: 65ch; font-size: 0.92rem; color: var(--text-muted); margin-top: 0.8rem; }
+.eyebrow { color: var(--accent); font-size: 0.65rem; letter-spacing: 0.12em; font-weight: 600; margin-bottom: 0.7rem; }
+.hero-download { min-width: 0; border: 1px solid var(--border-soft); border-radius: 0.35rem; background: #252b23; padding: 0.8rem 1rem; font-size: 0.8rem; color: var(--text-primary); }
+.hero-download small { color: var(--text-muted); }
+.hero-download:hover { background: #30392a; border-color: var(--accent); }
+.ioc-lookup, .investigation-workspace, .status-banner, .panel, .table-card,
+.top-threats, .score-distribution, .delta-strip {
+  background: var(--card-bg-soft); border-color: var(--border-soft); border-radius: 0.45rem; box-shadow: none;
+}
+.ioc-lookup { padding: 1.2rem; }
+.lookup-heading { margin-bottom: 0.8rem; align-items: center; }
+.lookup-heading h2 { font-size: 1rem; font-weight: 600; }
+.lookup-heading > p { font-size: 0.75rem; color: var(--text-muted); }
+input.lookup-input { border-radius: 0.3rem; background: var(--bg-color); }
+.button, .button-link, .panel-header-link, .hero-download, .export-card { transition: background 140ms ease, border-color 140ms ease; }
+.button, .button-link, .button.ghost, .panel-header-link {
+  background: #272e25; border-color: var(--border-soft); color: var(--text-primary); border-radius: 0.3rem; box-shadow: none;
+}
+.button:hover, .button-link:hover, .button.ghost:hover, .panel-header-link:hover { background: #343e2f; border-color: #7e8b78; color: var(--text-strong); transform: none; }
+.lookup-form .button-link, .button.primary, .button-link.primary {
+  background: var(--accent); border-color: var(--accent); color: #1c2516; border-radius: 0.3rem;
+}
+.lookup-form .button-link:hover, .button.primary:hover, .button-link.primary:hover { background: #d2deaf; }
+.button:disabled, .button-link:disabled { opacity: 0.45; }
+.status-banner { padding: 0.85rem 0; border: 0; border-bottom: 1px solid var(--border-soft); border-radius: 0; background: none; gap: 0.75rem; }
+.status-meta dt, .status-meta dd { color: var(--text-muted); }
+.status-details { color: var(--accent); }
+.status-dot { box-shadow: none; }
+.metrics-strip { gap: 0; border-bottom: 1px solid var(--border-soft); margin-block: 0 1rem; }
+.metric-card, .metric-card-accent { background: none; border: 0; border-radius: 0; box-shadow: none; padding: 1.2rem; }
+.metric-card + .metric-card { border-left: 1px solid var(--border-subtle); }
+.metric-card:first-child { padding-left: 0; }
+.metric-card:hover { background: none; box-shadow: none; transform: none; }
+.metric-value, .metric-card-accent .metric-value { color: var(--text-strong); font-size: 1.8rem; font-weight: 500; font-variant-numeric: tabular-nums; }
+.metric-label, .metric-caption { color: var(--text-muted); }
+.score-distribution { padding: 0.8rem 0; background: none; border: 0; }
+.delta-strip { padding: 1rem; }
+.delta-copy h2 { font-size: 1rem; }
+.delta-copy p:not(.eyebrow) { color: var(--text-muted); }
+.discovery-desk { padding: 1.75rem 0; margin: 1.5rem 0; border: 0; border-top: 1px solid var(--border-soft); border-radius: 0; background: none; }
+.discovery-heading h2 { font-size: 1.6rem; letter-spacing: -0.03em; font-weight: 550; margin: 0.2rem 0 0.5rem; }
+.discovery-heading p:not(.eyebrow), .discovery-reason, .discovery-scope, .discovery-status,
+.discovery-card-top, .vulnerability-toolbar label, .vulnerability-rejected-control,
+.vulnerability-pagination, .vulnerability-meta { color: var(--text-muted); }
+.discovery-lenses { gap: 0.3rem; }
+.discovery-lenses button { padding: 0.65rem 0.8rem; min-height: 2.75rem; border-radius: 0.25rem; background: #222720; border-color: var(--border-soft); color: var(--text-muted); font: inherit; font-size: 0.78rem; }
+.discovery-lenses button[aria-pressed='true'] { color: #1c2516; background: var(--accent); border-color: var(--accent); }
+.discovery-lenses button:hover { border-color: var(--accent); }
+.discovery-lenses button:focus-visible, .discovery-card summary:focus-visible, .vulnerability-toolbar :focus-visible { outline-color: var(--accent); }
+.discovery-card { padding: 1.1rem; background: var(--card-bg-soft); border-color: var(--border-soft); border-radius: 0.4rem; transition: border-color 140ms ease; }
+.discovery-card:hover { transform: none; border-color: #7e8b78; }
+.discovery-reason-label, .discovery-score { color: var(--accent); }
+.discovery-card details { color: var(--text-muted); border-color: var(--border-soft); }
+.discovery-card summary, .vulnerability-title, .vulnerability-action, .vulnerability-evidence { color: var(--text-primary); }
+.vulnerability-toolbar { margin-block: 1rem; gap: 0.8rem; }
+.vulnerability-toolbar input, .vulnerability-toolbar select { background: var(--bg-color); border-color: var(--border-control); border-radius: 0.3rem; }
+.vulnerability-dates { background: #282e25; border-color: var(--accent); color: #c8d0bb; }
+.collection-notes { color: var(--text-muted); font-size: 0.78rem; margin-top: 0.75rem; }
+.collection-notes summary { padding-block: 0.5rem; cursor: pointer; color: var(--accent); }
+.collection-notes .discovery-scope { margin-top: 0.5rem; }
+.tool-disclosure { border: 1px solid var(--border-soft); border-radius: 0.4rem; margin-block: 1rem; background: var(--card-bg-soft); }
+.tool-disclosure > summary { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 1.2rem; cursor: pointer; list-style: none; }
+.tool-disclosure > summary::-webkit-details-marker { display: none; }
+.tool-disclosure > summary strong { display: block; font-size: 1rem; font-weight: 550; color: var(--text-strong); }
+.tool-disclosure > summary small { display: block; color: var(--text-muted); margin-top: 0.25rem; font-size: 0.75rem; }
+.tool-disclosure > summary:hover { background: #292f26; }
+.disclosure-symbol { color: var(--accent); font-size: 1.5rem; transition: transform 140ms ease; }
+.tool-disclosure[open] > summary { border-bottom: 1px solid var(--border-soft); }
+.tool-disclosure[open] > summary .disclosure-symbol { transform: rotate(45deg); }
+.tool-disclosure > .panel { margin: 0; border: 0; border-radius: 0; }
+.panel-header, .table-card-header { background: none; border-color: var(--border-soft); }
+.preview-toolbar { position: static; background: #252b23; border-color: var(--border-soft); border-radius: 0.35rem; backdrop-filter: none; }
+.toolbar-search input, .toolbar-controls select, .facet-menu summary, .facet-options,
+.campaign-controls select { background: var(--bg-color); color: var(--text-primary); border-color: var(--border-control); border-radius: 0.3rem; }
+.preview-table thead th, .preview-table td, .preview-detail-row td, .table-card table th,
+.table-card table td { border-color: var(--border-subtle); }
+.preview-table thead, .preview-table thead th { background: #292f27; }
+.preview-table tbody tr, .preview-detail-row td, .lookup-result, .export-card { background: #202420; }
+.preview-table tbody tr:nth-child(even) { background: #242922; }
+.preview-table tbody tr:hover { background: #2c3429; }
+.preview-indicator, .preview-row-detail dd { color: var(--text-primary); }
+.export-card, .threat-card { border-color: var(--border-soft); border-radius: 0.35rem; box-shadow: none; }
+.export-card:hover { background: #2c3429; transform: none; border-color: var(--accent); }
+.campaign-stage, .campaign-inspector { background: #1b211c; }
+.investigation-list li, .campaign-node-meta div { background: #242a22; border-color: var(--border-soft); }
+.site-footer { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 1rem; margin-top: 2.5rem; padding-top: 1.5rem; border-top: 1px solid var(--border-soft); color: var(--text-muted); font-size: 0.72rem; }
+.site-footer div { display: flex; flex-wrap: wrap; gap: 1.5rem; }
+.site-footer a { color: var(--accent); }
+@media (max-width: 820px) {
+  .top-nav { position: static; align-items: start; flex-direction: column; gap: 0.2rem; }
+  .nav-links { width: 100%; flex-wrap: wrap; }
+  .nav-links a { padding-inline: 0.6rem; }
+  .nav-links a:first-child { padding-left: 0; }
+  .page-header-main { flex-direction: column; align-items: start; gap: 1.1rem; }
+  .hero-download { width: auto; }
+  [id] { scroll-margin-top: 1rem; }
+}
+@media (max-width: 640px) {
+  .page-wrapper { padding-inline: 1rem; }
+  .page-header { margin-block: 1.75rem; }
+  .brand-tagline { display: inline; }
+  .nav-links { font-size: 0.75rem; gap: 0; }
+  .lookup-heading { align-items: start; gap: 0.4rem; }
+  .lookup-heading > p { text-align: left; }
+  .status-meta { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .metrics-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .metrics-strip .metric-card:nth-child(n) { display: block; padding: 1rem 0.65rem; }
+  .metric-card:nth-child(odd) { border-left: 0; padding-left: 0; }
+  .metric-value { font-size: 1.6rem; }
+  .discovery-desk { padding-block: 1.4rem; }
+  .discovery-lenses { display: flex; flex-wrap: wrap; }
+  .discovery-lenses button { flex: 1 1 auto; text-align: center; }
+  .vulnerability-views { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .vulnerability-views button { min-width: 0; }
+  .preview-table tbody tr, .preview-row-detail { border-color: var(--border-soft); background: var(--card-bg-soft); }
+  .tool-disclosure > summary { padding: 1rem; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .disclosure-symbol, .button, .button-link, .hero-download, .export-card { transition: none; }
+}
+.collection-overview .score-distribution { padding-inline: 1.2rem; }
+.collection-overview .delta-strip { margin: 0; border: 0; border-top: 1px solid var(--border-subtle); }
+.tool-disclosure > .top-threats { border: 0; margin: 0; }
+.delta-counts div { background: #2b3227; border-radius: 0.3rem; }
+.delta-counts dd { color: var(--accent); }
+.status-meta { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.status-banner .status-dot { box-shadow: none; }
+.preview-table tr:not(.preview-detail-row), .preview-table tr:not(.preview-detail-row) td { background: var(--card-bg-soft); }
+.preview-table tr:not(.preview-detail-row):hover, .preview-table tr:not(.preview-detail-row):hover td { background: #2c3429; }
+@media (max-width: 820px) { .status-meta { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 760px) {
+  /* Long dates and unbroken feed labels must shrink inside the card grid. */
+  .preview-table tbody, .preview-table tr, .preview-table td { min-width: 0; }
+  .preview-table td { white-space: normal; overflow-wrap: anywhere; grid-template-columns: minmax(4.5rem, 5.5rem) minmax(0, 1fr); }
+  .preview-table td > * { min-width: 0; }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
       content="Free, open-source threat intelligence feed of the latest malicious IPs, domains, URLs, and file hashes — scored, cross-source corroborated, and refreshed automatically. Download CSV, JSON, JSONL, or STIX 2.1."
     />
     <meta name="keywords" content="threat intelligence feed, malicious IP list, IOC feed, indicators of compromise, C2 IP blocklist, open source threat intel, STIX feed, free IOC download" />
-    <meta name="theme-color" content="#0f172a" />
+    <meta name="theme-color" content="#191c19" />
     <link rel="canonical" href="https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="SwiftIOC — Free Live IOC Feed" />
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=16" />
+    <link rel="stylesheet" href="assets/styles.css?v=17" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -90,37 +90,23 @@
           <span class="brand-tagline">Threat Intelligence</span>
         </a>
         <div class="nav-links">
-          <a href="#ioc-lookup">Check an IOC</a>
+          <a href="#ioc-lookup">Lookup</a>
+          <a href="#vulnerabilities">CVEs</a>
+          <a href="#live-preview">IOC feed</a>
           <a href="#discovery">Discover</a>
-          <a href="#vulnerabilities">Vulnerabilities</a>
-          <a href="#campaign-graph">Campaign graph</a>
-          <a href="#live-preview">Browse feed</a>
-          <a href="#sources">Sources</a>
-          <a href="#indicator-types">Types</a>
-          <a href="#tags">Tags</a>
-          <a href="diagnostics/summary.html">Run diagnostics</a>
+          <a href="#exports">Downloads</a>
         </div>
       </nav>
 
       <main id="main-content">
       <header class="page-header">
-        <div class="signal-radar" aria-hidden="true">
-          <span class="radar-ring radar-ring-one"></span>
-          <span class="radar-ring radar-ring-two"></span>
-          <span class="radar-ring radar-ring-three"></span>
-          <span class="radar-crosshair"></span>
-          <span class="radar-sweep"></span>
-          <i class="radar-blip blip-one"></i>
-          <i class="radar-blip blip-two"></i>
-          <i class="radar-blip blip-three"></i>
-        </div>
         <div class="page-header-main">
           <div>
-            <p class="eyebrow">Open-source · refreshed every four hours</p>
-            <h1 class="section-title">Threat intelligence you can act on</h1>
+            <p class="eyebrow">Independent feeds. Open-source intelligence.</p>
+            <h1 class="section-title">The threat intelligence desk.</h1>
             <p class="page-header-subtitle">
-              Search, investigate, and export scored indicators from independent
-              threat feeds. Freshness and corroboration are built into every score.
+              Look up an indicator, review exploited vulnerabilities, or follow the evidence.
+              Collected every four hours, with sources attached.
             </p>
           </div>
           <a
@@ -131,8 +117,8 @@
             data-fallback-caption="CSV · current snapshot"
             download
           >
-            <span>Download block-ready feed</span>
-            <small>High-confidence CSV</small>
+            <span>Download high-confidence CSV</span>
+            <small>Current snapshot ↗</small>
           </a>
         </div>
       </header>
@@ -140,7 +126,6 @@
       <section id="ioc-lookup" class="ioc-lookup" aria-labelledby="ioc-lookup-heading">
         <div class="lookup-heading">
           <div>
-            <p class="eyebrow">Instant IOC lookup</p>
             <h2 id="ioc-lookup-heading">Check an indicator</h2>
           </div>
           <p id="ioc-lookup-help">Raw and defanged IPs, domains, URLs, hashes, and CVEs are supported.</p>
@@ -290,6 +275,8 @@
         </article>
       </section>
 
+      <details class="tool-disclosure collection-overview" data-tool-disclosure>
+        <summary><span><strong>Collection overview</strong><small>Score distribution and changes since the previous run</small></span><span class="disclosure-symbol" aria-hidden="true">+</span></summary>
       <section
         class="score-distribution"
         data-score-distribution
@@ -321,14 +308,16 @@
         </div>
       </section>
 
+      </details>
+
       <section class="discovery-desk vulnerability-desk" id="vulnerabilities" aria-labelledby="vulnerability-heading" data-vulnerability-root>
         <div class="discovery-heading">
           <div>
-            <p class="eyebrow">Vulnerability collection · one record per CVE</p>
-            <h2 id="vulnerability-heading">Known exploited. Newly disclosed. Prioritized.</h2>
-            <p>Separate vulnerabilities from network and file indicators. Inspect known exploitation, affected products, and each provider’s evidence without joining unrelated CVEs into a campaign.</p>
+            <p class="eyebrow">01 / Vulnerabilities</p>
+            <h2 id="vulnerability-heading">Vulnerabilities to watch</h2>
+            <p>Known exploitation first, newest KEV additions at the top. Each CVE keeps its own evidence.</p>
           </div>
-          <a class="button ghost" href="collections/vulnerabilities.json" data-vulnerability-download>Get collection JSON ↗</a>
+          <a class="button ghost" href="collections/vulnerabilities.json" data-vulnerability-download>Collection JSON ↗</a>
         </div>
         <div class="discovery-lenses vulnerability-views" role="group" aria-label="Vulnerability view">
           <button type="button" data-vulnerability-view="exploited" aria-pressed="true">Known exploited</button>
@@ -362,24 +351,28 @@
           <span data-vulnerability-page>Page 0 of 0</span>
           <button type="button" class="button ghost" data-vulnerability-next disabled>Next</button>
         </div>
+        <p class="discovery-scope">KEV records known exploitation; it does not confirm an attack is happening now.</p>
+        <details class="collection-notes">
+          <summary>Coverage, evidence &amp; integration notes</summary>
         <p class="discovery-scope">This collection covers the retained feed, not the complete KEV or NVD catalogs. Source windows, outages, and retention affect coverage. KEV membership records known exploitation; it does not date an attack or confirm one is happening now. Severity alone does not establish exploitation. These filters are independent of the IOC preview.</p>
         <p class="discovery-scope">Building an IOC integration? <a href="collections/observables.jsonl" data-observables-download>Download the observable-only collection</a>. Existing combined exports remain available.</p>
+        </details>
       </section>
 
       <section class="discovery-desk" id="discovery" aria-labelledby="discovery-heading" data-discovery-root>
         <div class="discovery-heading">
           <div>
-            <p class="eyebrow">The discovery desk</p>
-            <h2 id="discovery-heading">Find your next lead.</h2>
+            <p class="eyebrow">02 / Discovery</p>
+            <h2 id="discovery-heading">Follow the evidence</h2>
             <p>Follow the evidence behind the score. Explore corroboration, recent sightings, and uncommon tags in the loaded preview.</p>
           </div>
           <a class="button ghost" href="#live-preview">Refine the sample ↓</a>
         </div>
         <div class="discovery-toolbar">
           <div class="discovery-lenses" role="group" aria-label="Discovery lens">
-            <button type="button" data-discovery-mode="corroborated" aria-pressed="true">01 · Cross-source</button>
-            <button type="button" data-discovery-mode="recent" aria-pressed="false">02 · Recent sightings</button>
-            <button type="button" data-discovery-mode="uncommon" aria-pressed="false">03 · Uncommon tags</button>
+            <button type="button" data-discovery-mode="corroborated" aria-pressed="true">Cross-source</button>
+            <button type="button" data-discovery-mode="recent" aria-pressed="false">Recent sightings</button>
+            <button type="button" data-discovery-mode="uncommon" aria-pressed="false">Uncommon tags</button>
           </div>
           <button type="button" class="button ghost" data-discovery-export disabled>Export evidence brief</button>
         </div>
@@ -389,7 +382,9 @@
         <p class="discovery-scope">Observables from the compact preview, not the complete feed. CVEs are listed in the vulnerability collection above. Preview filters apply here. Nothing is uploaded when you explore or export.</p>
       </section>
 
-      <section
+      <details class="tool-disclosure" data-tool-disclosure>
+        <summary><span><strong>Relationship graph</strong><small>Explore shared tags and reporting sources</small></span><span class="disclosure-symbol" aria-hidden="true">+</span></summary>
+        <section
         id="campaign-graph"
         class="panel campaign-graph-section"
         data-campaign-root
@@ -482,6 +477,7 @@
           </aside>
         </div>
       </section>
+      </details>
 
       <div class="dashboard-main">
         <section
@@ -604,7 +600,8 @@
                 <label class="toolbar-group" for="preview-limit">
                   <span>Rows</span>
                   <select id="preview-limit" data-preview-limit>
-                    <option value="12">12</option>
+                    <option value="6">6</option>
+                    <option value="12" selected>12</option>
                     <option value="25">25</option>
                     <option value="50">50</option>
                     <option value="100">100</option>
@@ -748,6 +745,8 @@
           </div>
         </section>
 
+        <details class="tool-disclosure" data-tool-disclosure>
+        <summary><span><strong>Sources &amp; feed composition</strong><small>Source contributions, indicator types, and tags</small></span><span class="disclosure-symbol" aria-hidden="true">+</span></summary>
         <section
           class="panel"
           id="sources"
@@ -868,8 +867,11 @@
             </div>
           </div>
         </section>
+      </details>
       </div>
 
+      <details class="tool-disclosure" data-tool-disclosure>
+        <summary><span><strong>Highest-scoring indicators</strong><small>A quick shortlist from the current collection</small></span><span class="disclosure-symbol" aria-hidden="true">+</span></summary>
       <section
         class="top-threats"
         data-top-threats-section
@@ -885,7 +887,11 @@
         <div class="top-threats-grid" data-top-threats></div>
       </section>
 
-      <section
+      </details>
+
+      <details class="tool-disclosure" data-tool-disclosure>
+        <summary><span><strong>Downloads &amp; integrations</strong><small>CSV, JSON, STIX, and detection rules</small></span><span class="disclosure-symbol" aria-hidden="true">+</span></summary>
+        <section
         id="exports"
         class="panel"
         aria-labelledby="exports-heading"
@@ -909,7 +915,7 @@
               data-fallback-label="Complete CSV"
               rel="nofollow"
               download
-              title="Only score ≥80 or indicators confirmed by 2+ sources — block-ready"
+              title="Only score ≥80 or indicators confirmed by 2+ sources"
               >★ High-confidence CSV</a>
             <a
               class="button-link exports-highlight"
@@ -918,7 +924,7 @@
               data-fallback-label="Complete JSONL"
               rel="nofollow"
               download
-              title="Only score ≥80 or indicators confirmed by 2+ sources — block-ready"
+              title="Only score ≥80 or indicators confirmed by 2+ sources"
               >★ High-confidence JSONL</a>
             <a
               class="button-link"
@@ -976,17 +982,22 @@
           </div>
           <p class="panel-footnote">
             The ★ high-confidence feeds contain only indicators scoring ≥80 or
-            confirmed by 2+ independent sources — block-ready with minimal false
-            positives. All files come from the same SwiftIOC collector run that
+            confirmed by 2+ independent sources. Review indicators against your
+            environment before applying blocking rules. All files come from the same SwiftIOC collector run that
             powers the live dashboard above.
           </p>
         </div>
       </section>
+      </details>
+      <footer class="site-footer">
+        <span>SwiftIOC / Open-source threat intelligence</span>
+        <div><a href="diagnostics/summary.html">Collection diagnostics</a><a href="https://github.com/PKHarsimran/SwiftIOC-Automated-Threat-Intelligence-Collector">Source code ↗</a></div>
+      </footer>
       </main>
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=16"></script>
-    <script defer src="assets/dashboard.js?v=16"></script>
+    <script defer src="assets/dashboard-core.js?v=17"></script>
+    <script defer src="assets/dashboard.js?v=17"></script>
   </body>
 </html>

--- a/scripts/test_dashboard_layout.cjs
+++ b/scripts/test_dashboard_layout.cjs
@@ -52,6 +52,7 @@ const assert = require('node:assert/strict');
     assert.equal(await rows.count(), 6);
     assert.equal(await page.locator('[data-preview-limit]').inputValue(), '6');
     await page.locator('[data-preview-limit]').selectOption('12');
+    await page.reload({ waitUntil: 'networkidle' });
     assert.equal(await rows.count(), 12);
     await page.locator('[data-preview-limit]').selectOption('6');
     await page.reload({ waitUntil: 'networkidle' });

--- a/scripts/test_dashboard_layout.cjs
+++ b/scripts/test_dashboard_layout.cjs
@@ -1,0 +1,80 @@
+/* Serve public/ locally. Uses synthetic indicators and Playwright + Chromium.
+ * BASE_URL defaults to http://127.0.0.1:8765.
+ */
+const { chromium } = require('playwright');
+const assert = require('node:assert/strict');
+
+(async () => {
+  const browser = await chromium.launch({ headless: true,
+    ...(process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+      ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH } : {}),
+  });
+  const base = process.env.BASE_URL || 'http://127.0.0.1:8765';
+  try {
+    const context = await browser.newContext({ reducedMotion: 'reduce', viewport: { width: 1440, height: 1000 } });
+    const feed = Array.from({ length: 30 }, (_, i) => JSON.stringify({
+      indicator: `192.0.2.${i + 1}`, type: 'ipv4', score: 90, confidence: 'high',
+      source: 'fixture-a,fixture-b', tags: 'fixture-shared', last_seen: new Date().toISOString(),
+    })).join('\n');
+    await context.route('**/iocs/dashboard.jsonl', (route) => route.fulfill({ contentType: 'application/x-ndjson', body: feed }));
+    const page = await context.newPage();
+    const errors = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+    await page.goto(base, { waitUntil: 'networkidle' });
+    const rows = page.locator('[data-preview-body] > tr:not(.preview-detail-row)');
+    assert.equal(await rows.count(), 12);
+    assert.equal(await page.locator('[data-tool-disclosure][open]').count(), 0);
+    // Native summary controls must work with the keyboard.
+    const exports = page.locator('details').filter({ has: page.locator('#exports') });
+    const summary = exports.locator(':scope > summary');
+    await summary.focus();
+    await page.keyboard.press('Enter');
+    assert.equal(await exports.getAttribute('open'), '');
+    await page.keyboard.press('Enter');
+    assert.equal(await exports.getAttribute('open'), null);
+    await page.locator('.nav-links a[href="#exports"]').click();
+    await page.waitForFunction(() => document.getElementById('exports').closest('details').open);
+    await exports.evaluate((element) => { element.open = false; });
+    await page.locator('.nav-links a[href="#exports"]').click();
+    await page.waitForFunction(() => document.getElementById('exports').closest('details').open);
+    // Existing direct links must reveal ancestors on initial navigation.
+    for (const id of ['sources', 'tags', 'indicator-types', 'campaign-graph']) {
+      await page.goto(`${base}/#${id}`, { waitUntil: 'networkidle' });
+      assert.equal(await page.locator(`#${id}`).evaluate((element) => element.closest('details').open), true);
+    }
+    await page.locator('[data-graph-node]').first().click();
+    assert.equal(await page.locator('[data-graph-node][aria-pressed="true"]').count(), 1);
+    // Malformed fragments cannot break bootstrap or expose a selector error.
+    await page.goto(`${base}/#%E0%A4%A`, { waitUntil: 'networkidle' });
+    assert.equal(await rows.count(), 12);
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(base, { waitUntil: 'networkidle' });
+    assert.equal(await rows.count(), 6);
+    assert.equal(await page.locator('[data-preview-limit]').inputValue(), '6');
+    await page.locator('[data-preview-limit]').selectOption('12');
+    assert.equal(await rows.count(), 12);
+    await page.locator('[data-preview-limit]').selectOption('6');
+    await page.reload({ waitUntil: 'networkidle' });
+    assert.equal(await rows.count(), 6);
+    for (const width of [320, 390, 768, 1440]) {
+      await page.setViewportSize({ width, height: 900 });
+      assert.equal(await page.evaluate(() => document.documentElement.scrollWidth > innerWidth), false, `Page overflow at ${width}px`);
+      const links = await page.locator('.nav-links a').evaluateAll((elements) => elements.map((el) => {
+        const rect = el.getBoundingClientRect();
+        return { left: rect.left, right: rect.right, height: rect.height };
+      }));
+      for (const link of links) {
+        assert.ok(link.left >= 0 && link.right <= width, `Navigation clipped at ${width}px`);
+        assert.ok(link.height >= 44, 'Navigation touch target too short');
+      }
+    }
+    assert.deepEqual(errors, []);
+    // Downloads remain available if dashboard JavaScript fails or is disabled.
+    const noJs = await browser.newPage({ javaScriptEnabled: false });
+    await noJs.goto(base);
+    const downloadSummary = noJs.locator('.tool-disclosure > summary').filter({ hasText: 'Downloads & integrations' });
+    await downloadSummary.click();
+    assert.equal(await noJs.locator('#exports a').first().isVisible(), true);
+    console.log('PASS: keyboard disclosures, bookmarks, repeated anchors, graph selection, compact/shared rows, mobile navigation, and no-JS downloads.');
+  } finally { await browser.close(); }
+})().catch((error) => { console.error(error); process.exitCode = 1; });


### PR DESCRIPTION
The dashboard's animated hero and many equally prominent panels made routine triage harder to scan. This change introduces a graphite-and-olive theme, compact editorial header, simpler navigation, quieter metrics, and consistent evidence cards. The radar, moving background, cursor spotlight, and entrance effects are removed.

Collection statistics, the relationship graph, source tables, the highest-scoring shortlist, and exports now open through native keyboard-accessible disclosures. Existing bookmarks reveal the relevant section, including repeated clicks after manually closing it. Downloads remain reachable without JavaScript. Exploitation-first CVE views and evidence stay prominent; longer coverage notes open on demand.

Mobile preview defaults to six rows, while explicit row choices survive shared links and reloads. Narrow cards wrap long dates and metadata. The filter toolbar no longer covers results on short screens. All three asset URLs move together to v17. README describes the new layout and high-confidence download wording avoids promising automatic blocking safety.

Validation: 35 frontend unit tests; JavaScript syntax and git whitespace checks; existing CVE browser regression suite; new browser checks for keyboard disclosures, direct/repeated anchors, graph selection, malformed fragments, row-count round trips, navigation at 320/390/768/1440px, and downloads without JavaScript. Desktop/mobile screenshots inspected. Python collection and scoring behavior is unchanged.