### PR TITLE
fix: prevent republishing Google keys collected in threat feeds

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -37,7 +37,9 @@ env:
   DIAG_DIR: "public/diagnostics"
   IOC_DIR: "public/iocs"
   CHANGELOG_DIR: "public/changelog"
-  RAW_DIR: "public/diagnostics/raw"
+  # Upstream captures may contain credentials embedded in phishing URLs.
+  # Keep them outside every public artifact and the Pages deployment tree.
+  RAW_DIR: "_private/diagnostics/raw"
   SOURCES_FILE: "sources.yml"
 
 jobs:
@@ -180,6 +182,7 @@ jobs:
             public/collections/**
             public/feed.xml
             public/badge.json
+            !public/diagnostics/raw/**
 
       - name: Upload built public site
         if: success() && github.ref == 'refs/heads/main'
@@ -188,7 +191,9 @@ jobs:
           name: swiftioc-public-site
           retention-days: 3
           if-no-files-found: error
-          path: public/**
+          path: |
+            public/**
+            !public/diagnostics/raw/**
 
       - name: Auto-commit updated outputs
         if: success() && github.ref == 'refs/heads/main'

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ public/detections/
 
 # Raw feed captures (only created with --save-raw-dir)
 public/diagnostics/raw/
+/_private/
 
 # Time-machine SQLite index (large; rebuilt from git history on demand).
 # The compact history_summary.json it also produces IS committed.

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ For a workstation, server, or another CI system, schedule the collector command 
 
 ### Check the collection, not just the website
 
-An available static site can still contain stale data. Individual sources can fail while collection succeeds unless failure guardrails are configured. Use source diagnostics and the collection workflow status together. Options include `--fail-on-empty name`, `--fail-if-stale name=HOURS` (based on newest `first_seen`), and `--warn-if-volume-drop name=PERCENT`. Save raw responses with `--save-raw-dir` when investigating parser failures.
+An available static site can still contain stale data. Individual sources can fail while collection succeeds unless failure guardrails are configured. Use source diagnostics and the collection workflow status together. Options include `--fail-on-empty name`, `--fail-if-stale name=HOURS` (based on newest `first_seen`), and `--warn-if-volume-drop name=PERCENT`. Save raw responses with `--save-raw-dir` outside the published directory when investigating parser failures. The workflow keeps raw captures outside public artifacts. Collected Google-key-shaped records are omitted from exports and Delta; see [collected-credential handling](SECURITY.md#collected-credentials-and-secret-scanning-alerts) for scope and historical-alert guidance.
 
 Generate the readable IOC summary manually with:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,4 +34,34 @@ We aim to acknowledge reports within **5 business days** and to provide a
 remediation timeline after triage. Coordinated disclosure is appreciated: please
 give us a reasonable window to ship a fix before any public write-up.
 
+## Collected credentials and secret-scanning alerts
+
+Phishing feeds can include third-party credentials inside indicator URLs.
+Treat these as exposed data; their presence does not prove that SwiftIOC uses
+the credential or owns the associated account. Do not test a collected key
+against its provider or paste it into issues, PRs, or test fixtures.
+
+The collector omits records containing recognizable Google API-key values
+before persistence and public export, including metadata and nested CVE
+evidence. It also filters the previous snapshot before generating Delta, so
+removed-record payloads cannot republish the key. It omits the entire record
+instead of altering a URL into an unobserved indicator or widening it into a
+domain block. Diagnostics report `sensitive_rows_omitted` and
+`sensitive_previous_rows_omitted`; source fetch counts still describe ingestion.
+This is a targeted pattern safeguard, not comprehensive credential detection.
+Standalone writer APIs do not apply it; callers must filter their inputs.
+
+The collection workflow stores raw upstream responses outside `public/` and
+excludes legacy raw-capture paths from uploaded artifacts. When running locally,
+keep `--save-raw-dir` outside your published directory; raw captures are not
+sanitized. In particular, override the raw path when using `--ci-safe`.
+
+Removing a key from current exports does not revoke it or erase historical
+commits, old artifacts, forks, or clones. Confirm ownership before resolving an
+alert. For a key you control, rotate/revoke it in the provider console and review
+usage before marking it revoked. For confirmed third-party threat data, record
+that provenance and inability to revoke it; do not claim revocation or label a
+potentially real credential as a test key. See
+[GitHub's alert-resolution guidance](https://docs.github.com/en/code-security/how-tos/manage-security-alerts/manage-secret-scanning-alerts/resolving-alerts).
+
 Thank you for helping us keep SwiftIOC secure! 🛡️

--- a/swiftioc/cli.py
+++ b/swiftioc/cli.py
@@ -18,6 +18,7 @@ from .detections import write_detection_pack
 from .http_client import UA_POOL, get_fetch_metrics, logger
 from .logging_utils import configure_logging
 from .models import classify, defang_min, iso, now_utc, parse_dt
+from .publication import filter_public_rows
 from .scoring import (
     apply_retention,
     compute_score,
@@ -254,6 +255,16 @@ def main() -> int:
     # dedup alone, not get conflated with those later mutations.
     deduped_count = len(rows)
 
+    # Apply the same publication boundary to fresh and retained records. The
+    # previous snapshot also feeds Delta removals and their previous payloads.
+    rows, sensitive_rows_omitted = filter_public_rows(rows)
+    previous_rows, sensitive_previous_omitted = filter_public_rows(previous_rows)
+    if sensitive_rows_omitted or sensitive_previous_omitted:
+        logger.warning(
+            "Omitted Google-key-shaped records from publication: %d current, %d previous",
+            sensitive_rows_omitted, sensitive_previous_omitted,
+        )
+
     # Living feed: merge the previously published feed so indicators persist
     # across runs. Re-observed entries refresh (score resets to full); entries
     # no longer being reported decay by age until they expire below --min-score.
@@ -412,6 +423,8 @@ def main() -> int:
         "collections": collection_counts,
         "duplicates_removed": duplicates_removed,
         "false_positives_removed": stats.get("false_positives_removed", 0),
+        "sensitive_rows_omitted": sensitive_rows_omitted,
+        "sensitive_previous_rows_omitted": sensitive_previous_omitted,
         "persist_feed": bool(args.persist_feed),
         "carried_forward": carried_forward,
         "expired_low_score": expired,

--- a/swiftioc/publication.py
+++ b/swiftioc/publication.py
@@ -1,0 +1,33 @@
+"""Keep recognizable collected credentials out of public IOC exports.
+
+This is a narrow Google API-key safeguard, not a general secret scanner.
+Dropping the whole record preserves exact-match IOC semantics: replacing a
+credential inside a URL would create a URL that was never observed.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict
+from typing import List, Tuple
+from urllib.parse import unquote
+
+from .models import Indicator
+
+
+_GOOGLE_API_KEY = re.compile(r"AIza[0-9A-Za-z_-]{35}")
+
+
+def filter_public_rows(rows: List[Indicator]) -> Tuple[List[Indicator], int]:
+    """Omit rows containing a Google-key-shaped value, without logging it.
+
+Inspect metadata and nested provider evidence as well as indicator identity.
+Decode URL escapes once for credential-bearing query parameters. Never mutate
+the caller's snapshot, including the baseline used by SOC Delta.
+"""
+    public = []
+    for row in rows:
+        serialized = json.dumps(asdict(row), ensure_ascii=False)
+        if not _GOOGLE_API_KEY.search(unquote(serialized)):
+            public.append(row)
+    return public, len(rows) - len(public)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -239,3 +239,45 @@ def test_cli_retains_fresh_kev_before_higher_scoring_ioc_when_capped(tmp_path, m
     retained = json.loads((out_dir / "iocs/latest.jsonl").read_text())
     assert retained["type"] == "cve"
     assert (out_dir / "collections/observables.jsonl").read_text() == ""
+
+
+def test_cli_does_not_republish_collected_keys_in_exports_or_delta(tmp_path, monkeypatch):
+    from dataclasses import asdict, replace
+    from swiftioc import cli
+    from swiftioc.models import iso, now_utc
+
+    # Keep reserved synthetic URLs eligible for snapshot loading so this test
+    # exercises the publication boundary, rather than the unrelated FP filter.
+    monkeypatch.setattr('swiftioc.scoring.is_false_positive', lambda *_: False)
+
+    sources = tmp_path / 'sources.yml'
+    sources.write_text('{}', encoding='utf-8')
+    stamp = iso(now_utc())
+    safe = si.Indicator('8[.]8[.]4[.]4', 'ipv4', 'test', stamp, stamp, 'high', 'CLEAR', '', '', '')
+    key = 'AI' + 'za' + '0123456789_' * 3 + 'ab'
+    unsafe = replace(safe, type='url', indicator='hxxps://example[.]invalid/?apiKey=' + key)
+    metadata = replace(safe, indicator='1[.]2[.]3[.]4', vulnerability={'nvd': {'description': key}})
+    for persist in (False, True):
+        out = tmp_path / str(persist)
+        (out / 'iocs').mkdir(parents=True)
+        (out / 'diagnostics').mkdir()
+        # A valid previous baseline must not leak through a removed event.
+        (out / 'iocs/latest.jsonl').write_text(json.dumps(asdict(unsafe)) + '\n', encoding='utf-8')
+        (out / 'diagnostics/run.json').write_text(json.dumps({'total': 1, 'ts': stamp, 'counts': {}}), encoding='utf-8')
+        monkeypatch.setattr(cli, 'collect_from_yaml', lambda *a, **kw: ([safe, metadata, unsafe], {'test': 3}, {'raw_total': 3}))
+        args = ['swiftioc', '--sources', str(sources), '--out-dir', str(out), '--skip-rss']
+        if persist:
+            args.append('--persist-feed')
+        assert _run_main(monkeypatch, args) == 0
+        for path in out.rglob('*'):
+            if path.is_file():
+                assert key not in path.read_text(encoding='utf-8'), path.relative_to(out)
+        diag = json.loads((out / 'diagnostics/run.json').read_text(encoding='utf-8'))
+        assert diag['sensitive_rows_omitted'] == 2
+        assert diag['sensitive_previous_rows_omitted'] == 1
+        assert diag['duplicates_removed'] == 0
+        assert diag['total'] == 1
+        assert diag['carried_forward'] == 0
+        delta = json.loads((out / 'iocs/delta.json').read_text(encoding='utf-8'))
+        assert delta['baseline_available'] is True
+        assert delta['counts'] == {'added': 1, 'updated': 0, 'removed': 0}

--- a/tests/test_publication.py
+++ b/tests/test_publication.py
@@ -1,0 +1,43 @@
+"""Synthetic patterns only: never commit a real leaked credential as a fixture."""
+from dataclasses import asdict, replace
+
+import pytest
+
+from swiftioc.models import Indicator
+from swiftioc.publication import filter_public_rows
+
+
+def _candidate_key():
+    return 'AI' + 'za' + '0123456789_' * 3 + 'ab'
+
+
+def _row():
+    return Indicator('hxxps://example[.]invalid/login', 'url', 'test',
+                     '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z',
+                     'high', 'CLEAR', 'phishing', '', '')
+
+
+@pytest.mark.parametrize('field', ['indicator', 'context', 'reference', 'tags', 'source'])
+def test_omits_credentials_in_identity_or_metadata_without_mutation(field):
+    safe = _row()
+    unsafe = replace(safe, **{field: 'prefix?apiKey=' + _candidate_key()})
+    baseline = asdict(unsafe)
+    public, omitted = filter_public_rows([safe, unsafe])
+    assert public == [safe]
+    assert omitted == 1
+    assert asdict(unsafe) == baseline
+
+
+def test_nested_evidence_and_url_escapes_are_checked():
+    key = _candidate_key()
+    escaped = ''.join('%' + format(ord(c), '02X') for c in key)
+    rows = [replace(_row(), vulnerability={'nvd': {'references': [{'url': key}]}}),
+            replace(_row(), indicator='hxxps://example[.]invalid/?key=' + escaped)]
+    assert filter_public_rows(rows) == ([], 2)
+
+
+def test_ordinary_urls_and_short_pattern_fragments_remain_exact():
+    rows = [_row(), replace(_row(), indicator='hxxps://example[.]invalid/AIza-short?case=Payload')]
+    public, omitted = filter_public_rows(rows)
+    assert public == rows
+    assert omitted == 0


### PR DESCRIPTION
Public phishing URLs can contain third-party Google API keys. Omit records containing recognizable key patterns before persistence, scoring and exports, scanning metadata and nested provider evidence as well as indicator identity. Filter the validated previous snapshot too, preventing Delta removal payloads from republishing excluded data. Omit entire records rather than invent modified URLs or broader domain blocks; report current/previous omission counts separately from deduplication.

Move workflow raw captures outside public/ and exclude the legacy raw path from both artifact uploads, so unsanitized upstream bodies cannot bypass the row filter into Pages. Document the targeted scope, standalone writer responsibilities and historical-alert triage. No real credential is included in test fixtures or this PR.

Validation: all 200 Python tests pass, including full CLI exports with persistence on/off, nested metadata, URL escapes and Delta baseline behavior. Ruff passes. Pyright reports zero errors and five dependency-source warnings. Workflow YAML parsed and both upload exclusions checked; git diff --check passes.

This prevents recurrence after merge/deployment. It does not revoke third-party credentials, remove existing artifacts, rewrite Git history or resolve historical secret-scanning alerts automatically.