### PR TITLE
Fix ordinary IOC graph searches and DNS policy zone exports

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -45,3 +45,17 @@ cosign verify-blob public/iocs/delta.jsonl \
   --certificate-identity-regexp 'https://github.com/PKHarsimran/SwiftIOC-Automated-Threat-Intelligence-Collector/' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
+
+
+## DNS response policy export
+
+The generated `detections/dns/swiftioc.rpz` contains exact-domain and wildcard
+QNAME triggers. Load it under your chosen response-policy zone origin. Trigger
+owners are deliberately relative (`evil.example` and `*.evil.example`); adding
+a trailing dot would place them outside that policy zone. The CNAME target `.`
+is absolute and specifies the NXDOMAIN action.
+
+Validate the generated file with `named-checkzone YOUR_POLICY_ZONE swiftioc.rpz`
+before deployment. See the [BIND RPZ documentation](https://bind9.readthedocs.io/en/v9.16.43/reference.html)
+for resolver configuration and policy behavior. Regenerate older SwiftIOC packs
+to obtain the corrected relative trigger names.

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -327,6 +327,19 @@
   };
   const graphProviderCount = (row) => sourceProviders(row).filter((provider) => provider.role === 'reporting').length;
 
+  const graphNodeMatches = (node, value) => {
+    const query = lower(value);
+    if (!query || !node) return false;
+    const literal = [node.label, node.row?.type, ...(node.feeds || []),
+      ...(node.providers || []).flatMap((provider) => [provider.label, ...provider.feeds]),
+      ...(node.row?.tags || []),
+    ].map(lower);
+    if (literal.some((field) => field.includes(query))) return true;
+    // Refang only IOC values. Provider and tag text must retain its literal
+    // meaning even when it happens to contain defanging-like punctuation.
+    return node.kind === 'indicator' && lower(refang(node.label)).includes(lower(refang(query)));
+  };
+
   const buildCampaignGraph = (value, options = {}) => {
     const rows = Array.isArray(value) ? value.filter((row) => row?.indicator && lower(row.type) !== 'cve') : [];
     const mode = ['all', 'tags', 'sources'].includes(options.mode) ? options.mode : 'all';
@@ -863,6 +876,7 @@
     vulnerabilityFacts,
     compareRows,
     buildCampaignGraph,
+    graphNodeMatches,
     sourceProviders,
     buildDiscovery,
     effectiveScore,

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -542,7 +542,7 @@ test('exploited and ransomware views require explicit evidence and never fall ba
 test('vulnerability release uses coordinated new asset cache keys', () => {
   const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
   for (const asset of ['styles.css', 'dashboard-core.js', 'dashboard.js']) {
-    assert.ok(html.includes(`assets/${asset}?v=19`));
+    assert.ok(html.includes(`assets/${asset}?v=20`));
   }
 });
 
@@ -657,4 +657,35 @@ test('malformed, incompatible, oversized, and future saved briefings cannot enab
     { ...state, watches: Array(21).fill(state.watches[0]) }, { ...state, snapshotAt: null }]) {
     assert.equal(core.normaliseBriefing(bad), null);
   }
+});
+
+
+test('graph search matches ordinary and defanged IOCs in either direction', () => {
+  for (const [ordinary, defanged] of [
+    ['77.239.124.108', '77[.]239[.]124[.]108'],
+    ['https://example.test/Payload?key=ABC', 'hxxps://example[.]test/Payload?key=ABC'],
+    ['http://example.test/path', 'hxxp://example[.]test/path'],
+    ['example.test', 'example[.]test'],
+  ]) {
+    assert.equal(core.graphNodeMatches({ kind: 'indicator', label: defanged }, ordinary), true);
+    assert.equal(core.graphNodeMatches({ kind: 'indicator', label: ordinary }, defanged), true);
+  }
+  assert.equal(core.graphNodeMatches({ kind: 'indicator', label: '77[.]239[.]124[.]108' }, '239.124'), true);
+  assert.equal(core.graphNodeMatches({ kind: 'indicator', label: '77[.]239[.]124[.]108' }, '77.239.124.109'), false);
+  assert.equal(core.graphNodeMatches(null, 'test'), false);
+  assert.equal(core.graphNodeMatches({ kind: 'indicator', label: 'test' }, '  '), false);
+});
+
+test('graph search keeps provider, feed, and tag matching literal', () => {
+  const pivot = { kind: 'pivot', label: 'Research[.]Team', feeds: ['hxxps://feed'] };
+  assert.equal(core.graphNodeMatches(pivot, 'research[.]team'), true);
+  assert.equal(core.graphNodeMatches(pivot, 'research.team'), false);
+  assert.equal(core.graphNodeMatches(pivot, 'https://feed'), false);
+  const indicator = { kind: 'indicator', label: '1[.]2[.]3[.]4',
+    row: { type: 'ipv4', tags: ['family[.]variant'] },
+    providers: [{ label: 'CINS Army', feeds: ['ci_army_list'] }] };
+  assert.equal(core.graphNodeMatches(indicator, 'ci_army_list'), true);
+  assert.equal(core.graphNodeMatches(indicator, 'CINS ARMY'), true);
+  assert.equal(core.graphNodeMatches(indicator, 'family[.]variant'), true);
+  assert.equal(core.graphNodeMatches(indicator, 'family.variant'), false);
 });

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -3639,11 +3639,7 @@
     const updateSearch = () => {
       if (!searchResults || !search) return;
       const query = normaliseLower(search.value);
-      const matches = query ? (graph?.nodes || []).filter((node) => normaliseLower([
-        node.label, node.row?.type, ...(node.feeds || []),
-        ...(node.providers || []).flatMap((provider) => [provider.label, ...provider.feeds]),
-        ...(node.row?.tags || []),
-      ].join(' ')).includes(query)) : [];
+      const matches = query ? (graph?.nodes || []).filter((node) => dashboardCore.graphNodeMatches(node, query)) : [];
       searchResults.hidden = !matches.length;
       searchResults.replaceChildren(...matches.map((node) => {
         const button = document.createElement('button');

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=19" />
+    <link rel="stylesheet" href="assets/styles.css?v=20" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -1023,7 +1023,7 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=19"></script>
-    <script defer src="assets/dashboard.js?v=19"></script>
+    <script defer src="assets/dashboard-core.js?v=20"></script>
+    <script defer src="assets/dashboard.js?v=20"></script>
   </body>
 </html>

--- a/scripts/test_personal_briefing.cjs
+++ b/scripts/test_personal_briefing.cjs
@@ -32,9 +32,9 @@ const path = require('node:path');
       return route.fulfill({ contentType: 'application/json', body: JSON.stringify({ schema_version: 1,
         generated_at: mode === 'older' ? '2026-09-07T00:00:00Z' : mode === 'initial' ? '2026-09-08T00:00:00Z' : '2026-09-09T00:00:00Z', items }) });
     });
-    const feed = Array.from({ length: 40 }, (_, index) => JSON.stringify({ indicator: `192.0.2.${index + 1}`, type: 'ipv4',
+    const feed = Array.from({ length: 40 }, (_, index) => JSON.stringify({ indicator: index === 0 ? 'hxxps://fixture[.]example/Payload?key=ABC' : `192[.]0[.]2[.]${index + 1}`, type: index === 0 ? 'url' : 'ipv4',
       source: index < 30 ? 'threatfox_export_json,urlhaus_recent_urls' : index < 35 ? 'ci_army_list' : 'dshield_block',
-      tags: index < 30 ? 'threatfox,urlhaus,scanner' : 'scanner', score: index < 30 ? 99 : 70,
+      tags: index < 30 ? 'threatfox,urlhaus,scanner' : 'scanner', score: index === 0 ? 100 : index < 30 ? 99 : 70,
       last_seen: '2026-09-09T00:00:00Z', confidence: 'high',
     })).join('\n');
     await context.route('**/iocs/dashboard.jsonl', (route) => route.fulfill({ contentType: 'application/x-ndjson', body: feed }));
@@ -129,6 +129,14 @@ const path = require('node:path');
       const ids = new Set(exported.nodes.map((node) => node.id));
       assert.ok(exported.edges.every((edge) => ids.has(edge.source) && ids.has(edge.target)));
     } finally { await fs.rm(graphTemp, { recursive: true }); }
+    await page.locator('[data-campaign-search]').fill('192.0.2.31');
+    assert.equal(await page.locator('[data-campaign-search-results] button').count(), 1);
+    await page.locator('[data-campaign-search-results] button').click();
+    assert.equal(await page.locator('[data-campaign-title]').innerText(), '192[.]0[.]2[.]31');
+    await page.locator('[data-campaign-search]').fill('https://fixture.example/Payload?key=ABC');
+    assert.equal(await page.locator('[data-campaign-search-results] button').count(), 1);
+    await page.locator('[data-campaign-search-results] button').click();
+    assert.equal(await page.locator('[data-campaign-title]').innerText(), 'hxxps://fixture[.]example/Payload?key=ABC');
     await page.locator('[data-campaign-search]').fill('ci_army_list');
     assert.equal(await page.locator('[data-campaign-search-results] button').count(), 6);
     await page.locator('[data-campaign-search-results] button').filter({ hasText: 'CINS Army' }).click();

--- a/swiftioc/detections.py
+++ b/swiftioc/detections.py
@@ -199,7 +199,9 @@ def _rpz_zone(domains: Sequence[str], serial: int) -> str:
         "@ IN NS localhost.",
     ]
     for domain in domains:
-        lines.extend((f"{domain}. CNAME .", f"*.{domain}. CNAME ."))
+        # QNAME triggers are relative to the configured RPZ origin. An
+        # absolute owner (trailing dot) is outside that policy zone.
+        lines.extend((f"{domain} CNAME .", f"*.{domain} CNAME ."))
     return "\n".join(lines) + "\n"
 
 

--- a/tests/test_detections.py
+++ b/tests/test_detections.py
@@ -65,8 +65,8 @@ def test_detection_pack_writes_valid_type_aware_artifacts(tmp_path):
     assert len(re.findall(r"\bsid:\d+;", rules)) == 5
 
     rpz = (tmp_path / "dns" / "swiftioc.rpz").read_text()
-    assert "evil.example. CNAME ." in rpz
-    assert "*.evil.example. CNAME ." in rpz
+    assert "evil.example CNAME ." in rpz
+    assert "*.evil.example CNAME ." in rpz
     assert json.loads((tmp_path / "manifest.json").read_text()) == manifest
 
 
@@ -143,3 +143,18 @@ def test_rpz_serial_advances_when_two_revisions_share_a_timestamp(tmp_path):
 
     assert second["rpz_serial"] == first["rpz_serial"] + 1
     assert f"({second['rpz_serial']} " in (tmp_path / "dns" / "swiftioc.rpz").read_text()
+
+
+def test_rpz_triggers_remain_relative_to_the_policy_zone(tmp_path):
+    si.write_detection_pack(
+        tmp_path, [_indicator("Evil[.]Example.", "domain")],
+        generated_at="2026-09-08T02:00:00Z",
+    )
+    zone = (tmp_path / "dns" / "swiftioc.rpz").read_text()
+    triggers = [line.split() for line in zone.splitlines() if " CNAME " in line]
+    assert len(triggers) == 2
+    for owner, record_type, target in triggers:
+        assert not owner.endswith("."), "Absolute triggers escape the RPZ origin"
+        assert record_type == "CNAME"
+        assert target == ".", "NXDOMAIN action must remain an absolute root target"
+    assert {owner for owner, *_ in triggers} == {"evil.example", "*.evil.example"}


### PR DESCRIPTION
Pasting an ordinary IP or URL into graph search now matches its defanged label, and defanged queries also match ordinary labels. A shared core helper applies refang only to indicator values while preserving case-insensitive literal matching for provider names, raw feed identifiers, and tags. Search still covers only displayed nodes. All three asset cache keys advance together to v20.

The Python detection exporter also wrote absolute DNS RPZ trigger owners, such as `evil.example.`, which fall outside the configured policy zone. Exact and wildcard owners are now relative (`evil.example` and `*.evil.example`); the CNAME root target remains absolute for NXDOMAIN. Integration documentation explains the format, validation, and regeneration of older packs. This follows the [BIND RPZ configuration reference](https://bind9.readthedocs.io/en/v9.16.43/reference.html).

Validation: 179 Python tests, 44 frontend unit tests, all three browser regression suites, Ruff, JavaScript syntax, and whitespace checks passed. Pyright reports zero errors and five environment import-source warnings. Added tests cover IP/domain/HTTP/HTTPS matching in both forms, literal metadata matching, partial and negative queries, browser searches against defanged IP/URL fixtures, and relative exact/wildcard RPZ owners. Independently loaded generated zones with dnspython under two different origins and verified both NXDOMAIN triggers; the validation library was installed only in a temporary directory, with no runtime dependency added.