### PR TITLE
Add a scanning header grid and selected graph connection effects

### DIFF
--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -542,7 +542,7 @@ test('exploited and ransomware views require explicit evidence and never fall ba
 test('vulnerability release uses coordinated new asset cache keys', () => {
   const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
   for (const asset of ['styles.css', 'dashboard-core.js', 'dashboard.js']) {
-    assert.ok(html.includes(`assets/${asset}?v=23`));
+    assert.ok(html.includes(`assets/${asset}?v=24`));
   }
 });
 

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -3697,3 +3697,46 @@ input.lookup-input { border-radius: 0.3rem; background: var(--bg-color); }
     }
   }
 }
+
+/* Instrument-panel detail, confined to navigation and the graph. */
+.page-header { position: relative; isolation: isolate; overflow: hidden; padding-block: 1.5rem; border-block: 1px solid var(--border-control); }
+.page-header::before {
+  content: ''; position: absolute; z-index: -1; inset: 0 0 0 52%; pointer-events: none;
+  background-image: linear-gradient(rgb(167 196 124 / .12) 1px, transparent 1px), linear-gradient(90deg, rgb(167 196 124 / .12) 1px, transparent 1px);
+  background-size: 24px 24px;
+  mask-image: linear-gradient(90deg, transparent, #000);
+}
+.campaign-inspector { border-top: 2px solid var(--accent); }
+.campaign-node.is-selected .campaign-node-core { stroke: #dcf3b0; stroke-width: 3; }
+.campaign-node.is-connected .campaign-node-core { stroke: #c5d5af; }
+.hero-download { position: relative; overflow: hidden; }
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes desk-grid-scan {
+    from { transform: translateX(-160%); opacity: 0; }
+    15%, 75% { opacity: .5; }
+    to { transform: translateX(280%); opacity: 0; }
+  }
+  @keyframes desk-link-trace { from { stroke-dashoffset: 24; } to { stroke-dashoffset: 0; } }
+  @keyframes desk-node-lock {
+    from { stroke-width: 5; stroke-opacity: .45; }
+    to { stroke-width: 3; stroke-opacity: 1; }
+  }
+  @keyframes desk-control-sheen {
+    from { transform: translateX(-180%) skewX(-20deg); }
+    to { transform: translateX(380%) skewX(-20deg); }
+  }
+  .page-header::after {
+    content: ''; position: absolute; z-index: -1; inset: 0 0 0 65%; pointer-events: none;
+    background: linear-gradient(90deg, transparent, rgb(167 196 124 / .14), transparent);
+    animation: desk-grid-scan 2400ms ease-in-out 2 both;
+  }
+  .campaign-edge.is-connected { stroke-dasharray: 5 7; animation: desk-link-trace 1200ms linear 3; }
+  .campaign-node.is-selected .campaign-node-core { animation: desk-node-lock 320ms ease-out; }
+  .hero-download::after {
+    content: ''; position: absolute; inset: 0; width: 35%; pointer-events: none;
+    background: linear-gradient(90deg, transparent, rgb(220 243 176 / .2), transparent);
+    transform: translateX(-180%) skewX(-20deg);
+  }
+  .hero-download:hover::after, .hero-download:focus-visible::after { animation: desk-control-sheen 600ms ease-out; }
+}
+@media (max-width: 640px) { .page-header::before { inset-inline-start: 72%; opacity: .5; } }

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -3707,8 +3707,8 @@ input.lookup-input { border-radius: 0.3rem; background: var(--bg-color); }
   mask-image: linear-gradient(90deg, transparent, #000);
 }
 .campaign-inspector { border-top: 2px solid var(--accent); }
-.campaign-node.is-selected .campaign-node-core { stroke: #dcf3b0; stroke-width: 3; }
-.campaign-node.is-connected .campaign-node-core { stroke: #c5d5af; }
+.campaign-node:is(.pivot, .indicator).is-selected .campaign-node-core { stroke: #dcf3b0; stroke-width: 3; }
+.campaign-node:is(.pivot, .indicator).is-connected .campaign-node-core { stroke: #c5d5af; }
 .hero-download { position: relative; overflow: hidden; }
 @media (prefers-reduced-motion: no-preference) {
   @keyframes desk-grid-scan {

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=23" />
+    <link rel="stylesheet" href="assets/styles.css?v=24" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -1038,9 +1038,9 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=23"></script>
-    <script defer src="assets/inventory-core.js?v=23"></script>
-    <script defer src="assets/inventory.js?v=23"></script>
-    <script defer src="assets/dashboard.js?v=23"></script>
+    <script defer src="assets/dashboard-core.js?v=24"></script>
+    <script defer src="assets/inventory-core.js?v=24"></script>
+    <script defer src="assets/inventory.js?v=24"></script>
+    <script defer src="assets/dashboard.js?v=24"></script>
   </body>
 </html>


### PR DESCRIPTION
Adds a subtle header grid with a finite scan, a highlight sweep on the main download control, moving dashes on selected graph connections, and a short selected-node outline animation. Header borders and inspector accents provide a more technical visual treatment without changing intelligence content.

Effects stop within five seconds and run only when reduced motion is not requested. The grid remains a static decorative layer for reduced-motion users; pseudo-elements cannot intercept input. Mobile grid coverage is reduced, and frontend asset keys move together to v24. The merged Splunk link is preserved.

Validation: 53 frontend unit tests, the dashboard layout browser suite, and direct browser checks for selected graph animation, header scan, live reduced-motion changes, and mobile overflow passed. Inspected the rendered header screenshot. PR #106 merged during development; this is a follow-up against current main.