### PR TITLE
Polish dashboard entrances, evidence reveals, and interaction feedback

### DIFF
--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -542,7 +542,7 @@ test('exploited and ransomware views require explicit evidence and never fall ba
 test('vulnerability release uses coordinated new asset cache keys', () => {
   const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
   for (const asset of ['styles.css', 'dashboard-core.js', 'dashboard.js']) {
-    assert.ok(html.includes(`assets/${asset}?v=21`));
+    assert.ok(html.includes(`assets/${asset}?v=23`));
   }
 });
 

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -3646,3 +3646,54 @@ input.lookup-input { border-radius: 0.3rem; background: var(--bg-color); }
 .inventory-results h3 { margin-top: 0; font-size: 1rem; }
 .inventory-results pre { max-height: 20rem; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere; font-size: .75rem; }
 .inventory-results summary { cursor: pointer; }
+
+/* Quiet interaction feedback: content remains visible without animation support. */
+.button, .button-link, .hero-download, .nav-links a,
+.discovery-lenses button, .vulnerability-views button {
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+.vulnerability-card, .inventory-results article, .threat-card {
+  transition: border-color 180ms ease, box-shadow 180ms ease;
+}
+.vulnerability-card:focus-within, .inventory-results article:focus-within,
+.threat-card:focus-within {
+  border-color: var(--accent);
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+.nav-links a { text-underline-offset: .4em; }
+.nav-links a:hover, .nav-links a:focus-visible { text-decoration: underline; }
+
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes desk-enter {
+    from { opacity: .35; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  @keyframes desk-detail-enter {
+    from { opacity: .55; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  .page-header-main > div { animation: desk-enter 460ms cubic-bezier(.2,.7,.2,1) both; }
+  .page-header .hero-download { animation: desk-enter 460ms 70ms cubic-bezier(.2,.7,.2,1) both; }
+  .vulnerability-card, .inventory-results article, .threat-card {
+    animation: desk-enter 280ms cubic-bezier(.2,.7,.2,1) both;
+  }
+  .vulnerability-card:nth-child(2), .inventory-results article:nth-child(2), .threat-card:nth-child(2) { animation-delay: 30ms; }
+  .vulnerability-card:nth-child(3), .inventory-results article:nth-child(3), .threat-card:nth-child(3) { animation-delay: 60ms; }
+  .vulnerability-card:nth-child(4), .inventory-results article:nth-child(4), .threat-card:nth-child(4) { animation-delay: 90ms; }
+  .vulnerability-card:nth-child(n+13), .inventory-results article:nth-child(n+13), .threat-card:nth-child(n+13) { animation: none; }
+  .collection-notes[open] > :not(summary), .campaign-feed-evidence[open] > :not(summary),
+  .inventory-results details[open] > :not(summary), .vulnerability-card details[open] > :not(summary) {
+    animation: desk-detail-enter 180ms ease-out both;
+  }
+  .button, .button-link, .hero-download {
+    transition: transform 160ms ease, background-color 160ms ease, border-color 160ms ease, color 160ms ease;
+  }
+  .button:not(:disabled):active, .button-link:active { transform: translateY(1px); }
+  @media (hover: hover) and (pointer: fine) {
+    .button:not(:disabled):hover, .button-link:hover { transform: translateY(-2px); }
+    .vulnerability-card:hover, .inventory-results article:hover, .threat-card:hover {
+      border-color: var(--accent);
+      box-shadow: 0 5px 16px rgb(0 0 0 / .12);
+    }
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=21" />
+    <link rel="stylesheet" href="assets/styles.css?v=23" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -1037,9 +1037,9 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=21"></script>
-    <script defer src="assets/inventory-core.js?v=21"></script>
-    <script defer src="assets/inventory.js?v=21"></script>
-    <script defer src="assets/dashboard.js?v=21"></script>
+    <script defer src="assets/dashboard-core.js?v=23"></script>
+    <script defer src="assets/inventory-core.js?v=23"></script>
+    <script defer src="assets/inventory.js?v=23"></script>
+    <script defer src="assets/dashboard.js?v=23"></script>
   </body>
 </html>


### PR DESCRIPTION
Adds brief header and finding-card entrances, lightly staggered initial results, evidence disclosure reveals, and subtle hover/press feedback. Keyboard focus receives a visible inset accent on finding cards. Entrance animation is disabled after the first twelve cards to bound work on long reports. Hover movement applies only to precise hover-capable pointers.

All new motion is gated by prefers-reduced-motion: no-preference; content remains visible without animation. These are finite interaction animations, with no looping decoration or added JavaScript. Coordinated frontend asset keys advance to v23.

Validation: 53 frontend unit tests and the dashboard layout browser suite passed. Additional browser checks verified normal-motion entrance styles, expanded evidence animation, changing reduced-motion preferences at runtime, content visibility, no script errors, and no horizontal overflow at 390px. Layout regressions cover keyboard disclosures, graph selection, mobile navigation, shared row counts, and no-JavaScript downloads. Whitespace checks passed.