### PR TITLE
Automatically generate Splunk hunts for the investigation queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ For example, a high-confidence IP from two source identifiers starts at 88 and d
 
 The `high_confidence` feed includes records at or above the threshold (default 80) **or with at least two source identifiers**. Review provenance, age, and local context before using any feed for blocking. Use the observable collection when an integration must exclude CVE IDs.
 
+## Investigation queue SPL
+
+Adding observables to the investigation queue automatically builds a copyable Splunk hunt for those selected values. The query updates on removal and supports IPs/CIDRs, exact DNS domains, full URLs, and MD5/SHA-1/SHA-256. Unsupported entries are listed explicitly; an empty supported selection disables export. Replace `YOUR_INDEX` and map the documented event fields before use. Results retain all matching queued IOC identities. This is a bounded triage query; use the lookup-based Splunk library for full-feed matching. Validate execution in your own Splunk deployment.
+
 ## Feeds and integrations
 
 **[Splunk hunt library](https://harsim.ca/SwiftIOC-Automated-Threat-Intelligence-Collector/splunk/)** — copy-ready SPL for source/destination IPs, exact DNS domains, SHA-256 hashes, and exact URLs, with lookup preparation and field-mapping instructions.

--- a/public/assets/dashboard-core.js
+++ b/public/assets/dashboard-core.js
@@ -198,6 +198,50 @@
     .map((value) => `${' '.repeat(indent)}- ${JSON.stringify(value)}`)
     .join('\n');
 
+  const rowsToSpl = (value) => {
+    const rows = Array.isArray(value) ? value : [];
+    const clauses = [], skipped = [], seen = new Set();
+    for (const row of rows) {
+      const type = lower(row?.type);
+      let indicator = refang(row?.indicator);
+      let condition = '';
+      const quote = JSON.stringify;
+      if (!indicator || /[\u0000-\u001f\u007f]/.test(indicator)) { skipped.push(row); continue; }
+      if (['ipv4', 'ipv6', 'ipv4_cidr', 'ipv6_cidr', 'domain'].includes(type)) {
+        const validated = detectionRows([row])[0];
+        if (validated) {
+          indicator = validated.indicator.toLowerCase();
+          if (type === 'domain') condition = `lower(rtrim(trim(query), "."))=${quote(indicator)}`;
+          else {
+            const network = type.endsWith('_cidr') ? indicator : `${indicator}/${type === 'ipv6' ? 128 : 32}`;
+            condition = `(cidrmatch(${quote(network)}, src_ip) OR cidrmatch(${quote(network)}, dest_ip))`;
+          }
+        }
+      } else if (['md5', 'sha1', 'sha256'].includes(type)) {
+        const length = { md5: 32, sha1: 40, sha256: 64 }[type];
+        if (new RegExp(`^[a-f0-9]{${length}}$`, 'i').test(indicator)) {
+          indicator = indicator.toLowerCase();
+          condition = `lower(trim(${type}))=${quote(indicator)}`;
+        }
+      } else if (type === 'url') {
+        try {
+          if (['http:', 'https:'].includes(new URL(indicator).protocol)) condition = `url=${quote(indicator)}`;
+        } catch { /* Unsupported URL remains in the skipped list. */ }
+      }
+      if (!condition) { skipped.push(row); continue; }
+      const key = `${type}:${indicator}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      clauses.push(`    if(${condition}, ${quote(key)}, null())`);
+    }
+    return { included: seen.size, skipped,
+      spl: clauses.length ? 'index=YOUR_INDEX earliest=-24h latest=now\n'
+        + '| fields _time host user src_ip dest_ip query url md5 sha1 sha256 action\n'
+        + '| eval swiftioc_matches=mvappend(\n' + clauses.join(',\n') + ',\n    null())\n'
+        + '| where mvcount(swiftioc_matches)>0\n'
+        + '| table _time host user src_ip dest_ip query url action swiftioc_matches\n' : '' };
+  };
+
   const rowsToSigma = (value) => {
     const rows = detectionRows(value);
     const addresses = rows.filter((row) => /^ipv[46]$/.test(row.type)).map((row) => row.indicator);
@@ -888,6 +932,7 @@
     refang,
     rowsToCsv,
     rowsToSigma,
+    rowsToSpl,
     rowsToSuricata,
     writeViewUrl,
   };

--- a/public/assets/dashboard-core.test.js
+++ b/public/assets/dashboard-core.test.js
@@ -542,7 +542,7 @@ test('exploited and ransomware views require explicit evidence and never fall ba
 test('vulnerability release uses coordinated new asset cache keys', () => {
   const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
   for (const asset of ['styles.css', 'dashboard-core.js', 'dashboard.js']) {
-    assert.ok(html.includes(`assets/${asset}?v=23`));
+    assert.ok(html.includes(`assets/${asset}?v=25`));
   }
 });
 
@@ -688,4 +688,28 @@ test('graph search keeps provider, feed, and tag matching literal', () => {
   assert.equal(core.graphNodeMatches(indicator, 'CINS ARMY'), true);
   assert.equal(core.graphNodeMatches(indicator, 'family[.]variant'), true);
   assert.equal(core.graphNodeMatches(indicator, 'family.variant'), false);
+});
+
+test('selected-IOC SPL includes exact typed evidence and never emits an empty broad hunt', () => {
+  assert.equal(core.rowsToSpl([]).spl, '');
+  const hunt = core.rowsToSpl([
+    { type: 'ipv4', indicator: '1[.]2[.]3[.]4' }, { type: 'ipv6', indicator: '2001:db8::1' },
+    { type: 'ipv4_cidr', indicator: '10.0.0.0/8' }, { type: 'domain', indicator: 'Example[.]TEST' },
+    { type: 'sha256', indicator: 'A'.repeat(64) }, { type: 'cve', indicator: 'CVE-2026-1234' },
+  ]);
+  assert.equal(hunt.included, 5); assert.equal(hunt.skipped.length, 1);
+  assert.ok(hunt.spl.includes('cidrmatch("1.2.3.4/32", src_ip) OR cidrmatch("1.2.3.4/32", dest_ip)'));
+  assert.ok(hunt.spl.includes('2001:db8::1/128'));
+  assert.ok(hunt.spl.includes('lower(rtrim(trim(query), "."))="example.test"'));
+  assert.ok(hunt.spl.includes('| where mvcount(swiftioc_matches)>0'));
+});
+
+test('selected URL SPL preserves case and escapes values as eval literals', () => {
+  const indicator = 'hxxps://example[.]test/Payload?q="x"|makeresults';
+  const hunt = core.rowsToSpl([{ type: 'url', indicator }, { type: 'url', indicator: 'https://example.test/payload' }]);
+  assert.equal(hunt.included, 2);
+  assert.ok(hunt.spl.includes('url=' + JSON.stringify(core.refang(indicator))));
+  assert.ok(!hunt.spl.includes('lower(url)'));
+  assert.equal(core.rowsToSpl([{ type: 'url', indicator: 'https://x.test/\n|makeresults' }]).spl, '');
+  assert.equal(core.rowsToSpl([{ type: 'ipv4', indicator: '999.1.1.1' }]).skipped.length, 1);
 });

--- a/public/assets/dashboard.js
+++ b/public/assets/dashboard.js
@@ -414,9 +414,26 @@
     const sigma = qs('[data-investigation-sigma]', root);
     const suricata = qs('[data-investigation-suricata]', root);
     const clear = qs('[data-investigation-clear]', root);
+    const splCode = qs('[data-investigation-spl-code]', root);
+    const splStatus = qs('[data-investigation-spl-status]', root);
+    const splCopy = qs('[data-investigation-spl-copy]', root);
+    const splDownload = qs('[data-investigation-spl-download]', root);
+    let currentSpl = '';
+    splCopy?.addEventListener('click', () => {
+      if (currentSpl) copyOrPrompt(currentSpl, 'Selected-IOC SPL copied. Map your event fields before running.');
+    });
+    splDownload?.addEventListener('click', () => {
+      if (currentSpl) downloadDetection(currentSpl, 'swiftioc-selected-iocs.spl', 'text/plain');
+    });
 
     const render = (rows) => {
       root.hidden = !rows.length;
+      const hunt = dashboardCore.rowsToSpl(rows);
+      currentSpl = hunt.spl;
+      setText(splCode, currentSpl || 'Add a supported observable to generate SPL.');
+      setText(splStatus, `${hunt.included} queued IOCs included. ${hunt.skipped.length} unsupported or invalid entries skipped${hunt.skipped.length ? ': ' + hunt.skipped.map((row) => `${row.type || 'unknown'} ${row.indicator || ''}`).join('; ') : ''}. Updates automatically with your queue.`);
+      if (splCopy) splCopy.disabled = !currentSpl;
+      if (splDownload) splDownload.disabled = !currentSpl;
       setText(count, formatNumber(rows.length));
       if (!list) return;
       list.innerHTML = '';

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -3697,3 +3697,8 @@ input.lookup-input { border-radius: 0.3rem; background: var(--bg-color); }
     }
   }
 }
+
+.investigation-spl { margin-top: 1.25rem; border-top: 1px solid var(--border-control); padding-top: 1rem; min-width: 0; }
+.investigation-spl p { font-size: .8rem; overflow-wrap: anywhere; }
+.investigation-spl pre { max-width: 100%; max-height: 22rem; overflow: auto; padding: 1rem; background: var(--bg-color); border: 1px solid var(--border-control); border-radius: .3rem; font-size: .78rem; }
+@media (prefers-reduced-motion: no-preference) { .investigation-spl { animation: desk-detail-enter 180ms ease-out; } }

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
       });
     </script>
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
-    <link rel="stylesheet" href="assets/styles.css?v=23" />
+    <link rel="stylesheet" href="assets/styles.css?v=25" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -195,6 +195,18 @@
           </div>
         </div>
         <ul class="investigation-list" data-investigation-list aria-label="Queued indicators"></ul>
+        <div class="investigation-spl" data-investigation-spl>
+          <h3>Hunt this queue in Splunk</h3>
+          <p data-investigation-spl-status role="status"></p>
+          <p>Replace <code>YOUR_INDEX</code> and map these single-valued event fields: <code>src_ip</code>, <code>dest_ip</code>, DNS <code>query</code>, full <code>url</code>, <code>md5</code>, <code>sha1</code>, <code>sha256</code>. Each result lists every matching queued IOC.</p>
+          <div class="investigation-actions">
+            <button type="button" class="button ghost" data-investigation-spl-copy disabled>Copy selected-IOC SPL</button>
+            <button type="button" class="button ghost" data-investigation-spl-download disabled>Download .spl</button>
+            <a class="button ghost" href="splunk/">Splunk setup &amp; full-feed hunts</a>
+          </div>
+          <pre><code data-investigation-spl-code></code></pre>
+          <p>IP/CIDR matching checks both endpoints. Domains match exact DNS names; URL paths and queries retain case and require exact event values. No match does not mean safe. Validate field mappings in Splunk before scheduling.</p>
+        </div>
       </section>
 
       <section
@@ -1038,9 +1050,9 @@
     </div>
 
     <div class="toast" data-toast role="status" aria-live="polite" aria-atomic="true" hidden></div>
-    <script defer src="assets/dashboard-core.js?v=23"></script>
-    <script defer src="assets/inventory-core.js?v=23"></script>
-    <script defer src="assets/inventory.js?v=23"></script>
-    <script defer src="assets/dashboard.js?v=23"></script>
+    <script defer src="assets/dashboard-core.js?v=25"></script>
+    <script defer src="assets/inventory-core.js?v=25"></script>
+    <script defer src="assets/inventory.js?v=25"></script>
+    <script defer src="assets/dashboard.js?v=25"></script>
   </body>
 </html>

--- a/scripts/test_investigation_spl.cjs
+++ b/scripts/test_investigation_spl.cjs
@@ -1,0 +1,34 @@
+const { chromium } = require('playwright');
+const assert = require('node:assert/strict');
+(async () => {
+  const browser = await chromium.launch({ headless: true, ...(process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH } : {}) });
+  try {
+    const context = await browser.newContext({ permissions: ['clipboard-read', 'clipboard-write'] });
+    await context.addInitScript(() => localStorage.setItem('swiftioc-investigation-workspace-v1', JSON.stringify([
+      { indicator: '1[.]2[.]3[.]4', type: 'ipv4' }, { indicator: 'CVE-2026-1234', type: 'cve' },
+    ])));
+    const page = await context.newPage(); const errors = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+    await page.goto(process.env.BASE_URL || 'http://127.0.0.1:8765');
+    await page.locator('[data-investigation-spl-copy]').click();
+    const code = await page.locator('[data-investigation-spl-code]').textContent();
+    assert.ok(code.includes('cidrmatch("1.2.3.4/32"'));
+    assert.equal(await page.evaluate(() => navigator.clipboard.readText()), code.trim());
+    assert.match(await page.locator('[data-investigation-spl-status]').innerText(), /1 unsupported/);
+    const downloadPromise = page.waitForEvent('download');
+    await page.locator('[data-investigation-spl-download]').click();
+    const download = await downloadPromise;
+    assert.equal(download.suggestedFilename(), 'swiftioc-selected-iocs.spl');
+    const stream = await download.createReadStream();
+    let downloaded = ''; for await (const chunk of stream) downloaded += chunk.toString();
+    assert.equal(downloaded, code);
+    await page.setViewportSize({ width: 390, height: 844 });
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth > innerWidth), false);
+    await page.getByRole('button', { name: 'Remove 1[.]2[.]3[.]4 from investigation queue', exact: true }).click();
+    assert.equal(await page.locator('[data-investigation-spl-copy]').isDisabled(), true);
+    assert.equal(await page.locator('[data-investigation-spl-download]').isDisabled(), true);
+    assert.ok(!(await page.locator('[data-investigation-spl-code]').textContent()).includes('1.2.3.4'));
+    assert.deepEqual(errors, []);
+    console.log('PASS: queued SPL, copy/download contents, skipped types, stale-query removal, mobile layout.');
+  } finally { await browser.close(); }
+})().catch((error) => { console.error(error); process.exitCode = 1; });


### PR DESCRIPTION
Adding observables to the investigation queue now presents a live SPL panel with Copy and Download actions. The query updates on add/remove, including graph selections and restored queues. Supported types are IPv4/IPv6, CIDRs, exact DNS domains, exact full URLs, and MD5/SHA-1/SHA-256. Each result retains all matching typed IOC identities in swiftioc_matches. IP/CIDR clauses check both endpoints.

Values are refanged and inserted as escaped eval string literals. URL path/query case stays intact, and invalid/control-character values are skipped. Unsupported entries such as CVEs are explicitly listed. No supported selection produces no hunt and disables both actions, preventing stale or broad exports. A null sentinel keeps the multivalue expression usable with a single selected IOC.

The panel documents the index placeholder and single-valued event fields to map, exact-match limitations, and links to the full-feed lookup playbook. It has a bounded code preview, mobile-safe overflow, and a reduced-motion-aware entrance. Asset cache keys advance together to v25.

Validation: 58 frontend unit tests, dashboard layout browser regressions, and a new investigation SPL browser suite pass. Tests cover typed clauses, escaping, URL case, unsupported values, clipboard/download contents, removal clearing stale SPL, and mobile layout. Syntax and whitespace checks pass. No Splunk deployment was available; generated SPL execution and local field mappings must be validated in the analyst’s environment.