### PR TITLE
fix: preserve Suricata rule IDs and verify detection packs

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -107,6 +107,20 @@ jobs:
           echo "OUT_DIR=$OUT_DIR"
           echo "SOURCES_FILE=$SOURCES_FILE"
 
+      - name: Restore committed Suricata SID registry
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          registry="$OUT_DIR/detections/suricata/sid-registry.json"
+          # The first run bootstraps the registry. Subsequent fresh checkouts
+          # restore the force-tracked state committed by successful runs.
+          if git cat-file -e "HEAD:$registry" 2>/dev/null; then
+            mkdir -p "$(dirname "$registry")"
+            git show "HEAD:$registry" > "$registry"
+          else
+            echo "No committed SID registry yet; bootstrapping on this run."
+          fi
+
       - name: Run collector
         id: collector
         shell: bash
@@ -192,6 +206,15 @@ jobs:
           retention-days: 3
           if-no-files-found: error
           path: public/**
+
+      - name: Stage persistent Suricata SID registry
+        if: success() && github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # Detection outputs are ignored, but this small state file must
+          # survive fresh checkouts, including assignments for inactive IOCs.
+          git add -f -- "$OUT_DIR/detections/suricata/sid-registry.json"
 
       - name: Auto-commit updated outputs
         if: success() && github.ref == 'refs/heads/main'

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -138,6 +138,9 @@ jobs:
             --report "$DIAG_DIR/REPORT.md" \
             --fail-on-empty urlhaus_recent_urls malwarebazaar_recent
 
+      - name: Verify generated detection pack
+        run: python -m swiftioc.verify_detections "$OUT_DIR/detections" --json
+
       - name: Summarize IOC outputs
         if: always()
         shell: bash

--- a/README.md
+++ b/README.md
@@ -311,6 +311,22 @@ Keys combine indicator type and value. Removed events use the action `removed_fr
 
 An `added` event means new to the retained feed; it does not prove the indicator was just created. A `removed` event means absent from the current snapshot, not benign. Material score and vulnerability-report changes produce `updated` events; a changed polling timestamp alone does not. A delta describes one collection interval, so consumers that miss runs should reconcile against the full snapshot.
 
+### Verify a detection pack before loading it
+
+Download the complete `detections/` directory from a collection artifact, then run:
+
+```bash
+python -m swiftioc.verify_detections ./detections
+# For automation: JSON result, exit 0 on success or 1 on verification failure
+python -m swiftioc.verify_detections ./detections --json
+```
+
+Schema-version 2 manifests list SHA-256 checksums and byte sizes for the generated Sigma, Suricata, RPZ, SID registry and README files. Verification detects missing or modified files and stale managed Sigma rules left over from another pack; it rejects symlinks and unsupported manifest paths. Older packs need regeneration. The collection workflow verifies packs before publishing them.
+
+Checksums establish consistency with the manifest you supplied, **not publisher authenticity or detection correctness**. Obtain the manifest from a trusted source and still validate rule syntax and local mappings before deployment. Unrelated files outside the managed set are not checked.
+
+When generating successive packs locally, retain `detections/suricata/sid-registry.json` so assigned Suricata IDs remain reserved even if an IOC disappears and returns. Deleting that state, or generating on a fresh runner without restoring it, loses collision history. The pack writer uses UTF-8 with consistent line endings so verification also works on Windows.
+
 See [integration examples](integrations/README.md) for Splunk, Elastic Security, Microsoft Sentinel, and detection guidance. For retained Git history, [build_history_index.py](scripts/build_history_index.py) and [ioc_timeline.py](scripts/ioc_timeline.py) support indicator timeline investigations.
 
 ## Source configuration

--- a/swiftioc/detections.py
+++ b/swiftioc/detections.py
@@ -115,15 +115,19 @@ def _sigma_documents(grouped: Dict[str, List[str]], generated_at: str) -> Dict[s
     return documents
 
 
-def _sid(value: str, used: set[int], registry: Dict[str, int]) -> int:
+def _sid(value: str, used: set[int], reserved: set[int], registry: Dict[str, int]) -> int:
     registered = registry.get(value)
     if registered is not None and registered not in used:
         used.add(registered)
         return registered
     candidate = 4_000_000 + int(hashlib.sha256(value.encode("utf-8")).hexdigest()[:8], 16) % 900_000
-    while candidate in used:
+    start = candidate
+    while candidate in used or candidate in reserved:
         candidate = 4_000_000 + ((candidate - 4_000_000 + 1) % 900_000)
+        if candidate == start:
+            raise ValueError("Suricata SID range exhausted; review the retained SID registry")
     used.add(candidate)
+    reserved.add(candidate)
     registry[value] = candidate
     return candidate
 
@@ -131,6 +135,9 @@ def _sid(value: str, used: set[int], registry: Dict[str, int]) -> int:
 def _suricata_rules(grouped: Dict[str, List[str]], registry: Dict[str, int]) -> Tuple[str, int]:
     rules: List[str] = []
     used: set[int] = set()
+    # Reserve even currently inactive assignments before processing new IOCs.
+    # Otherwise an earlier new rule can steal the SID of a later old rule.
+    reserved = set(registry.values())
     addresses = grouped["ipv4"] + grouped["ipv6"] + grouped["ipv4_cidr"] + grouped["ipv6_cidr"]
     for address in addresses:
         target = f"[{address}]" if ":" in address else address
@@ -138,13 +145,13 @@ def _suricata_rules(grouped: Dict[str, List[str]], registry: Dict[str, int]) -> 
             ("inbound", f"alert ip {target} any -> $HOME_NET any"),
             ("outbound", f"alert ip $HOME_NET any -> {target} any"),
         ):
-            sid = _sid(f"ip:{address}:{direction}", used, registry)
+            sid = _sid(f"ip:{address}:{direction}", used, reserved, registry)
             rules.append(
                 f'{header} (msg:"SwiftIOC {direction} high-confidence IP match"; '
                 f'classtype:trojan-activity; sid:{sid}; rev:1;)'
             )
     for domain in grouped["domain"]:
-        sid = _sid(f"dns:{domain}", used, registry)
+        sid = _sid(f"dns:{domain}", used, reserved, registry)
         rules.append(
             'alert dns $HOME_NET any -> any 53 '
             f'(msg:"SwiftIOC high-confidence DNS match"; dns.query; dotprefix; content:".{domain}"; '
@@ -166,9 +173,11 @@ def _load_detection_state(out_dir: Path) -> Tuple[Dict[str, int], int | None]:
     except (OSError, ValueError, TypeError):
         previous = {}
     if isinstance(previous, dict):
-        for key, value in previous.items():
-            if isinstance(key, str) and isinstance(value, int) and 1 <= value <= 0xFFFFFFFF:
+        assigned: set[int] = set()
+        for key, value in sorted(previous.items()):
+            if isinstance(key, str) and type(value) is int and 1 <= value <= 0xFFFFFFFF and value not in assigned:
                 registry[key] = value
+                assigned.add(value)
 
     previous_serial: int | None = None
     try:
@@ -178,7 +187,7 @@ def _load_detection_state(out_dir: Path) -> Tuple[Dict[str, int], int | None]:
             value = int(match.group(1))
             if 0 <= value <= 0xFFFFFFFF:
                 previous_serial = value
-    except OSError:
+    except (OSError, UnicodeError):
         pass
     return registry, previous_serial
 
@@ -215,7 +224,9 @@ Generated from the curated high-confidence feed. Treat these artifacts as detect
 - `suricata/swiftioc.rules` contains stable-SID inbound, outbound, and DNS alert rules.
 - `suricata/sid-registry.json` preserves collision-resolved SIDs across feed revisions.
 - `dns/swiftioc.rpz` is a response-policy zone for exact domains and their subdomains.
-- `manifest.json` records coverage and every unsupported or invalid indicator type that was skipped.
+- `manifest.json` records coverage, skipped types, and the SHA-256 and byte size of every managed file.
+
+Run `python -m swiftioc.verify_detections PATH_TO_PACK` after downloading the complete pack. A successful check detects no missing, stale or modified managed files; it does not validate rule syntax or authenticate the publisher. Keep the manifest from a trusted source. Preserve `suricata/sid-registry.json` between generation runs to retain rule IDs, including when indicators disappear and return.
 
 Compile Sigma for your backend with Sigma CLI, load the Suricata file through your managed rules directory, or configure the RPZ as a secondary policy zone. Field mappings and network variables vary by environment, so validate generated detections before production use.
 """
@@ -245,13 +256,18 @@ def write_detection_pack(out_dir: Path, rows: Sequence[Indicator], *, generated_
         (out_dir / relative).unlink(missing_ok=True)
     included = {kind: len(values) for kind, values in grouped.items() if values}
     manifest: Dict[str, Any] = {
-        "schema_version": 1,
+        "schema_version": 2,
         "generated_at": generated_at,
         "source": "SwiftIOC high-confidence feed",
         "policy": "review-required",
         "rpz_serial": rpz_serial,
         "included": included,
         "skipped": dict(sorted(skipped.items())),
+        "files": {
+            relative: {"sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+                       "bytes": len(content.encode("utf-8"))}
+            for relative, content in sorted(artifacts.items())
+        },
         "artifacts": {
             "sigma_rules": len(sigma),
             "suricata_rules": suricata_count,
@@ -259,7 +275,8 @@ def write_detection_pack(out_dir: Path, rows: Sequence[Indicator], *, generated_
         },
     }
     for relative, content in artifacts.items():
-        with _atomic_text_writer(out_dir / relative) as handle:
+        # Preserve the hashed UTF-8/LF bytes on Windows as well as Unix.
+        with _atomic_text_writer(out_dir / relative, newline="") as handle:
             handle.write(content)
     with _atomic_text_writer(out_dir / "manifest.json") as handle:
         json.dump(manifest, handle, ensure_ascii=False, indent=2, sort_keys=True)

--- a/swiftioc/verify_detections.py
+++ b/swiftioc/verify_detections.py
@@ -1,0 +1,109 @@
+"""Offline file-integrity checks for generated detection packs.
+
+Usage: python -m swiftioc.verify_detections PACK_DIRECTORY [--json]
+Checks consistency with a supplied manifest, not publisher authenticity or
+whether the detections are suitable for the analyst's environment.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict
+
+
+REQUIRED_FILES = {'README.md', 'suricata/swiftioc.rules', 'suricata/sid-registry.json', 'dns/swiftioc.rpz'}
+OPTIONAL_FILES = {'sigma/network-iocs.yml', 'sigma/dns-iocs.yml'}
+
+
+def _unique_pairs(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError('Manifest contains duplicate JSON keys')
+        result[key] = value
+    return result
+
+
+def _plain_file(root: Path, relative: str) -> Path:
+    path = root
+    if path.is_symlink():
+        raise ValueError('Pack directory must not be a symbolic link')
+    for part in Path(relative).parts:
+        path = path / part
+        if path.is_symlink():
+            raise ValueError(f'Symbolic link is not allowed: {relative}')
+    if not path.is_file():
+        raise ValueError(f'Missing or non-regular file: {relative}')
+    return path
+
+
+def verify_detection_pack(root: Path) -> Dict[str, Any]:
+    errors = []
+    checked = 0
+    try:
+        manifest_path = _plain_file(root, 'manifest.json')
+        with manifest_path.open('rb') as handle:
+            content = handle.read(65537)
+        if len(content) > 65536:
+            raise ValueError('Manifest exceeds 64 KiB')
+        manifest = json.loads(content, object_pairs_hook=_unique_pairs)
+        if not isinstance(manifest, dict) or manifest.get('schema_version') != 2:
+            raise ValueError('Expected a schema-version 2 manifest; regenerate older packs')
+        files = manifest.get('files')
+        if not isinstance(files, dict) or not REQUIRED_FILES <= files.keys():
+            raise ValueError('Manifest is missing required file entries')
+        if not files.keys() <= REQUIRED_FILES | OPTIONAL_FILES:
+            raise ValueError('Manifest contains an unsupported file path')
+        for relative, expected in sorted(files.items()):
+            if (not isinstance(expected, dict) or type(expected.get('bytes')) is not int
+                    or expected['bytes'] < 0 or not isinstance(expected.get('sha256'), str)
+                    or not re.fullmatch(r'[0-9a-f]{64}', expected['sha256'])):
+                errors.append(f'Invalid checksum entry: {relative}')
+                continue
+            try:
+                path = _plain_file(root, relative)
+                if path.stat().st_size != expected['bytes']:
+                    errors.append(f'Byte-size mismatch: {relative}')
+                    continue
+                digest = hashlib.sha256()
+                size = 0
+                with path.open('rb') as handle:
+                    for chunk in iter(lambda: handle.read(1024 * 1024), b''):
+                        digest.update(chunk)
+                        size += len(chunk)
+                checked += 1
+                if size != expected['bytes'] or digest.hexdigest() != expected['sha256']:
+                    errors.append(f'Checksum or byte-size mismatch: {relative}')
+            except (OSError, ValueError) as error:
+                errors.append(str(error))
+        for relative in sorted(OPTIONAL_FILES - files.keys()):
+            path = root / relative
+            if path.exists() or path.is_symlink():
+                errors.append(f'Stale managed file absent from manifest: {relative}')
+    except (OSError, ValueError, RecursionError) as error:
+        errors.append(str(error))
+    return {'valid': not errors, 'checked_files': checked, 'errors': errors}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('pack', type=Path)
+    parser.add_argument('--json', action='store_true', help='Print machine-readable verification results')
+    args = parser.parse_args()
+    result = verify_detection_pack(args.pack)
+    if args.json:
+        print(json.dumps(result))
+    elif result['valid']:
+        print(f"Verified {result['checked_files']} managed files against the manifest.")
+    else:
+        print('Detection pack verification failed:')
+        for error in result['errors']:
+            print(f'- {error}')
+    return 0 if result['valid'] else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_detections.py
+++ b/tests/test_detections.py
@@ -68,6 +68,8 @@ def test_detection_pack_writes_valid_type_aware_artifacts(tmp_path):
     assert "evil.example CNAME ." in rpz
     assert "*.evil.example CNAME ." in rpz
     assert json.loads((tmp_path / "manifest.json").read_text()) == manifest
+    from swiftioc.verify_detections import verify_detection_pack
+    assert verify_detection_pack(tmp_path) == {'valid': True, 'checked_files': 6, 'errors': []}
 
 
 def test_detection_pack_is_deterministic_and_deduplicates(tmp_path):
@@ -158,3 +160,33 @@ def test_rpz_triggers_remain_relative_to_the_policy_zone(tmp_path):
         assert record_type == "CNAME"
         assert target == ".", "NXDOMAIN action must remain an absolute root target"
     assert {owner for owner, *_ in triggers} == {"evil.example", "*.evil.example"}
+
+
+def test_new_collision_cannot_steal_existing_or_inactive_sid(tmp_path):
+    # These two real hash collisions also cover insertion order: IP rules are
+    # generated before DNS rules, even when the DNS assignment already exists.
+    domain = _indicator('fakelouisvuitton.org', 'domain')
+    address = _indicator('154.91.59.103', 'ipv4')
+    stamp = '2026-09-08T02:00:00Z'
+    si.write_detection_pack(tmp_path, [domain], generated_at=stamp)
+    registry_path = tmp_path / 'suricata/sid-registry.json'
+    original = json.loads(registry_path.read_text())['dns:fakelouisvuitton.org']
+    si.write_detection_pack(tmp_path, [address], generated_at=stamp)
+    registry = json.loads(registry_path.read_text())
+    assert registry['dns:fakelouisvuitton.org'] == original
+    assert len(set(registry.values())) == len(registry)
+    si.write_detection_pack(tmp_path, [address, domain], generated_at=stamp)
+    registry = json.loads(registry_path.read_text())
+    assert registry['dns:fakelouisvuitton.org'] == original
+    assert len(set(registry.values())) == len(registry)
+
+
+def test_corrupt_detection_state_recovers_without_boolean_or_duplicate_sids(tmp_path):
+    from swiftioc.detections import _load_detection_state
+    (tmp_path / 'suricata').mkdir()
+    (tmp_path / 'dns').mkdir()
+    (tmp_path / 'suricata/sid-registry.json').write_text(json.dumps({'a': True, 'b': 4000001, 'c': 4000001}))
+    (tmp_path / 'dns/swiftioc.rpz').write_bytes(b'\xff\xfe')
+    registry, serial = _load_detection_state(tmp_path)
+    assert registry == {'b': 4000001}
+    assert serial is None

--- a/tests/test_verify_detections.py
+++ b/tests/test_verify_detections.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from swiftioc.detections import write_detection_pack
+from swiftioc.verify_detections import verify_detection_pack
+
+
+def _pack(path):
+    return write_detection_pack(path, [], generated_at='2026-09-12T00:00:00Z')
+
+
+def test_verification_detects_same_size_corruption_missing_and_stale_rules(tmp_path):
+    manifest = _pack(tmp_path)
+    assert manifest['schema_version'] == 2
+    assert verify_detection_pack(tmp_path) == {'valid': True, 'checked_files': 4, 'errors': []}
+    rule = tmp_path / 'suricata/swiftioc.rules'
+    content = rule.read_bytes()
+    rule.write_bytes(b'!' + content[1:])
+    assert not verify_detection_pack(tmp_path)['valid']
+    rule.write_bytes(content)
+    rule.unlink()
+    assert not verify_detection_pack(tmp_path)['valid']
+    rule.write_bytes(content)
+    (tmp_path / 'sigma').mkdir()
+    (tmp_path / 'sigma/dns-iocs.yml').write_text('old detection')
+    assert 'Stale managed file' in verify_detection_pack(tmp_path)['errors'][0]
+
+
+@pytest.mark.parametrize('kind', ['traversal', 'absolute', 'missing', 'bad_hash', 'bad_size', 'old_schema', 'invalid_json'])
+def test_verification_rejects_incompatible_or_unsafe_manifests(tmp_path, kind):
+    manifest = _pack(tmp_path)
+    if kind in {'traversal', 'absolute'}:
+        manifest['files']['../outside' if kind == 'traversal' else '/outside'] = manifest['files']['README.md']
+    elif kind == 'missing':
+        del manifest['files']['README.md']
+    elif kind == 'bad_hash':
+        manifest['files']['README.md']['sha256'] = 'broken'
+    elif kind == 'bad_size':
+        manifest['files']['README.md']['bytes'] = True
+    elif kind == 'old_schema':
+        manifest['schema_version'] = 1
+    (tmp_path / 'manifest.json').write_text('{' if kind == 'invalid_json' else json.dumps(manifest))
+    assert not verify_detection_pack(tmp_path)['valid']
+
+
+def test_verifier_refuses_symlinks_in_file_and_parent(tmp_path):
+    root = tmp_path / 'pack'
+    _pack(root)
+    rule = root / 'suricata/swiftioc.rules'
+    outside = tmp_path / 'outside'
+    rule.rename(outside)
+    try:
+        rule.symlink_to(outside)
+    except OSError:
+        pytest.skip('Symlink creation is unavailable')
+    assert not verify_detection_pack(root)['valid']
+    rule.unlink()
+    outside.rename(rule)
+    (root / 'suricata').rename(tmp_path / 'rules')
+    (root / 'suricata').symlink_to(tmp_path / 'rules', target_is_directory=True)
+    assert not verify_detection_pack(root)['valid']
+
+
+def test_verifier_cli_provides_json_and_failure_exit_code(tmp_path):
+    _pack(tmp_path)
+    command = [sys.executable, '-m', 'swiftioc.verify_detections', str(tmp_path), '--json']
+    good = subprocess.run(command, capture_output=True, text=True)
+    assert good.returncode == 0
+    assert json.loads(good.stdout)['valid'] is True
+    (tmp_path / 'README.md').write_text('modified')
+    bad = subprocess.run(command, capture_output=True, text=True)
+    assert bad.returncode == 1
+    assert json.loads(bad.stdout)['valid'] is False
+
+
+@pytest.mark.parametrize('payload', [b' ' * 65537, b'\xff', b'{"schema_version":2,"schema_version":1}', b'[' * 2000 + b']' * 2000])
+def test_verifier_reports_malformed_manifests_without_crashing(tmp_path, payload):
+    (tmp_path / 'manifest.json').write_bytes(payload)
+    result = verify_detection_pack(tmp_path)
+    assert result['valid'] is False
+    assert result['checked_files'] == 0
+    assert result['errors']


### PR DESCRIPTION
New rules could claim SIDs already assigned to rules processed later, changing established rule IDs and breaking downstream tuning. Reserve all retained assignments, including inactive IOCs, before allocation. Reject boolean and duplicate saved SIDs, stop cleanly on range exhaustion, and recover from an invalid UTF-8 RPZ state file.

Add schema-version 2 detection manifests with SHA-256 and byte size for each managed artifact. Write UTF-8/LF content consistently across platforms. New offline command `python -m swiftioc.verify_detections PACK_DIRECTORY [--json]` detects missing/modified files and stale managed Sigma rules, rejects malformed manifests, unsupported paths and symlinks, and returns a failure exit code. Run verification in the collection workflow before public site upload.

Document complete-pack downloads, regeneration of older manifests, and the need to preserve the SID registry between generation runs. Checksums verify consistency with the supplied manifest; they do not authenticate the publisher or validate detection syntax/applicability. Unrelated files outside the managed set are not checked.

Validation: all 208 Python tests pass on this branch. Tests cover actual SID collisions in reverse insertion order and after an IOC disappears/returns; corrupted saved state; complete packs; same-size tampering; missing/stale files; unsafe paths/symlinks; oversized, duplicate-key and deeply nested manifests; and CLI JSON/exit codes. Ruff passes; Pyright reports zero errors and five dependency-source warnings. Workflow ordering/YAML and git diff --check pass.

Targets main independently of #117 and #118.