### PR TITLE
fix: validate persisted IOC rows and stream snapshot loading

### DIFF
--- a/swiftioc/scoring.py
+++ b/swiftioc/scoring.py
@@ -143,7 +143,10 @@ def load_previous_feed(path: Path) -> List[Indicator]:
     """Load a previously published latest.jsonl so the feed can persist.
 
     Tolerant of missing files, malformed lines, and schema drift (unknown
-    keys are ignored; rows missing required fields are skipped). Entries that
+    keys are ignored; rows with missing or incompatible fields are skipped).
+    Stream lines so large snapshots do not require a second full-file copy
+    in memory; a malformed encoding on one line does not discard later rows.
+    Entries that
     the current false-positive rules would reject are dropped on load, so an
     improved FP list retroactively cleans the carried-forward feed. File
     hashes are validated and reclassified to repair legacy type mismatches
@@ -153,37 +156,50 @@ def load_previous_feed(path: Path) -> List[Indicator]:
         return []
     field_names = {f.name for f in dataclass_fields(Indicator)}
     out: List[Indicator] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            data = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(data, dict):
-            continue
-        try:
-            ind = Indicator(**{k: v for k, v in data.items() if k in field_names})
-        except TypeError:
-            continue
-        if ind.type in {"md5", "sha1", "sha256", "sha512"}:
-            if not isinstance(ind.indicator, str):
+    with path.open("rb") as snapshot:
+        for line in snapshot:
+            line = line.strip()
+            if not line:
                 continue
-            actual_type = classify(ind.indicator)
-            if actual_type not in {"md5", "sha1", "sha256", "sha512"}:
+            try:
+                data = json.loads(line)
+            except (json.JSONDecodeError, UnicodeDecodeError):
                 continue
-            ind.type = actual_type
-            ind.indicator = ind.indicator.strip().lower()
-        if ind.type == "cve":
-            if not isinstance(ind.indicator, str) or classify(ind.indicator.strip()) != "cve":
+            if not isinstance(data, dict):
                 continue
-            ind.indicator = normalize_value("cve", ind.indicator)
-        if not isinstance(ind.vulnerability, dict):
-            ind.vulnerability = {}
-        if is_false_positive(ind.type, ind.indicator):
-            continue
-        out.append(ind)
+            try:
+                ind = Indicator(**{k: v for k, v in data.items() if k in field_names})
+            except TypeError:
+                continue
+            # Dataclasses do not enforce annotations. Reject incompatible rows
+            # before key(), split(), false-positive checks or scoring use them.
+            text_fields = ("indicator", "type", "source", "first_seen", "last_seen",
+                           "confidence", "tlp", "tags", "reference", "context")
+            if any(not isinstance(getattr(ind, name), str) for name in text_fields):
+                continue
+            if not ind.indicator.strip() or not ind.type.strip():
+                continue
+            if type(ind.score) is not int or not 0 <= ind.score <= 100:
+                continue
+            if type(ind.sightings) is not int or ind.sightings < 1:
+                continue
+            if ind.type in {"md5", "sha1", "sha256", "sha512"}:
+                if not isinstance(ind.indicator, str):
+                    continue
+                actual_type = classify(ind.indicator)
+                if actual_type not in {"md5", "sha1", "sha256", "sha512"}:
+                    continue
+                ind.type = actual_type
+                ind.indicator = ind.indicator.strip().lower()
+            if ind.type == "cve":
+                if not isinstance(ind.indicator, str) or classify(ind.indicator.strip()) != "cve":
+                    continue
+                ind.indicator = normalize_value("cve", ind.indicator)
+            if not isinstance(ind.vulnerability, dict):
+                ind.vulnerability = {}
+            if is_false_positive(ind.type, ind.indicator):
+                continue
+            out.append(ind)
     return out
 
 

--- a/tests/test_swiftioc.py
+++ b/tests/test_swiftioc.py
@@ -1377,3 +1377,28 @@ def test_nvd_retains_applicability_conditions_for_inventory_matching(monkeypatch
     monkeypatch.setattr(si, "http_get", lambda *args, **kwargs: json.dumps(payload))
     rows = si.fetch_nvd_recent("https://example.com/nvd", "ref", "nvd", now - timedelta(hours=1))
     assert rows[0].vulnerability["nvd"]["configurations"] == configurations
+
+
+@pytest.mark.parametrize('field,value', [
+    ('indicator', ['8.8.8.8']), ('type', []), ('tags', None),
+    ('source', 12), ('last_seen', {}), ('score', '80'), ('score', True),
+    ('score', 101), ('sightings', None), ('sightings', 0), ('indicator', ''),
+])
+def test_previous_feed_skips_incompatible_field_types(tmp_path, field, value):
+    from dataclasses import asdict
+    good = asdict(_sample_indicator(indicator='8.8.8.8', type='ipv4'))
+    bad = {**good, field: value}
+    path = tmp_path / 'latest.jsonl'
+    path.write_text(json.dumps(bad) + '\n' + json.dumps(good) + '\n', encoding='utf-8')
+    loaded = si.load_previous_feed(path)
+    assert len(loaded) == 1
+    assert loaded[0].indicator == '8.8.8.8'
+    si.merge_with_previous([], loaded)
+
+
+def test_previous_feed_recovers_after_invalid_utf8_line(tmp_path):
+    from dataclasses import asdict
+    good = json.dumps(asdict(_sample_indicator(indicator='8.8.8.8', type='ipv4'))).encode()
+    path = tmp_path / 'latest.jsonl'
+    path.write_bytes(b'\xff\xfe broken\n' + good + b'\n')
+    assert [row.indicator for row in si.load_previous_feed(path)] == ['8.8.8.8']


### PR DESCRIPTION
Previously, syntactically valid JSON with incompatible fields (such as null tags, a list-valued indicator, or string scores) was accepted by the Indicator dataclass and could crash subsequent merging or scoring. Validate text fields, score bounds and positive sighting counts before using loaded records. Preserve existing unknown-field tolerance, hash repairs and vulnerability normalization.

Read snapshots line by line instead of creating a whole-file string and split-line list. Malformed encoding on one line is skipped without losing later valid records.

Validation: all 192 Python tests passed, including 12 new regression cases; Ruff and Pyright passed. This improves snapshot ingestion robustness; it does not perform a complete provider-schema validation.