### PR TITLE
Add private software inventory imports and explainable CVE exposure reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,11 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
-          node --test public/assets/dashboard-core.test.js
+          node --test public/assets/dashboard-core.test.js public/assets/inventory-core.test.js
           node --check public/assets/dashboard-core.js
           node --check public/assets/dashboard.js
+          node --check public/assets/inventory.js
+          node --check public/assets/inventory-core.js
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/README.md
+++ b/README.md
@@ -82,6 +82,37 @@ A routine poll timestamp does not create a new evidence alert. Rejected records 
 
 Watchlists and review state stay in this browser's local storage. There is no account sync or automatic notification service; blocked storage limits persistence to the current tab. Product matching uses available CISA vendor/product fields, so an NVD-only record without those fields cannot match a watch. Coverage is limited to the retained collection, not an asset inventory or a complete vulnerability assessment.
 
+## Local exposure report
+
+Open **Exposure report** in the CVE section, download the sample JSON, replace
+its example values, and import your inventory. Up to 200 assets and 500 KB are
+accepted. Inventory stays in memory in the current tab: it is not uploaded,
+saved to local storage, or shared with other users. Export the report before
+closing the tab if you need to retain it.
+
+Each asset needs a unique `id`, `vendor`, and `product`. Supply `version` for
+version checks, `exposure` (`internet`, `internal`, or `unknown`), and
+`importance` (`critical` or `standard`) for prioritization. These are your
+assertions, not scan results. Optional `cpe_vendor` and `cpe_product` must use
+explicit NVD CPE identifiers; `cpe_part` defaults to `a` (application), with
+`o` (operating system) and `h` (hardware) also supported. Display names are not
+automatically translated into CPE identities.
+
+The report distinguishes **version match**, **needs verification**, and
+**outside reported range**. Simple NVD applicability rules support exact
+versions and dotted-numeric inclusive/exclusive boundaries. Complex platform
+conditions, missing evidence, and unsupported version ordering remain uncertain.
+CISA-only product matches cannot confirm affected versions. Older snapshots
+without NVD configurations still support product-level review; a new collection
+run supplies applicability evidence when NVD provides it.
+
+Reports include provider evidence, matching reasons, remediation, the snapshot
+timestamp, and assets without a retained match. No match is not a safety verdict.
+The display paginates findings; exports include the whole calculated report,
+up to a disclosed 10,000-finding limit. Failed, future, or out-of-order snapshot
+refreshes disable the report until usable evidence returns. This first version
+is an on-demand assessment, not a scanner, SBOM parser, or change-alert service.
+
 ## Quick start
 
 Requires **Python 3.10+** and Git. Run these commands from a terminal.
@@ -307,7 +338,7 @@ ruff check .
 pyright
 python -m swiftioc --self-test
 pytest -q
-node --test public/assets/dashboard-core.test.js
+node --test public/assets/dashboard-core.test.js public/assets/inventory-core.test.js
 ```
 
 Python tests mock network calls. The frontend core suite checks data logic with Node.js. For browser regressions, install Playwright and serve the site:
@@ -324,6 +355,7 @@ In a second terminal:
 node scripts/test_vulnerability_ui.cjs
 node scripts/test_dashboard_layout.cjs
 node scripts/test_personal_briefing.cjs
+node scripts/test_inventory_ui.cjs
 ```
 
 These suites use synthetic fixtures to exercise filtering, refresh failures, mobile layout, personal briefing state, and provider graph behavior. Set `BASE_URL` for a different local server or `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` for an existing Chromium browser.

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -542,7 +542,7 @@ test('exploited and ransomware views require explicit evidence and never fall ba
 test('vulnerability release uses coordinated new asset cache keys', () => {
   const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
   for (const asset of ['styles.css', 'dashboard-core.js', 'dashboard.js']) {
-    assert.ok(html.includes(`assets/${asset}?v=20`));
+    assert.ok(html.includes(`assets/${asset}?v=21`));
   }
 });
 

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -3277,6 +3277,7 @@
       failed = false;
       items = [];
       snapshotTime = null;
+      window.dispatchEvent(new CustomEvent('swiftioc:vulnerability-snapshot', { detail: null }));
       page = 0;
       render();
       const controller = new AbortController();
@@ -3304,6 +3305,9 @@
       } finally {
         window.clearTimeout(timer);
         loading = false;
+        window.dispatchEvent(new CustomEvent('swiftioc:vulnerability-snapshot', {
+          detail: !failed && snapshotTime <= Date.now() / 1000 ? { items, generated_at: new Date(snapshotTime * 1000).toISOString() } : null,
+        }));
         render();
       }
     };

--- a/public/assets/inventory-core.js
+++ b/public/assets/inventory-core.js
@@ -1,0 +1,130 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.SwiftIOCInventory = api;
+})(typeof window !== 'undefined' ? window : globalThis, function () {
+  'use strict';
+  const text = (value) => typeof value === 'string' ? value.trim() : '';
+  const same = (a, b) => text(a).toLowerCase() === text(b).toLowerCase();
+  const parseInventory = (value) => {
+    if (value?.schema_version !== 1 || !Array.isArray(value.assets) || !value.assets.length || value.assets.length > 200) throw new Error('Use schema_version 1 with 1–200 assets.');
+    const ids = new Set();
+    return value.assets.map((asset, index) => {
+      if (!asset || typeof asset !== 'object') throw new Error(`Asset ${index + 1} must be an object.`);
+      const clean = {};
+      for (const field of ['id', 'vendor', 'product', 'version', 'cpe_vendor', 'cpe_product']) {
+        if (asset[field] != null && typeof asset[field] !== 'string') throw new Error(`Asset ${index + 1}: ${field} must be text.`);
+        clean[field] = text(asset[field]);
+        if (clean[field].length > 160) throw new Error(`Asset ${index + 1}: ${field} is too long.`);
+      }
+      if (!clean.id || !clean.vendor || !clean.product || ids.has(clean.id)) throw new Error('Every asset needs a unique id, vendor, and product.');
+      if (!!clean.cpe_vendor !== !!clean.cpe_product) throw new Error('Supply both cpe_vendor and cpe_product, or neither.');
+      clean.cpe_part = asset.cpe_part ?? 'a';
+      if (!['a', 'o', 'h'].includes(clean.cpe_part)) throw new Error('cpe_part must be a, o, or h.');
+      clean.exposure = asset.exposure ?? 'unknown';
+      clean.importance = asset.importance ?? 'standard';
+      if (!['internet', 'internal', 'unknown'].includes(clean.exposure) || !['critical', 'standard'].includes(clean.importance)) throw new Error('Exposure must be internet/internal/unknown; importance must be critical/standard.');
+      ids.add(clean.id);
+      return clean;
+    });
+  };
+  // Conservative dotted-numeric comparison; vendor suffixes and SemVer build
+  // metadata are not assumed to follow the same ordering across products.
+  const compareVersions = (a, b) => {
+    if (![a, b].every((v) => typeof v === 'string' && /^\d+(?:\.\d+)*$/.test(v) && v.length <= 160)) return null;
+    const left = a.split('.').map(BigInt), right = b.split('.').map(BigInt);
+    for (let i = 0; i < Math.max(left.length, right.length); i += 1) {
+      const x = left[i] ?? 0n, y = right[i] ?? 0n;
+      if (x !== y) return x > y ? 1 : -1;
+    }
+    return 0;
+  };
+  const versionMatch = (version, rule, cpeVersion) => {
+    if (!version) return null;
+    let constrained = false;
+    if (cpeVersion !== '*') {
+      if (cpeVersion === '-' || /[?\\]/.test(cpeVersion)) return null;
+      constrained = true;
+      // Exact vendor versions can be checked without ordering them.
+      if (version !== cpeVersion) {
+        const order = compareVersions(version, cpeVersion);
+        if (order === null) return null;
+        if (order !== 0) return false;
+      }
+    }
+    let outside = false;
+    for (const [field, direction, inclusive] of [
+      ['versionStartIncluding', 1, true], ['versionStartExcluding', 1, false],
+      ['versionEndIncluding', -1, true], ['versionEndExcluding', -1, false],
+    ]) {
+      if (rule[field] == null) continue;
+      constrained = true;
+      const cmp = compareVersions(version, rule[field]);
+      if (cmp === null) return null;
+      if (cmp * direction < 0 || (!inclusive && cmp === 0)) outside = true;
+    }
+    return constrained ? !outside : null;
+  };
+  const evidenceFor = (asset, item) => {
+    const kev = item.reports?.cisa_kev;
+    const vendorMatch = kev && same(asset.vendor, kev.vendor) && same(asset.product, kev.product);
+    const candidates = [];
+    let complex = false;
+    let visited = 0;
+    const walk = (node, depth) => {
+      if (!node || typeof node !== 'object' || depth > 8 || ++visited > 2000) { complex = true; return; }
+      if (node.negate === true || node.operator === 'AND' || (node.operator && node.operator !== 'OR')) complex = true;
+      if (Array.isArray(node.cpeMatch)) for (const rule of node.cpeMatch) {
+        if (rule?.vulnerable !== true || typeof rule.criteria !== 'string') continue;
+        const parts = rule.criteria.split(':');
+        // Escaped CPEs and environment-specific qualifiers need a full CPE engine.
+        if (parts.length !== 13 || parts[0] !== 'cpe' || parts[1] !== '2.3') continue;
+        if (parts[2] !== (asset.cpe_part || 'a') || !asset.cpe_vendor || !same(asset.cpe_vendor, parts[3]) || !same(asset.cpe_product, parts[4])) continue;
+        const supported = !rule.criteria.includes('\\') && parts.slice(6).every((part) => part === '*');
+        candidates.push({ criteria: rule.criteria, range: Object.fromEntries(Object.entries(rule).filter(([key]) => key.startsWith('version'))),
+          match: supported ? versionMatch(asset.version, rule, parts[5]) : null });
+      }
+      for (const field of ['nodes', 'children']) if (Array.isArray(node[field])) node[field].forEach((child) => walk(child, depth + 1));
+    };
+    const configs = item.reports?.nvd?.configurations;
+    if (Array.isArray(configs)) configs.forEach((config) => walk(config, 0));
+    if (!vendorMatch && !candidates.length) return null;
+    let status = 'needs-verification';
+    let reason = 'Exact CISA vendor/product match; affected-version evidence is unavailable or cannot be evaluated.';
+    if (candidates.length) {
+      if (complex || candidates.some((entry) => entry.match === null)) reason = 'CPE product matched, but complex applicability conditions or unsupported/missing versions require vendor verification.';
+      else if (candidates.some((entry) => entry.match)) {
+        status = 'version-match'; reason = 'Explicit CPE product mapping and supplied version match a supported NVD rule. Confirm applicability with the vendor.';
+      } else {
+        status = 'outside-reported-range'; reason = 'Supplied version falls outside the evaluated NVD rules. This is not a declaration that the asset is safe.';
+      }
+    }
+    if (same(item.reports?.nvd?.status, 'rejected')) { status = 'needs-verification'; reason = 'NVD marks this CVE rejected. Review the provider records before taking action.'; }
+    return { status, reason, cisa_product_match: !!vendorMatch, nvd_rules: candidates };
+  };
+  const buildReport = (assets, items, generatedAt) => {
+    const findings = [];
+    const matched = new Set();
+    let truncated = false;
+    outer: for (const asset of assets) for (const item of items) {
+      const evidence = evidenceFor(asset, item);
+      if (!evidence) continue;
+      if (findings.length >= 10000) { truncated = true; break outer; }
+      matched.add(asset.id);
+      findings.push({ asset, cve_id: item.cve_id, exploitation_status: item.exploitation_status,
+        ...evidence, required_action: item.reports?.cisa_kev?.required_action || 'Consult the vendor advisory.',
+        reports: item.reports });
+    }
+    const exploitation = { known_exploited: 0, reported_exploitation: 1, not_established: 2 };
+    findings.sort((a, b) => Number(a.status === 'outside-reported-range') - Number(b.status === 'outside-reported-range')
+      || (exploitation[a.exploitation_status] ?? 2) - (exploitation[b.exploitation_status] ?? 2)
+      || Number(b.asset.exposure === 'internet') - Number(a.asset.exposure === 'internet')
+      || Number(b.asset.importance === 'critical') - Number(a.asset.importance === 'critical')
+      || a.cve_id.localeCompare(b.cve_id) || a.asset.id.localeCompare(b.asset.id));
+    return { schema_version: 1, snapshot_generated_at: generatedAt,
+      scope: 'Retained CVE collection only. Inventory and exposure are user supplied; matches are not confirmed exposure. No match does not mean safe.',
+      asset_count: assets.length, findings, truncated,
+      unmatched_assets: truncated ? [] : assets.filter((asset) => !matched.has(asset.id)) };
+  };
+  return { parseInventory, compareVersions, versionMatch, buildReport };
+});

--- a/public/assets/inventory-core.test.js
+++ b/public/assets/inventory-core.test.js
@@ -1,0 +1,73 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const core = require('./inventory-core.js');
+const asset = { id: 'edge', vendor: 'Vendor', product: 'Server', version: '2.4', cpe_vendor: 'vendor', cpe_product: 'server', exposure: 'internet', importance: 'critical' };
+const fixture = (range = {}) => ({ cve_id: 'CVE-2026-1234', exploitation_status: 'known_exploited', reports: {
+  cisa_kev: { vendor: 'Vendor', product: 'Server' }, nvd: { configurations: [{ nodes: [{ operator: 'OR', cpeMatch: [
+    { vulnerable: true, criteria: 'cpe:2.3:a:vendor:server:*:*:*:*:*:*:*:*', ...range },
+  ] }] }] },
+} });
+const match = (item, overrides = {}) => core.buildReport([{ ...asset, ...overrides }], [item], '2026-09-01').findings[0];
+test('inventory rejects malformed, ambiguous and oversized inputs', () => {
+  assert.equal(core.parseInventory({ schema_version: 1, assets: [asset] }).length, 1);
+  for (const assets of [[asset, asset], [{ ...asset, version: 2 }], [{ ...asset, cpe_product: '' }], [{ ...asset, exposure: 'public' }], Array(201).fill(asset)]) {
+    assert.throws(() => core.parseInventory({ schema_version: 1, assets }));
+  }
+});
+test('numeric versions compare components, not lexical strings', () => {
+  assert.equal(core.compareVersions('2.10', '2.9'), 1);
+  assert.equal(core.compareVersions('2.4.0', '2.4'), 0);
+  assert.equal(core.compareVersions('1.0-rc1', '1.0'), null);
+  assert.equal(core.compareVersions('999999999999999999999', '2'), 1);
+});
+test('inclusive and exclusive boundaries are respected', () => {
+  assert.equal(match(fixture({ versionStartIncluding: '2.4', versionEndExcluding: '3' })).status, 'version-match');
+  assert.equal(match(fixture({ versionStartExcluding: '2.4' })).status, 'outside-reported-range');
+  assert.equal(match(fixture({ versionEndIncluding: '2.4' })).status, 'version-match');
+  assert.equal(match(fixture({ versionEndExcluding: '2.4' })).status, 'outside-reported-range');
+});
+test('missing versions and complex or unsupported applicability stay uncertain', () => {
+  assert.equal(match(fixture()).status, 'needs-verification');
+  assert.equal(match(fixture({ versionEndIncluding: '3' }), { version: '' }).status, 'needs-verification');
+  assert.equal(match(fixture({ versionEndIncluding: '3-rc1' })).status, 'needs-verification');
+  const item = fixture({ versionEndIncluding: '3' }); item.reports.nvd.configurations[0].operator = 'AND';
+  assert.equal(match(item).status, 'needs-verification');
+  item.reports.nvd.configurations[0].operator = 'OR'; item.reports.nvd.configurations[0].negate = true;
+  assert.equal(match(item).status, 'needs-verification');
+});
+test('CISA-only product matches never imply version exposure and unmatched assets stay explicit', () => {
+  assert.equal(match(fixture(), { cpe_vendor: '', cpe_product: '' }).status, 'needs-verification');
+  const report = core.buildReport([{ ...asset, vendor: 'Different', cpe_vendor: 'different' }], [fixture()], '2026-09-01');
+  assert.equal(report.findings.length, 0); assert.equal(report.unmatched_assets.length, 1);
+});
+test('rejected CVEs remain review findings even when versions match', () => {
+  const item = fixture({ versionEndIncluding: '3' }); item.reports.nvd.status = 'Rejected';
+  assert.equal(match(item).status, 'needs-verification');
+});
+test('exploit evidence and asset context determine ordering without suppressing outside-range evidence', () => {
+  const item = fixture({ versionEndIncluding: '3' });
+  const report = core.buildReport([{ ...asset, id: 'internal', exposure: 'internal' }, asset, { ...asset, id: 'patched', version: '4' }], [item], '2026-09-01');
+  assert.deepEqual(report.findings.map((row) => row.asset.id), ['edge', 'internal', 'patched']);
+});
+
+test('exact versions, platform qualifiers and CPE parts remain distinct', () => {
+  const item = fixture();
+  const rule = item.reports.nvd.configurations[0].nodes[0].cpeMatch[0];
+  rule.criteria = 'cpe:2.3:a:vendor:server:2.4:*:*:*:*:*:*:*';
+  assert.equal(match(item).status, 'version-match');
+  assert.equal(match(item, { version: '2.5' }).status, 'outside-reported-range');
+  rule.criteria = 'cpe:2.3:a:vendor:server:2.4:*:*:*:*:windows:*:*';
+  assert.equal(match(item).status, 'needs-verification');
+  rule.criteria = 'cpe:2.3:o:vendor:server:2.4:*:*:*:*:*:*:*';
+  assert.equal(match(item).status, 'needs-verification');
+  assert.equal(match(item, { cpe_part: 'o' }).status, 'version-match');
+});
+
+test('separate OR ranges retain a matching version and do not mutate evidence', () => {
+  const item = fixture({ versionEndExcluding: '2' });
+  const rules = item.reports.nvd.configurations[0].nodes[0].cpeMatch;
+  rules.push({ ...rules[0], versionEndExcluding: '3' });
+  const before = JSON.stringify(item);
+  assert.equal(match(item).status, 'version-match');
+  assert.equal(JSON.stringify(item), before);
+});

--- a/public/assets/inventory.js
+++ b/public/assets/inventory.js
@@ -1,0 +1,68 @@
+(() => {
+  'use strict';
+  const core = window.SwiftIOCInventory;
+  const root = document.querySelector('[data-inventory-root]');
+  if (!root || !core) return;
+  const get = (name) => root.querySelector(`[data-inventory-${name}]`);
+  let assets = [], snapshot = null, report = null, limit = 20, importId = 0, newest = 0;
+  const save = (value, filename) => {
+    const url = URL.createObjectURL(new Blob([JSON.stringify(value, null, 2) + '\n'], { type: 'application/json' }));
+    const a = document.createElement('a'); a.href = url; a.download = filename;
+    document.body.appendChild(a); a.click(); a.remove(); setTimeout(() => URL.revokeObjectURL(url), 1000);
+  };
+  const add = (parent, tag, value) => {
+    const node = document.createElement(tag); node.textContent = value; parent.appendChild(node); return node;
+  };
+  const render = (notice = '') => {
+    get('results').replaceChildren();
+    get('export').disabled = !report;
+    get('clear').disabled = !assets.length;
+    get('more').hidden = !report || report.findings.length <= limit;
+    get('status').textContent = notice || (!assets.length ? 'Import an inventory to begin. No match does not mean safe.'
+      : !report ? `${assets.length} assets loaded. Waiting for a usable CVE snapshot; export is disabled.`
+      : `${assets.length} assets · ${report.findings.length} findings · ${report.unmatched_assets.length} assets without a match. Snapshot: ${report.snapshot_generated_at}. No match does not mean safe.${report.truncated ? ' Report limit reached; some assets were not fully assessed. Split the inventory into smaller files.' : ''}`);
+    if (!report) return;
+    for (const finding of report.findings.slice(0, limit)) {
+      const card = add(get('results'), 'article', '');
+      add(card, 'h3', `${finding.asset.id} · ${finding.cve_id}`);
+      add(card, 'p', `${finding.status.replaceAll('-', ' ')} · ${finding.exploitation_status.replaceAll('_', ' ')} · ${finding.asset.exposure} exposure · ${finding.asset.importance} importance`);
+      add(card, 'p', `${finding.asset.vendor} / ${finding.asset.product} / ${finding.asset.version || 'version unknown'}`);
+      add(card, 'p', finding.reason);
+      add(card, 'p', `Action: ${finding.required_action}`);
+      const details = add(card, 'details', ''); add(details, 'summary', 'Matching evidence and provider reports');
+      add(details, 'pre', JSON.stringify({ cisa_product_match: finding.cisa_product_match, nvd_rules: finding.nvd_rules, reports: finding.reports }, null, 2));
+    }
+    if (report.unmatched_assets.length) add(get('results'), 'p', `No retained match: ${report.unmatched_assets.map((asset) => asset.id).join(', ')}. Check naming, mappings, and collection coverage.`);
+  };
+  const rebuild = () => {
+    report = assets.length && snapshot ? core.buildReport(assets, snapshot.items, snapshot.generated_at) : null;
+    limit = 20; render();
+  };
+  window.addEventListener('swiftioc:vulnerability-snapshot', (event) => {
+    const next = event.detail, time = Date.parse(next?.generated_at);
+    snapshot = next && Number.isFinite(time) && time <= Date.now() && time >= newest ? next : null;
+    if (snapshot) newest = time;
+    rebuild();
+  });
+  get('file').addEventListener('change', async (event) => {
+    const request = ++importId;
+    const file = event.target.files?.[0]; if (!file) return;
+    try {
+      if (file.size > 500000) throw new Error('Inventory must be at most 500 KB.');
+      const contents = await file.text();
+      if (request !== importId) return;
+      const next = core.parseInventory(JSON.parse(contents));
+      assets = next; rebuild();
+    } catch (error) {
+      if (request === importId) render(`Import rejected: ${error.message}. ${assets.length ? 'Previous inventory retained.' : 'No inventory loaded.'}`);
+    } finally { if (request === importId) event.target.value = ''; }
+  });
+  get('clear').addEventListener('click', () => { ++importId; assets = []; get('file').value = ''; rebuild(); });
+  get('more').addEventListener('click', () => { limit += 20; render(); });
+  get('export').addEventListener('click', () => { if (report) save(report, 'swiftioc-exposure-report.json'); });
+  get('sample').addEventListener('click', () => save({ schema_version: 1, assets: [
+    { id: 'example-edge-service', vendor: 'Example Vendor', product: 'Example Server', version: '2.4.1',
+      cpe_vendor: 'example_vendor', cpe_product: 'example_server', exposure: 'internet', importance: 'critical' },
+  ] }, 'swiftioc-inventory-sample.json'));
+  render();
+})();

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -3637,3 +3637,12 @@ input.lookup-input { border-radius: 0.3rem; background: var(--bg-color); }
 .campaign-search-results[hidden] { display: none; }
 .campaign-related-list { max-height: 18rem; overflow: auto; overscroll-behavior: contain; }
 .campaign-search-results .campaign-related-node { overflow-wrap: anywhere; text-align: left; }
+
+.inventory-actions { display: flex; flex-wrap: wrap; align-items: end; gap: .75rem; margin: 1rem 0; }
+.inventory-actions label { display: grid; gap: .4rem; min-width: 0; max-width: 100%; }
+.inventory-actions input { max-width: 100%; }
+.inventory-results { display: grid; gap: .75rem; }
+.inventory-results article { padding: 1rem; border: 1px solid var(--border-control); border-radius: .3rem; overflow-wrap: anywhere; }
+.inventory-results h3 { margin-top: 0; font-size: 1rem; }
+.inventory-results pre { max-height: 20rem; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere; font-size: .75rem; }
+.inventory-results summary { cursor: pointer; }

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=20" />
+    <link rel="stylesheet" href="assets/styles.css?v=21" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -319,6 +319,20 @@
           </div>
           <a class="button ghost" href="collections/vulnerabilities.json" data-vulnerability-download>Collection JSON ↗</a>
         </div>
+        <details class="collection-notes inventory-desk" data-inventory-root>
+          <summary>Exposure report · match your software inventory</summary>
+          <p>Import up to 200 assets as JSON. Your inventory stays in this tab and is never uploaded or saved to browser storage. Explicit CPE mapping enables conservative version checks; product-only matches need verification.</p>
+          <div class="inventory-actions">
+            <label>Inventory JSON <input type="file" accept=".json,application/json" data-inventory-file /></label>
+            <button type="button" class="button ghost" data-inventory-sample>Download sample</button>
+            <button type="button" class="button ghost" data-inventory-export disabled>Export report</button>
+            <button type="button" class="button ghost" data-inventory-clear disabled>Clear inventory</button>
+          </div>
+          <p data-inventory-status role="status">Import an inventory to begin. No match does not mean safe.</p>
+          <p>Order: findings needing review first, known exploitation, internet exposure, then critical assets. Outside-range findings come last. Exposure and importance are supplied by you.</p>
+          <div data-inventory-results class="inventory-results"></div>
+          <button type="button" class="button ghost" data-inventory-more hidden>Show more findings</button>
+        </details>
         <details class="collection-notes briefing-settings" data-briefing-settings>
           <summary>Personal briefing · follow vendors &amp; products</summary>
           <p>Match exact CISA vendor and product fields. NVD-only records without these fields cannot be matched. Watches stay in this browser; a product match does not confirm your installed version is affected.</p>
@@ -1023,7 +1037,9 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=20"></script>
-    <script defer src="assets/dashboard.js?v=20"></script>
+    <script defer src="assets/dashboard-core.js?v=21"></script>
+    <script defer src="assets/inventory-core.js?v=21"></script>
+    <script defer src="assets/inventory.js?v=21"></script>
+    <script defer src="assets/dashboard.js?v=21"></script>
   </body>
 </html>

--- a/scripts/test_inventory_ui.cjs
+++ b/scripts/test_inventory_ui.cjs
@@ -1,0 +1,68 @@
+const { chromium } = require('playwright');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+(async () => {
+  const browser = await chromium.launch({ headless: true, ...(process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH } : {}) });
+  try {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+    const errors = []; page.on('pageerror', (error) => errors.push(error.message));
+    let failure = false;
+    const generated = new Date(Date.now() - 60000).toISOString();
+    await page.route('**/collections/vulnerabilities.json', (route) => route.fulfill({ status: failure ? 503 : 200,
+      contentType: 'application/json', body: JSON.stringify({ schema_version: 1, generated_at: generated, items: [{
+        cve_id: 'CVE-2026-1234', sources: ['cisa_kev'], exploitation_status: 'known_exploited', reports: {
+          cisa_kev: { vendor: 'Vendor', product: 'Server', required_action: 'Update' },
+          nvd: { configurations: [{ nodes: [{ operator: 'OR', cpeMatch: [{ vulnerable: true,
+            criteria: 'cpe:2.3:a:vendor:server:*:*:*:*:*:*:*:*', versionEndExcluding: '3.0' }] }] }] },
+        },
+      }] }) }));
+    await page.goto(process.env.BASE_URL || 'http://127.0.0.1:8765');
+    await page.locator('[data-vulnerability-status]').filter({ hasText: '1 of 1 CVEs' }).waitFor();
+    await page.locator('[data-inventory-root] > summary').click();
+    const assets = [{ id: '<img src=x onerror=alert(1)>', vendor: 'Vendor', product: 'Server', version: '2.5', cpe_vendor: 'vendor', cpe_product: 'server', exposure: 'internet', importance: 'critical' }];
+    const upload = (value) => page.locator('[data-inventory-file]').setInputFiles({ name: 'inventory.json', mimeType: 'application/json', buffer: Buffer.from(JSON.stringify(value)) });
+    await upload({ schema_version: 1, assets });
+    await page.locator('[data-inventory-status]').filter({ hasText: '1 findings' }).waitFor();
+    assert.match(await page.locator('[data-inventory-results]').innerText(), /version match/);
+    assert.equal(await page.locator('[data-inventory-results] img').count(), 0);
+    const [download] = await Promise.all([page.waitForEvent('download'), page.locator('[data-inventory-export]').click()]);
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'inventory-test-'));
+    try {
+      const file = path.join(dir, 'report.json'); await download.saveAs(file);
+      const report = JSON.parse(await fs.readFile(file, 'utf8'));
+      assert.equal(report.findings[0].status, 'version-match');
+      assert.equal(report.snapshot_generated_at, generated);
+    } finally { await fs.rm(dir, { recursive: true }); }
+    await upload({ schema_version: 1, assets: [assets[0], assets[0]] });
+    await page.locator('[data-inventory-status]').filter({ hasText: 'Import rejected' }).waitFor();
+    assert.equal(await page.locator('[data-inventory-export]').isDisabled(), false);
+    failure = true; await page.locator('[data-vulnerability-refresh]').click();
+    await page.locator('[data-vulnerability-status]').filter({ hasText: 'Collection unavailable' }).waitFor();
+    assert.equal(await page.locator('[data-inventory-export]').isDisabled(), true);
+    assert.equal(await page.locator('[data-inventory-results] article').count(), 0);
+    failure = false; await page.locator('[data-vulnerability-refresh]').click();
+    await page.locator('[data-inventory-status]').filter({ hasText: '1 findings' }).waitFor();
+    await page.setViewportSize({ width: 390, height: 844 });
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth > innerWidth), false);
+    if (process.env.SCREENSHOT_DIR) {
+      await page.locator('[data-inventory-root]').scrollIntoViewIfNeeded();
+      await page.screenshot({ path: `${process.env.SCREENSHOT_DIR}/inventory-mobile.png` });
+    }
+    for (const generated_at of ['2000-01-01T00:00:00Z', '2999-01-01T00:00:00Z']) {
+      await page.evaluate((generated_at) => window.dispatchEvent(new CustomEvent('swiftioc:vulnerability-snapshot', { detail: { items: [], generated_at } })), generated_at);
+      assert.equal(await page.locator('[data-inventory-export]').isDisabled(), true);
+      assert.equal(await page.locator('[data-inventory-results] article').count(), 0);
+    }
+    await page.locator('[data-inventory-clear]').click();
+    assert.equal(await page.locator('[data-inventory-export]').isDisabled(), true);
+    await upload({ schema_version: 1, assets });
+    await page.reload();
+    await page.locator('[data-inventory-root] > summary').click();
+    await page.locator('[data-inventory-status]').filter({ hasText: 'Import an inventory' }).waitFor();
+    assert.match(await page.locator('[data-inventory-status]').innerText(), /Import an inventory/);
+    assert.deepEqual(errors, []);
+    console.log('PASS: inventory import, safe rendering, evidence export, invalid replacement, refresh failure/retry, mobile layout, clear, and tab-only lifetime.');
+  } finally { await browser.close(); }
+})().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/swiftioc/parsers.py
+++ b/swiftioc/parsers.py
@@ -267,6 +267,7 @@ def fetch_nvd_recent(url: str, ref_url: str, source: str, ws: datetime, *, api_k
                     "published_at": cve.get("published"), "modified_at": cve.get("lastModified"),
                     "status": cve.get("vulnStatus"), "severity": severity,
                     "description": description,
+                    "configurations": cve.get("configurations", []),
                 }},
             )
         )

--- a/tests/test_swiftioc.py
+++ b/tests/test_swiftioc.py
@@ -1364,3 +1364,16 @@ def test_collect_from_yaml_single_worker_matches(monkeypatch):
     rows_parallel = run(4)
     rows_serial = run(1)
     assert [r.indicator for r in rows_parallel] == [r.indicator for r in rows_serial]
+
+
+def test_nvd_retains_applicability_conditions_for_inventory_matching(monkeypatch):
+    now = si.now_utc()
+    configurations = [{"operator": "AND", "nodes": [{"operator": "OR", "cpeMatch": [{
+        "vulnerable": True, "criteria": "cpe:2.3:a:vendor:server:*:*:*:*:*:*:*:*",
+        "versionStartIncluding": "2.0", "versionEndExcluding": "3.0",
+    }]}]}]
+    payload = {"vulnerabilities": [{"cve": {"id": "CVE-2026-1234",
+        "published": si.iso(now), "lastModified": si.iso(now), "configurations": configurations}}]}
+    monkeypatch.setattr(si, "http_get", lambda *args, **kwargs: json.dumps(payload))
+    rows = si.fetch_nvd_recent("https://example.com/nvd", "ref", "nvd", now - timedelta(hours=1))
+    assert rows[0].vulnerability["nvd"]["configurations"] == configurations


### PR DESCRIPTION
Analysts can import a software inventory in the CVE section and get a report connecting their assets to retained vulnerability evidence. The downloadable sample defines asset ID, vendor/product, installed version, user-supplied exposure and importance, and optional explicit CPE vendor/product/part mapping. Inventory stays in this tab’s memory; it is never uploaded or persisted in browser storage. Imports are validated and capped at 200 assets/500 KB; invalid replacements preserve the previous inventory.

The collector now retains NVD applicability configurations. Exact CISA product matches remain needs-verification findings; explicit CPE mapping enables conservative exact-version and dotted-numeric boundary checks. Results distinguish version matches, uncertain applicability, and versions outside the reported ranges. Complex AND/negated conditions, platform qualifiers, unfamiliar version ordering, missing data, and rejected CVEs require verification. No match or outside-range result is not a safety verdict.

Findings prioritize review over outside-range results, exploitation evidence, internet exposure, and critical assets. Each shows the matching explanation, remediation, and expandable provider evidence. JSON exports include the source snapshot timestamp and unmatched assets. Display pagination and a disclosed 10,000-finding cap bound output. Refresh start/failure and future/out-of-order snapshots clear the report and disable export. Clearing or closing the tab removes the inventory. This is an on-demand assessment, not a scanner, SBOM parser, or change-alert service.

Validation: 180 Python tests, 53 JavaScript unit tests, Ruff, and four browser suites passed. Pyright reports zero errors with five environment import-source warnings. Tests cover version boundaries, exact versions, CPE parts, unsupported/complex conditions, import validation, evidence export, safe rendering, failed refresh/retry, stale/future snapshots, mobile overflow, and tab-only lifetime. Inspected the mobile rendering. CI includes the inventory unit tests and syntax checks; README documents setup and limitations. Frontend assets advance together to v21.