### PR TITLE
Make the reporting graph searchable and export investigation evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Two reports about the **same CVE** become one CVE record with separate provider 
 | Search and filters | Narrow indicators by type, source, age, score, and other available context. |
 | Discovery lenses | Surface recent sightings and uncommon investigative tags, excluding known feed-name tags. |
 | Investigation workspace | Keep selected indicators in a browser-local queue and export a working set. |
-| Provider and tag graph | Explore shared reporting and tags, with original feed identifiers available for inspection. |
+| Provider and tag graph | Search displayed nodes by indicator, provider, tag, or raw feed name; inspect every connected node and export the graph or a selected neighborhood as evidence JSON. |
 | CVE briefing | Match watched products and distinguish newly encountered records from changed evidence. |
 | Diagnostics | Explain missing data, source failures, retention, and the latest collection results. |
 

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -542,7 +542,7 @@ test('exploited and ransomware views require explicit evidence and never fall ba
 test('vulnerability release uses coordinated new asset cache keys', () => {
   const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
   for (const asset of ['styles.css', 'dashboard-core.js', 'dashboard.js']) {
-    assert.ok(html.includes(`assets/${asset}?v=18`));
+    assert.ok(html.includes(`assets/${asset}?v=19`));
   }
 });
 

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -3470,6 +3470,11 @@
     const mode = qs('[data-campaign-mode]', root);
     const density = qs('[data-campaign-density]', root);
     const remix = qs('[data-campaign-layout]', root);
+    const search = qs('[data-campaign-search]', root);
+    const searchResults = qs('[data-campaign-search-results]', root);
+    const searchStatus = qs('[data-campaign-search-status]', root);
+    const reset = qs('[data-campaign-reset]', root);
+    const exportGraph = qs('[data-campaign-export]', root);
     const empty = qs('[data-campaign-empty]', root);
     const title = qs('[data-campaign-title]', root);
     const description = qs('[data-campaign-description]', root);
@@ -3519,19 +3524,22 @@
       const positions = new Map();
       const grouped = new Map(pivots.map((pivot) => [pivot.id, []]));
       indicators.forEach((node) => {
-        const first = graph.edges.find((edge) => edge.target === node.id);
-        if (first) grouped.get(first.source)?.push(node);
+        // Balance shared indicators between their actual pivots instead of
+        // assigning every overlap to whichever edge sorts first.
+        const owners = pivots.filter((pivot) => graph.edges.some((edge) => edge.source === pivot.id && edge.target === node.id));
+        owners.sort((a, b) => grouped.get(a.id).length - grouped.get(b.id).length);
+        if (owners.length) grouped.get(owners[0].id).push(node);
       });
       let top = 25;
       const reverse = Math.round(rotation / (Math.PI / 7)) % 2 === 1;
       pivots.forEach((pivot) => {
         const members = grouped.get(pivot.id);
         if (reverse) members.reverse();
-        const height = Math.max(95, Math.ceil(members.length / 6) * 75 + 20);
+        const height = Math.max(95, Math.ceil(members.length / 5) * 75 + 20);
         positions.set(pivot.id, { x: 145, y: top + height / 2 });
         members.forEach((node, index) => positions.set(node.id, {
-          x: 350 + (index % 6) * 115,
-          y: top + 30 + Math.floor(index / 6) * 75,
+          x: 350 + (index % 5) * 140,
+          y: top + 30 + Math.floor(index / 5) * 75,
         }));
         top += height;
       });
@@ -3541,6 +3549,8 @@
 
     const selectNode = (node) => {
       selected = node;
+      if (reset) reset.disabled = false;
+      if (exportGraph) exportGraph.textContent = 'Export selected relationships';
       const connected = new Set();
       graph.edges.forEach((edge) => {
         if (edge.source === node.id) connected.add(edge.target);
@@ -3579,7 +3589,7 @@
       if (meta) meta.hidden = false;
       if (description) {
         description.textContent = node.kind === 'pivot'
-          ? `${formatNumber(node.totalCount)} indicators share this ${node.pivotKind}; ${formatNumber(node.count)} are visible in this graph. Their average risk score is ${node.averageScore}.`
+          ? `${formatNumber(node.totalCount)} indicators in the filtered sample share this ${node.pivotKind}; ${formatNumber(node.count)} are displayed. Average collector score across all ${formatNumber(node.totalCount)} matching indicators: ${node.averageScore}.`
           : `${node.row?.confidence ? `${node.row.confidence} confidence · ` : ''}Reported by ${node.providers.map((provider) => provider.label).join(', ') || 'unspecified sources'}${node.row?.context ? ` · ${compactText(node.row.context)}` : ''}.`;
       }
       const feedEvidence = qs('[data-campaign-feed-evidence]', root);
@@ -3600,7 +3610,7 @@
       }
       if (tagBlock) tagBlock.hidden = !tags.length;
       if (relatedList) {
-        relatedList.replaceChildren(...relatedNodes.slice(0, 10).map((candidate) => {
+        relatedList.replaceChildren(...relatedNodes.map((candidate) => {
           const button = document.createElement('button');
           button.type = 'button';
           button.className = 'campaign-related-node';
@@ -3610,7 +3620,7 @@
           return button;
         }));
       }
-      if (relatedHeading) relatedHeading.textContent = node.kind === 'pivot' ? 'Connected indicators' : 'Relationship pivots';
+      if (relatedHeading) relatedHeading.textContent = `${node.kind === 'pivot' ? 'Connected indicators' : 'Relationship pivots'} (${relatedNodes.length})`;
       if (relatedBlock) relatedBlock.hidden = !relatedNodes.length;
       const reportUrl = node.kind === 'indicator' ? safeHttpUrl(node.row?.reference) : null;
       if (reference) {
@@ -3624,6 +3634,33 @@
           ? 'Remove from queue'
           : 'Add indicator to queue';
       }
+    };
+
+    const updateSearch = () => {
+      if (!searchResults || !search) return;
+      const query = normaliseLower(search.value);
+      const matches = query ? (graph?.nodes || []).filter((node) => normaliseLower([
+        node.label, node.row?.type, ...(node.feeds || []),
+        ...(node.providers || []).flatMap((provider) => [provider.label, ...provider.feeds]),
+        ...(node.row?.tags || []),
+      ].join(' ')).includes(query)) : [];
+      searchResults.hidden = !matches.length;
+      searchResults.replaceChildren(...matches.map((node) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'campaign-related-node';
+        button.textContent = `${node.label} · ${node.kind === 'pivot' ? `${node.count} displayed IOCs` : `${node.row?.type || 'indicator'} · score ${node.score}`}`;
+        button.addEventListener('click', () => {
+          selectNode(node);
+          const element = qsa('[data-graph-node]', svg).find((item) => item.dataset.graphNode === node.id);
+          element?.focus({ preventScroll: true });
+          element?.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'instant' });
+        });
+        return button;
+      }));
+      setText(searchStatus, query
+        ? `${matches.length} matching nodes in the displayed graph. Main filters control the sample; this search does not expand it.`
+        : 'Search the displayed sample. Use the main filters to change its coverage.');
     };
 
     const render = () => {
@@ -3641,6 +3678,12 @@
       svg.hidden = !hasGraph;
       root.hidden = !entries.length;
       if (stats) stats.hidden = !hasGraph;
+      if (reset) reset.disabled = true;
+      if (exportGraph) {
+        exportGraph.disabled = !hasGraph;
+        exportGraph.textContent = 'Export graph JSON';
+      }
+      updateSearch();
       setText(high, formatNumber(graph.stats.highScore));
       setText(corroborated, formatNumber(graph.stats.corroborated));
       setText(average, formatNumber(graph.stats.averageScore));
@@ -3673,8 +3716,9 @@
         const start = positions.get(edge.source);
         const end = positions.get(edge.target);
         if (!start || !end) return;
-        const line = createSvg('line', {
-          x1: start.x, y1: start.y, x2: end.x, y2: end.y,
+        const line = createSvg('path', {
+          d: `M ${start.x + 120} ${start.y} C ${start.x + 175} ${start.y}, ${end.x - 55} ${end.y}, ${end.x - 17} ${end.y}`,
+          fill: 'none',
           class: `campaign-edge ${edge.kind}`,
           'data-graph-edge': '',
           'data-source': edge.source,
@@ -3763,6 +3807,37 @@
       if (nextSelected) selectNode(nextSelected);
     };
 
+    search?.addEventListener('input', updateSearch);
+    reset?.addEventListener('click', () => {
+      selected = null;
+      if (search) search.value = '';
+      render();
+    });
+    root.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && selected) {
+        selected = null;
+        render();
+        search?.focus();
+      }
+    });
+    exportGraph?.addEventListener('click', () => {
+      if (!graph?.edges.length) return;
+      const edges = selected ? graph.edges.filter((edge) => edge.source === selected.id || edge.target === selected.id) : graph.edges;
+      const ids = new Set(edges.flatMap((edge) => [edge.source, edge.target]));
+      const nodes = graph.nodes.filter((node) => ids.has(node.id));
+      downloadDetection(JSON.stringify({
+        schema_version: 1,
+        exported_at: new Date().toISOString(),
+        scope: selected ? 'selected-neighborhood' : 'displayed-graph',
+        selected_node: selected?.id || null,
+        mode: graph.mode,
+        sample_indicator_count: entries.filter((row) => normaliseLower(row.type) !== 'cve').length,
+        limits: { indicators: Number(density?.value) || 36, pivots: 8 },
+        counts: { nodes: nodes.length, indicators: nodes.filter((node) => node.kind === 'indicator').length, relationships: edges.length },
+        caveat: 'Relationships describe shared reporting or tags in a bounded sample, not campaign attribution or independent verification. Pivot totals describe the filtered sample; edges describe this export.',
+        nodes, edges,
+      }, null, 2) + '\n', 'swiftioc-graph-evidence.json', 'application/json');
+    });
     mode?.addEventListener('change', render);
     density?.addEventListener('change', render);
     remix?.addEventListener('click', () => {

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -3626,3 +3626,14 @@ input.lookup-input { border-radius: 0.3rem; background: var(--bg-color); }
 @media (max-width: 640px) { .vulnerability-views select { width: 100%; } }
 .campaign-node.is-dimmed { opacity: 0.5; }
 .campaign-node.is-selected .campaign-node-core { filter: none; }
+
+/* Graph exploration stays separate from the scrollable diagram. */
+.campaign-search-tools { padding: 1rem; border-bottom: 1px solid var(--border-control); }
+.campaign-search-tools > label { display: block; margin-bottom: .4rem; font-weight: 600; }
+.campaign-search-tools input { width: 100%; min-width: 0; padding: .65rem .75rem; border: 1px solid var(--border-control); border-radius: .3rem; background: var(--bg-color); color: var(--text-primary); }
+.campaign-search-tools > p { font-size: .78rem; margin: .5rem 0; color: var(--text-secondary); }
+.campaign-search-actions { display: flex; flex-wrap: wrap; gap: .5rem; }
+.campaign-search-results { display: grid; gap: .35rem; max-height: 15rem; overflow: auto; margin: .75rem 0; }
+.campaign-search-results[hidden] { display: none; }
+.campaign-related-list { max-height: 18rem; overflow: auto; overscroll-behavior: contain; }
+.campaign-search-results .campaign-related-node { overflow-wrap: anywhere; text-align: left; }

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=18" />
+    <link rel="stylesheet" href="assets/styles.css?v=19" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -433,12 +433,22 @@
               </select>
             </div>
             <button type="button" class="button ghost" data-campaign-layout>
-              Remix layout
+              Reverse indicator order
             </button>
           </div>
         </div>
         <div class="panel-body campaign-graph-body">
           <div class="campaign-stage" data-campaign-stage>
+            <div class="campaign-search-tools">
+              <label for="campaign-search">Find in this graph</label>
+              <input id="campaign-search" type="search" data-campaign-search placeholder="Indicator, provider, tag or feed name" autocomplete="off" aria-describedby="campaign-search-status" />
+              <p id="campaign-search-status" data-campaign-search-status role="status">Search the displayed sample. Use the main filters to change its coverage.</p>
+              <div class="campaign-search-results" data-campaign-search-results hidden></div>
+              <div class="campaign-search-actions">
+                <button type="button" class="button ghost" data-campaign-reset disabled>Clear selection</button>
+                <button type="button" class="button ghost" data-campaign-export disabled>Export graph JSON</button>
+              </div>
+            </div>
             <dl class="campaign-stage-stats" data-campaign-stats hidden>
               <div><dt>High risk</dt><dd data-campaign-high>0</dd></div>
               <div><dt>2+ providers</dt><dd data-campaign-corroborated>0</dd></div>
@@ -1013,7 +1023,7 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=18"></script>
-    <script defer src="assets/dashboard.js?v=18"></script>
+    <script defer src="assets/dashboard-core.js?v=19"></script>
+    <script defer src="assets/dashboard.js?v=19"></script>
   </body>
 </html>

--- a/scripts/test_personal_briefing.cjs
+++ b/scripts/test_personal_briefing.cjs
@@ -112,7 +112,48 @@ const path = require('node:path');
     assert.match(await page.locator('[data-campaign-feed-evidence]').innerText(), /ci_army_list/);
     assert.equal(await graph.locator('[data-graph-node][aria-label*="abuse.ch"]').count(), 1);
     assert.equal(await graph.locator('[data-graph-node][aria-label*="SANS ISC"]').count(), 1);
-    if (process.env.SCREENSHOT_DIR) await page.screenshot({ path: `${process.env.SCREENSHOT_DIR}/provider-graph.png` });
+    // Search raw feed aliases, inspect all connections, and export only real edges.
+    await graph.locator('[data-graph-node][aria-label*="abuse.ch"]').click();
+    const relatedCount = Number((await page.locator('[data-campaign-related-heading]').innerText()).match(/\d+/)[0]);
+    assert.ok(relatedCount > 10);
+    assert.equal(await page.locator('[data-campaign-related-list] button').count(), relatedCount);
+    const [graphDownload] = await Promise.all([page.waitForEvent('download'), page.locator('[data-campaign-export]').click()]);
+    const graphTemp = await fs.mkdtemp(path.join(os.tmpdir(), 'swiftioc-graph-'));
+    try {
+      const dest = path.join(graphTemp, 'graph.json'); await graphDownload.saveAs(dest);
+      const exported = JSON.parse(await fs.readFile(dest, 'utf8'));
+      assert.equal(exported.scope, 'selected-neighborhood');
+      assert.equal(exported.counts.indicators, relatedCount);
+      assert.equal(exported.edges.length, relatedCount);
+      assert.ok(exported.edges.every((edge) => edge.source === exported.selected_node));
+      const ids = new Set(exported.nodes.map((node) => node.id));
+      assert.ok(exported.edges.every((edge) => ids.has(edge.source) && ids.has(edge.target)));
+    } finally { await fs.rm(graphTemp, { recursive: true }); }
+    await page.locator('[data-campaign-search]').fill('ci_army_list');
+    assert.equal(await page.locator('[data-campaign-search-results] button').count(), 6);
+    await page.locator('[data-campaign-search-results] button').filter({ hasText: 'CINS Army' }).click();
+    assert.equal(await page.locator('[data-campaign-title]').innerText(), 'CINS Army');
+    await page.keyboard.press('Escape');
+    assert.equal(await page.locator('[data-campaign-reset]').isDisabled(), true);
+    assert.equal(await graph.locator('.is-dimmed').count(), 0);
+    await page.locator('[data-campaign-search]').fill('no-such-fixture');
+    assert.match(await page.locator('[data-campaign-search-status]').innerText(), /0 matching nodes/);
+    assert.equal(await page.locator('[data-campaign-search-results] button').count(), 0);
+    await cins.click();
+    await page.locator('[data-campaign-reset]').click();
+    assert.equal(await page.locator('[data-campaign-search]').inputValue(), '');
+    assert.equal(await page.locator('[data-campaign-export]').innerText(), 'Export graph JSON');
+    await page.setViewportSize({ width: 390, height: 844 });
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth > innerWidth), false);
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    if (process.env.SCREENSHOT_DIR) {
+      await page.locator('#campaign-graph').scrollIntoViewIfNeeded();
+      await page.screenshot({ path: `${process.env.SCREENSHOT_DIR}/provider-graph.png` });
+    }
+    await page.evaluate(() => window.dispatchEvent(new CustomEvent('swiftioc:preview-filtered', { detail: { rows: [] } })));
+    assert.equal(await page.locator('[data-campaign-export]').isDisabled(), true);
+    assert.equal(await page.locator('[data-campaign-related]').isVisible(), false);
+
     assert.deepEqual(errors, []);
     // Malformed saved state cannot turn every historical CVE into a change.
     await page.evaluate((key) => localStorage.setItem(key, '{broken'), key);


### PR DESCRIPTION
Analysts can now find displayed graph nodes by indicator, provider, tag, or original feed name, then export the whole displayed graph or the selected node’s relationships as JSON. Exports include node evidence, actual edges, counts, sampling limits, and a clear distinction between shared reporting and campaign attribution. Search stays within the displayed sample and explains how to change coverage.

The inspector now lists every connected node in a bounded scroll area instead of silently truncating at ten. Shared indicators are distributed among their connected pivots, wider column spacing improves labels, and curved links leave provider cards at their edges. Clear selection and Escape restore the overview. Pivot descriptions explicitly distinguish the displayed count from the full filtered-sample average. Empty graph updates disable exports. All three frontend asset keys advance together to v19.

Validation: all 42 frontend unit tests and all three browser regression suites pass. Added browser coverage for raw feed search, complete connection lists, selected-neighborhood JSON exports with valid endpoints, keyboard reset, no matches, mobile overflow, and disabled export after the feed clears. Inspected the rendered desktop graph. README explains the new graph workflow.